### PR TITLE
Save derived fix

### DIFF
--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -1692,7 +1692,7 @@ function formulize_calcDerivedColumns($entry, $metadata, $relationship_id, $form
                         }
                     }
                 }
-                if ($xoopsDB) {
+                if ($xoopsDB and count($dataToWrite) > 0) {
                     // false for no proxy user, true to force the update even on get requests, false is do not update the metadata (modification user)
                     $data_handler->writeEntry($primary_entry_id, $dataToWrite, false, true, false);
                 }


### PR DESCRIPTION
When the derived calculation update completes and there are no changes to save, the sql query fails, so avoid that by skipping the writing to database step when there are no changes to save.
