### PR TITLE
Format numbers when displayed as text

### DIFF
--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -169,7 +169,7 @@ class formulizeElementRenderer{
 					$ele_value[2]	  //	default value
 					);
 				} else {															// nmc 2007.03.24 - added 
-					$form_ele = new XoopsFormLabel ($ele_caption, $ele_value[2]);	// nmc 2007.03.24 - added 
+					$form_ele = new XoopsFormLabel ($ele_caption, formulize_numberFormat($ele_value[2], $this->_ele->getVar('ele_handle')));	// nmc 2007.03.24 - added 
 				}
 				
 				//if placeholder value is set
@@ -1268,7 +1268,7 @@ class formulizeElementRenderer{
 					$hiddenValue = date("Y-m-d", $element->getValue());
 					break;
 				default:
-					$hiddenValue = $element->getValue(); // should work for all elements, since non-textbox type elements where the value would not be passed straight back, are handled differently at the time they are constructed
+					$hiddenValue = formulize_numberFormat($element->getValue(), $this->_ele->getVar('ele_handle')); // should work for all elements, since non-textbox type elements where the value would not be passed straight back, are handled differently at the time they are constructed
 			}
 			if(is_array($hiddenValue)) { // not sure when/if this would ever happen
 				foreach($hiddenValue as $value) {

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -3992,7 +3992,7 @@ function _formulize_numberFormat($value, $decimalOverride, $decimals="", $decSep
         // if no prefix actually is specified for the element, then use module pref if one is set, otherwise use ""
         $suffix = isset($formulizeConfig['number_suffix']) ? $formulizeConfig['number_suffix'] : "";
     }
-    return $prefix . number_format($value, $decimals, $decsep, $sep) . $suffix;
+    return trans($prefix) . number_format($value, $decimals, trans($decsep), trans($sep)) . trans($suffix);
 }
 
 


### PR DESCRIPTION
When in elements, we are not changing anything, because it may cause
some interaction effect when 5,17 is submitted to the database, and it
gets turned into a 0 because of the comma.  We need to look into fully
localized data formats and so on.  For now, we're just showing numbers
with formatting when elements are disabled, or on printable view.
