### PR TITLE
Moved the "Add 1" button

### DIFF
--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -1,4 +1,4 @@
-<p><input type="button" class="formButton" name="addoption" value="<{$smarty.const._AM_ELE_ADD_OPT_SUBMIT}> 1"</p>
+
 <div class="optionlist">
 <{if $content.useroptions|@count > 0}>
   <{foreach from=$content.useroptions key=text item=checked name=optionsloop}>
@@ -12,6 +12,8 @@
 <{if $content.type == "radio"}>
 <p><input type="button" class="formButton" name="cleardef" value="<{$smarty.const._AM_CLEAR_DEFAULT}>"/></p>
 <{/if}>
+
+<p><input type="button" class="formButton" name="addoption" value="<{$smarty.const._AM_ELE_ADD_OPT_SUBMIT}> 1"</p>
 
 <div class="description">
   <{if $content.type == "radio"}><p><{$smarty.const._AM_ELE_OPT_DESC2}></p><p><{$smarty.const._AM_ELE_OTHER}></p><{/if}>


### PR DESCRIPTION
In the admin view for adding options to elements, moved the Add ! button from above the options list to below it.

Tested using my local install. 
Required deleting the equivalent compiled template_c version before the changed showed up. 
