### PR TITLE
When cloning forms append tag

### DIFF
--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -983,7 +983,7 @@ class formulizeDataHandler  {
 				}
 				break;
 		}
-		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "*=+*:" : ""; // multiple selection possible? if so, setup prefix
+		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "#*=:*" : ""; // multiple selection possible? if so, setup prefix
 		$newValues = array_keys($newValues);
 		global $xoopsDB;
     $form_handler = xoops_getmodulehandler('forms', 'formulize');
@@ -1006,7 +1006,7 @@ class formulizeDataHandler  {
 					continue;
 				}
 				$foundIndex = array();
-				$key = array_search($oldValues[$i], $currentValues);
+				$key = array_search($oldValues[$i], $currentValues); 
 				if($key !== false AND !isset($foundIndex[$key])) { // if we find one of the old values in the current values, then swap in the new value it should have
 					// need to check that the match wasn't a 0 or on a string, etc...cannot use strict matching in array_search since that screws up all matches since the values don't really have their correct type owing to having been spun through lots of functions by now
 					if(!is_numeric($currentValues[$key]) AND $oldValues[$i] == '0') { continue; }

--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -983,7 +983,7 @@ class formulizeDataHandler  {
 				}
 				break;
 		}
-		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "#*=:*" : ""; // multiple selection possible? if so, setup prefix
+		$prefix = ($ele_type == "check" OR ($ele_type == "select" AND $ele_value[1])) ? "*=+*:" : ""; // multiple selection possible? if so, setup prefix
 		$newValues = array_keys($newValues);
 		global $xoopsDB;
     $form_handler = xoops_getmodulehandler('forms', 'formulize');
@@ -1006,7 +1006,7 @@ class formulizeDataHandler  {
 					continue;
 				}
 				$foundIndex = array();
