### PR TITLE
Add entry id to other box markup and reading

### DIFF
--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -1179,7 +1179,7 @@ class formulizeElementRenderer{
 		}
 		$s = explode('|', preg_replace('/[\{\}]/', '', $s));
 		$len = !empty($s[1]) ? $s[1] : $xoopsModuleConfig['t_width'];
-		$box = new XoopsFormText('', 'other[ele_'.$ele_id.']', $len, 255, $other_text);
+		$box = new XoopsFormText('', 'other[ele_'.$ele_id.'_'.$entry.']', $len, 255, $other_text);
 		if($checkbox) {
 			$box->setExtra("onchange=\"javascript:formulizechanged=1;\" onfocus=\"javascript:this.form.elements['" . $id . "[]'][$counter].checked = true;\"");
 		} else {

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -2069,8 +2069,13 @@ function checkOther($key, $id){
     if (!preg_match('/\{OTHER\|+[0-9]+\}/', $key) ){
         return false;
     }else{
-        if (!empty($_POST['other']['ele_'.$id]) ){
-            return $_POST['other']['ele_'.$id];
+        if( !empty($_POST['other'])) {
+            $otherValues = array();
+            foreach($_POST['other'] as $key=>$value) {
+              list($eletext, $element_id, $entry_id) = $keyParts = explode("_", $key);
+              $otherValues[$entry_id] = $value;
+            }
+            return $otherValues;
         }else{
             return "";
         }
@@ -2090,7 +2095,8 @@ function writeOtherValues($id_req, $fid) {
     include_once XOOPS_ROOT_PATH . "/modules/formulize/class/forms.php";
     $thisForm = new formulizeForm($fid);
     if (isset($GLOBALS['formulize_other']) and is_array($GLOBALS['formulize_other'])) {
-        foreach ($GLOBALS['formulize_other'] as $ele_id=>$value) {
+        foreach ($GLOBALS['formulize_other'] as $ele_id=>$values) {
+            $value = $values[$id_req];
             // filter out any ele_ids that are not part of this form, since when a framework is used, the formulize_other array would contain ele_ids from multiple forms
             if (!in_array($ele_id, $thisForm->getVar('elements'))) {
                 continue;


### PR DESCRIPTION
We read entry id out of the other box markup now, so we can save values
from other boxes in subform entries properly.
