### PR TITLE
Check and report on syntax errors when saving screen templates.

### DIFF
--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -58,6 +58,7 @@ if($op != "check_for_unique_value"
    AND $op != 'get_element_value'
    AND $op != 'get_element_row_html'
    AND $op != 'update_derived_value'
+   AND $op != 'validate_php_code'
   ) {
   exit();
 }
@@ -201,5 +202,19 @@ switch($op) {
     $data = getData($formRelationID, $formID,"","AND","",$limitStart,300);
     $GLOBALS['formulize_forceDerivedValueUpdate'] = false;
     print count($data); // return the number of entries found. when this reaches 0, the client will know to stop calling
+    break;
+
+    case "validate_php_code":
+    if (function_exists("shell_exec")) {
+        $tmpfname = tempnam(sys_get_temp_dir(), 'FZ');
+        file_put_contents($tmpfname, trim(urldecode($_POST["the_code"])));
+        $output = shell_exec('php -l "'.$tmpfname.'" 2>&1');
+        unlink($tmpfname);
+        if (false !== strpos($output, "PHP Parse error")) {
+            // remove the second line because detail about the error is on the first line
+            $output = str_replace("\nErrors parsing {$tmpfname}\n", "", $output);
+            echo str_replace("PHP Parse error:  s", "S", str_replace(" in $tmpfname", "", $output));
+        }
+    }
     break;
 }

--- a/modules/formulize/templates/admin/screen_list_templates.html
+++ b/modules/formulize/templates/admin/screen_list_templates.html
@@ -4,54 +4,71 @@
 <{* formulize_admin_handler and formulize_admin_key are required, to tell what the name of the save handling file is, and what the key is that we're inserting/updating on *}>
 
 <form id="form-<{$number}>" class="formulize-admin-form">
-<{$securitytoken}>
-<input type="hidden" name="formulize_admin_handler" value="screen_list_templates">
-<input type="hidden" name="formulize_admin_key" value="<{$content.sid}>">
+    <{$securitytoken}>
+    <input type="hidden" name="formulize_admin_handler" value="screen_list_templates">
+    <input type="hidden" name="formulize_admin_key" value="<{$content.sid}>">
 
-
-<div class="panel-content content">
-	
-	<p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_TOPTEMPLATE}></p>
-	<p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_TOPTEMPLATE2}></p>
-	<p>See the <a href="#templatedocs">bottom of this page for documentation</a> about how to include buttons and other interface elements in your templates.</p>
-	
-	  <div class="form-item">
-		  <fieldset>
-		  <legend>Top Template</legend>
-			  <textarea name="screens-toptemplate" class="code-textarea" rows="20"/>&lt;?php
+    <div class="panel-content content">
+        <p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_TOPTEMPLATE}></p>
+        <p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_TOPTEMPLATE2}></p>
+        <p>See the <a href="#templatedocs">bottom of this page for documentation</a> about how to include buttons and other interface elements in your templates.</p>
+        <div class="form-item">
+            <fieldset>
+                <legend>Top Template</legend>
+                <textarea id="screens-toptemplate"  name="screens-toptemplate" class="code-textarea" rows="20"/>&lt;?php
 <{$content.toptemplate}></textarea>
-		  </fieldset>
-	  </div>
+            </fieldset>
+        </div>
 
-	  <div class="form-item">
-		  <fieldset>
-		  <legend>List Template</legend>
-			  <textarea name="screens-listtemplate" class="code-textarea" rows="20"/>&lt;?php
+        <div class="form-item">
+            <fieldset>
+                <legend>List Template</legend>
+                <textarea id="screens-listtemplate" name="screens-listtemplate" class="code-textarea" rows="20"/>&lt;?php
 <{$content.listtemplate}></textarea>
-				  <a name="elementhandles"></a>
-					<table>
-					<tr><th>Form element</th><th>handle</th></tr>
-					<{foreach from=$content.listtemplatehelp item=row}>
-						<{$row}>
-					<{/foreach}>
-					</table>
-		  </fieldset>
-	  </div>
+                <a name="elementhandles"></a>
+                <table>
+                    <tr><th>Form element</th><th>handle</th></tr>
+                    <{foreach from=$content.listtemplatehelp item=row}>
+                        <{$row}>
+                    <{/foreach}>
+                </table>
+            </fieldset>
+        </div>
 
-	  <div class="form-item">
-		  <fieldset>
-		  <legend>Bottom Template</legend>
-			  <textarea name="screens-bottomtemplate" class="code-textarea" rows="20"/>&lt;?php
+        <div class="form-item">
+            <fieldset>
+            <legend>Bottom Template</legend>
+                <textarea id="screens-bottomtemplate" name="screens-bottomtemplate" class="code-textarea" rows="20"/>&lt;?php
 <{$content.bottomtemplate}></textarea>
-		  </fieldset>
-	  </div>
-	
-		<a name="templatedocs"></a>
-		<fieldset>
-			<legend>Template Documentation</legend>
-			<{$smarty.const._AM_FORMULIZE_SCREEN_LOE_TEMPLATEINTRO2}>
-		</fieldset>
-	
-</div>
+            </fieldset>
+        </div>
 
+        <a name="templatedocs"></a>
+        <fieldset>
+            <legend>Template Documentation</legend>
+            <{$smarty.const._AM_FORMULIZE_SCREEN_LOE_TEMPLATEINTRO2}>
+        </fieldset>
+    </div>
 </form>
+<script>
+jQuery(document).ready(function() {
+    jQuery(".savebutton").click(function() {
+        check_php_code("#screens-toptemplate", "Top template");
+        check_php_code("#screens-listtemplate", "List template");
+        check_php_code("#screens-bottomtemplate", "Bottom template");
+    });
+    function check_php_code(template_id, template_name) {
+        jQuery.ajax({
+            type: "POST",
+            url: "<{$icms_url}>/modules/formulize/formulize_xhr_responder.php?uid=<{$icms_userid}>&op=validate_php_code",
+            data: {the_code: escape(jQuery(template_id).val())},
+            success: function(result) {
+                if (result.length > 0) {
+                    alert("The "+template_name+" has an error:\n\n"+result+".");
+                }
+            },
+            async: false
+        });
+    }
+});
+</script>


### PR DESCRIPTION
Finding syntax errors in screen templates can be really tough, and really annoying. If you've ever added an extra } bracket or missed a ; at the end of the line, you'll appreciate getting a warning when saving the template so you know exactly which line the problem is on.
