### PR TITLE
Fixed delimiter, tested fix

### DIFF
--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -983,7 +983,7 @@ class formulizeDataHandler  {
 				}
 				break;
 		}
-		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "#*=:*" : ""; // multiple selection possible? if so, setup prefix
+		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "*=+*:" : ""; // multiple selection possible? if so, setup prefix
 		$newValues = array_keys($newValues);
 		global $xoopsDB;
     $form_handler = xoops_getmodulehandler('forms', 'formulize');
@@ -1006,7 +1006,7 @@ class formulizeDataHandler  {
 					continue;
 				}
 				$foundIndex = array();
-				$key = array_search($oldValues[$i], $currentValues); 
+				$key = array_search($oldValues[$i], $currentValues);
 				if($key !== false AND !isset($foundIndex[$key])) { // if we find one of the old values in the current values, then swap in the new value it should have
 					// need to check that the match wasn't a 0 or on a string, etc...cannot use strict matching in array_search since that screws up all matches since the values don't really have their correct type owing to having been spun through lots of functions by now
 					if(!is_numeric($currentValues[$key]) AND $oldValues[$i] == '0') { continue; }


### PR DESCRIPTION
The issue was  quite simple here: The problem arises when the initial entry was stored with a different prefix than the one that it looked for / imploded back onto the entry inside the changeUserSubmittedValues() function. Once I had checked phpMyAdmin to see the original save prefix, I changed it and everything worked fine.

Entries Before:![initialselect](https://cloud.githubusercontent.com/assets/10062206/6337530/aa54576e-bb80-11e4-8d1f-20fce25e64f3.png)

Entries after using Resynch:
![entrieschanged](https://cloud.githubusercontent.com/assets/10062206/6337531/b342fa56-bb80-11e4-8980-ea89b6da28bf.png)

:+1: 