-				$key = array_search($oldValues[$i], $currentValues); 
+				$key = array_search($oldValues[$i], $currentValues);
 				if($key !== false AND !isset($foundIndex[$key])) { // if we find one of the old values in the current values, then swap in the new value it should have
 					// need to check that the match wasn't a 0 or on a string, etc...cannot use strict matching in array_search since that screws up all matches since the values don't really have their correct type owing to having been spun through lots of functions by now
 					if(!is_numeric($currentValues[$key]) AND $oldValues[$i] == '0') { continue; }

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -1017,12 +1017,15 @@ class formulizeFormsHandler {
 	  // check if the default title is already in use as the name of a form...keep looking for the title and add numbers onto the end, until we don't find a match any longer
 	  $foundTitle = 1;
 	  $titleCounter = 0;
+      $form_handler = xoops_getmodulehandler('forms', 'formulize');
+      $formObject = $form_handler->get($fid);
+      $title = $formObject->getVar('title');
 	  while($foundTitle) {
 	    if(!isset($titleSearchingFor)) {
-	      $titleSearchingFor = _FORM_MODCLONED_FORM;
+	      $titleSearchingFor = sprintf(_FORM_MODCLONED_FORM,$title);//print 'FormName [Cloned]' instead of generic 'Cloned Form'.
 	    } else {
 	      $titleCounter++;
-	      $titleSearchingFor = _FORM_MODCLONED_FORM." $titleCounter";
+	      $titleSearchingFor = sprintf(_FORM_MODCLONED_FORM,$title)." $titleCounter"; //print 'FormName [Cloned]' instead of generic 'Cloned Form'.
 	    }
 	    $titleCheckSQL = "SELECT desc_form FROM " . $this->db->prefix("formulize_id") . " WHERE desc_form = '$titleSearchingFor'";
 	    $titleCheckResult = $this->db->query($titleCheckSQL);

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -1014,24 +1014,23 @@ class formulizeFormsHandler {
 		// duplicate rows in form table for that fid, but use new fid and increment ele_ids of course
 		// redraw page
 
-	  // check if the default title is already in use as the name of a form...keep looking for the title and add numbers onto the end, until we don't find a match any longer
-	  $foundTitle = 1;
-	  $titleCounter = 0;
-      $form_handler = xoops_getmodulehandler('forms', 'formulize');
-      $formObject = $form_handler->get($fid);
-      $title = $formObject->getVar('title');
-	  while($foundTitle) {
-	    if(!isset($titleSearchingFor)) {
-	      $titleSearchingFor = sprintf(_FORM_MODCLONED_FORM,$title);//print 'FormName [Cloned]' instead of generic 'Cloned Form'.
-	    } else {
-	      $titleCounter++;
-	      $titleSearchingFor = sprintf(_FORM_MODCLONED_FORM,$title)." $titleCounter"; //print 'FormName [Cloned]' instead of generic 'Cloned Form'.
-	    }
-	    $titleCheckSQL = "SELECT desc_form FROM " . $this->db->prefix("formulize_id") . " WHERE desc_form = '$titleSearchingFor'";
-	    $titleCheckResult = $this->db->query($titleCheckSQL);
-	    $foundTitle = $this->db->getRowsNum($titleCheckResult);
-	  }
-		$newtitle = $titleSearchingFor;	// use whatever the last searched for title is (because it was not found)
+        // add a number to the new form name to ensure it is unique
+        $foundTitle = 1;
+        $titleCounter = 0;
+        $form_handler = xoops_getmodulehandler('forms', 'formulize');
+        $formObject = $form_handler->get($fid);
+        $title = $formObject->getVar('title');
+        while ($foundTitle) {
+            $titleCounter++;
+            if ($titleCounter > 1) {
+                $newtitle = sprintf(_FORM_MODCLONED_FORM, $title)." $titleCounter";
+            } else {
+                $newtitle = sprintf(_FORM_MODCLONED_FORM, $title);
+            }
+            $titleCheckSQL = "SELECT desc_form FROM " . $this->db->prefix("formulize_id") . " WHERE desc_form = '".formulize_db_escape($newtitle)."'";
+            $titleCheckResult = $this->db->query($titleCheckSQL);
+            $foundTitle = $this->db->getRowsNum($titleCheckResult);
+        }
 
 		$getrow = q("SELECT * FROM " . $this->db->prefix("formulize_id") . " WHERE id_form = $fid");
 		$insert_sql = "INSERT INTO " . $this->db->prefix("formulize_id") . " (";

--- a/modules/formulize/language/english/main.php
+++ b/modules/formulize/language/english/main.php
@@ -82,7 +82,7 @@ define("_FORM_PERM","Permissions");
 
 define("_FORM_MODCLONE", "Clone this form");
 define("_FORM_MODCLONEDATA", "Clone this form and data");
-define("_FORM_MODCLONED_FORM", "Cloned Form");
+define("_FORM_MODCLONED_FORM", "%s [Cloned]",$str);
 
 define("_FORM_MODPERMLINKS","Modify scope of linked selectboxes (Deprecated -- edit on each selectbox's properties now)");
 define("_FORM_PERMLINKS","Linked Selectbox Scopes");

--- a/modules/formulize/language/english/main.php
+++ b/modules/formulize/language/english/main.php
@@ -82,7 +82,7 @@ define("_FORM_PERM","Permissions");
 
 define("_FORM_MODCLONE", "Clone this form");
 define("_FORM_MODCLONEDATA", "Clone this form and data");
-define("_FORM_MODCLONED_FORM", "%s [Cloned]",$str);
+define("_FORM_MODCLONED_FORM", "%s - Cloned");
 
 define("_FORM_MODPERMLINKS","Modify scope of linked selectboxes (Deprecated -- edit on each selectbox's properties now)");
 define("_FORM_PERMLINKS","Linked Selectbox Scopes");


### PR DESCRIPTION
Form names are now showing up in the structure: 'FormName [Cloned]' (or 'FormName [Cloned]1,2,etc.'). Only two small changes were required for this issue.


![twotests](https://cloud.githubusercontent.com/assets/10062206/6404513/5767a652-bdef-11e4-9fb5-1f6f14bea588.png)
