### PR TITLE
Prevent adding new options when an autocomplete box displays a list of user names

### DIFF
--- a/modules/formulize/admin/save/element_options_save.php
+++ b/modules/formulize/admin/save/element_options_save.php
@@ -252,8 +252,9 @@ if(isset($_POST['changeuservalues']) AND $_POST['changeuservalues']==1) {
 }
 
 //newly added for autocomplete box to make sure when {USERNAMES} and {FULLNAMES} are selected, system will not allow new entries to be added
+//ele_value[8] ==1 will make sure it's an autocomplete box
 //Added by Jinfu MAR 2015
-if($processedValues['elements']['ele_value'][2]['{USERNAMES}']==1||$processedValues['elements']['ele_value'][2]['{FULLNAMES}']==1){
+if($processedValues['elements']['ele_value'][8]==1&&($processedValues['elements']['ele_value'][2]['{USERNAMES}']==1||$processedValues['elements']['ele_value'][2]['{FULLNAMES}']==1)){
   $processedValues['elements']['ele_value'][16]=0;
 }
 

--- a/modules/formulize/admin/save/element_options_save.php
+++ b/modules/formulize/admin/save/element_options_save.php
@@ -251,10 +251,25 @@ if(isset($_POST['changeuservalues']) AND $_POST['changeuservalues']==1) {
   }
 }
 
-//newly added for autocomplete box to make sure when {USERNAMES} and {FULLNAMES} are selected, system will not allow new entries to be added
-//ele_value[8] ==1 will make sure it's an autocomplete box
-//Added by Jinfu MAR 2015
-if($processedValues['elements']['ele_value'][8]==1&&($processedValues['elements']['ele_value'][2]['{USERNAMES}']==1||$processedValues['elements']['ele_value'][2]['{FULLNAMES}']==1)){
+/**newly added for autocomplete box to make sure when {USERNAMES} and {FULLNAMES} are selected, system will not allow new entries to be added
+*ele_value[8] ==1 will make sure it's an autocomplete box
+*ele_value[16]=0 means say no match found,
+*	       1 means add as new entry.
+*
+*when $processedValues['elements']['ele_value'][2]['{USERNAMES}'] = 1, that means this one is checked;
+*	if it's 0, then it's not checked
+*							
+*this also applys in database: "{USERNAMES}";i:1; as selected;
+*			       "{USERNAMES}";i:0; for not selected.
+*
+*you can use those lines to check the value. 
+*  error_log("usernames: ".print_r($processedValues['elements']['ele_value'][2]['{USERNAMES}']));
+*  error_log("fullnames: ".print_r($processedValues['elements']['ele_value'][2]['{FULLNAMES}']));
+*
+*Added by Jinfu MAR 2015
+*/
+if($processedValues['elements']['ele_value'][8] == 1 &&
+   ($processedValues['elements']['ele_value'][2]['{USERNAMES}'] == 1 || $processedValues['elements']['ele_value'][2]['{FULLNAMES}'] == 1 )){
   $processedValues['elements']['ele_value'][16]=0;
 }
 

--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -671,24 +671,26 @@ class formulizeElementRenderer{
 					if($isDisabled) {
 						$disabledHiddenValues = implode("\n", $disabledHiddenValue); // glue the individual value elements together into a set of values
 						$renderedElement = implode(", ", $disabledOutputText);
-          } elseif($ele_value[8] == 1) {
-            // autocomplete construction: make sure that $renderedElement is the final output of this chunk of code
-            // write the possible values to a cached file so we can look them up easily when we need them, don't want to actually send them to the browser, since it could be huge, but don't want to replicate all the logic that has already gathered the values for us, each time there's an ajax request
-            $cachedLinkedOptionsFileName = "formulize_Options_".str_replace(".","",microtime(true));
-            formulize_scandirAndClean(XOOPS_ROOT_PATH."/cache/", "formulize_Options_");
-            $maxLength = 10;
-            $the_values = array();
-            foreach($options as $id => $text) {
-                $the_values[$id] = trans($text);
-                $thisTextLength = strlen($the_values[$id]);
-                $maxLength = ($thisTextLength > $maxLength) ? $thisTextLength : $maxLength;
-            }
-            file_put_contents(XOOPS_ROOT_PATH."/cache/$cachedLinkedOptionsFileName",
-                "<?php\n\$$cachedLinkedOptionsFileName = ".var_export($the_values, true).";\n");
-            $defaultSelected = is_array($selected) ? $selected[0] : $selected;
-            $renderedComboBox = $this->formulize_renderQuickSelect($form_ele_id, $cachedLinkedOptionsFileName, $defaultSelected, $options[$defaultSelected], $maxLength);
-            $form_ele2 = new xoopsFormLabel($ele_caption, $renderedComboBox);
-            $renderedElement = $form_ele2->render();
+					} elseif($ele_value[8] == 1) {
+						// autocomplete construction: make sure that $renderedElement is the final output of this chunk of code
+						// write the possible values to a cached file so we can look them up easily when we need them,
+						//don't want to actually send them to the browser, since it could be huge,
+						//but don't want to replicate all the logic that has already gathered the values for us, each time there's an ajax request
+						$cachedLinkedOptionsFileName = "formulize_Options_".str_replace(".","",microtime(true));
+						formulize_scandirAndClean(XOOPS_ROOT_PATH."/cache/", "formulize_Options_");
+						$maxLength = 10;
+						$the_values = array();
+						foreach($options as $id => $text) {
+							$the_values[$id] = trans($text);
+							$thisTextLength = strlen($the_values[$id]);
+							$maxLength = ($thisTextLength > $maxLength) ? $thisTextLength : $maxLength;
+						}
+						file_put_contents(XOOPS_ROOT_PATH."/cache/$cachedLinkedOptionsFileName",
+							"<?php\n\$$cachedLinkedOptionsFileName = ".var_export($the_values, true).";\n");
+						$defaultSelected = is_array($selected) ? $selected[0] : $selected;
+						$renderedComboBox = $this->formulize_renderQuickSelect($form_ele_id, $cachedLinkedOptionsFileName, $defaultSelected, $options[$defaultSelected], $maxLength);
+						$form_ele2 = new xoopsFormLabel($ele_caption, $renderedComboBox);
+						$renderedElement = $form_ele2->render();
 					} else { // normal element
 						$renderedElement = $form_ele1->render();
 					}
@@ -707,9 +709,9 @@ class formulizeElementRenderer{
 					$eltcaption = $ele_caption;
 					$eltmsg = empty($eltcaption) ? sprintf( _FORM_ENTER, $eltname ) : sprintf( _FORM_ENTER, $eltcaption );
 					$eltmsg = str_replace('"', '\"', stripslashes( $eltmsg ) );
-          if($ele_value[8] == 1) {// Has been edited in order to not allow the user to submit a form when "No match found" or "Choose an Option" is selected from the quickselect box.
+					if($ele_value[8] == 1) {// Has been edited in order to not allow the user to submit a form when "No match found" or "Choose an Option" is selected from the quickselect box.
 						$form_ele->customValidationCode[] = "\nif ( myform.{$eltname}.value == '' || myform.{$eltname}.value == 'none'  ) {\n window.alert(\"{$eltmsg}\");\n myform.{$eltname}_user.focus();\n return false;\n }\n";
-          } elseif($ele_value[0] == 1) { 
+					} elseif($ele_value[0] == 1) { 
 						$form_ele->customValidationCode[] = "\nif ( myform.{$eltname}.options[0].selected ) {\n window.alert(\"{$eltmsg}\");\n myform.{$eltname}.focus();\n return false;\n }\n";
 					} elseif($ele_value[0] > 1) {
 						$form_ele->customValidationCode[] = "selection = false;\n";

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -7,13 +7,13 @@
     <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>">
     <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
-    <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>" onchange="checkNAMES()"></input></p>
+    <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>" onchange="checkForNames()"></input></p>
   <{/foreach}>
 <{else}>
   <p class="useroptions" name="0">
   <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=0></input>
   <{else}><input type="checkbox" name="defaultoption[0]" value=0></input>
-  <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]" onchange="checkNAMES()"></input></p>
+  <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]" onchange="checkForNames()"></input></p>
 <{/if}>
 </div>
 
@@ -41,7 +41,6 @@
 </fieldset>
 
 <script type="text/javascript">
-  var length=<{$content.useroptions|@count}>;   //option count it will change when add button clicked
   
   $("[name=addoption]").click(function (){
     number = $(".useroptions:last").attr('name');
@@ -54,7 +53,6 @@
     $(".useroptions:last").append(appendContents2);
     $("[name=addoption]").blur();
     setDisplay('savewarning','block');
-    length+=1;
   });
 
   <{if $content.type == "radio"}>
@@ -65,45 +63,16 @@
   <{/if}>
   
   <{if $content.type eq "select"}>
-  checkNAMES();
-  /**
-   *this function will consantly check for {USERNAMES} and {FULLNAMES}
-   */
-  function checkNAMES(){
-    var x=0,y=-1,z=-1;    //y for {FULLNAMES}  z for {USERNAMES}
-    for(x=0;x<length;x++){
-      if ($("[name=ele_value["+x+"]]").val()=="{USERNAMES}"){
-        z=x;
-        if ($("[name=defaultoption["+x+"]]").is(":checked")){
-          disableForAutocomplete();
-        }
-      }
-      if($("[name=ele_value["+x+"]]").val()=="{FULLNAMES}"){
-        y=x;     
-        if ($("[name=defaultoption["+x+"]]").is(":checked")) {
-          disableForAutocomplete();
-        }
-      }
+  checkForNames();
+  
+  function checkForNames() {
+    if ($("[name=ele_value[0]]").val() == "{USERNAMES}" || $("[name=ele_value[0]]").val() == "{FULLNAMES}"){
+      disableForAutocomplete();
+    }else{
+      enableForAutocomplete();
     }
-    
-    $("[name=defaultoption["+z+"]]").click(function(){
-      if($(this).is(':checked')){
-        disableForAutocomplete();
-      } else {
-        enableForAutocomplete();
-      }
-    });
-
-    $("[name=defaultoption["+y+"]]").click(function(){
-      if($(this).is(':checked')){
-        disableForAutocomplete();
-      } else {
-        enableForAutocomplete();
-      }
-    });
   }
 
-  
   function disableForAutocomplete(){
     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
     $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
@@ -112,12 +81,12 @@
   
   function enableForAutocomplete(){
     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
-    if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
+    /*if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
       $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
     }
     if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
       $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
-    }
+    }*/
     $("[name=addoption]").attr("disabled",0);
   }
   <{/if}>

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -46,7 +46,7 @@
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
     appendContents1 = '<{if $content.type == "radio"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
-    appendContents2 = '<input type="text" name="ele_value['+number+']" onchange="checkNAMES()"></input>';
+    appendContents2 = '<input type="text" name="ele_value['+number+']" onchange="checkForNAMES()"></input>';
     $(".optionlist").append('<p class="useroptions" name="'+number+'"></p>');
     $(".useroptions:last").append(appendContents1);
     $(".useroptions:last").append('&nbsp;&nbsp;');

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -4,10 +4,16 @@
 
 <{if $content.useroptions|@count > 0}>
   <{foreach from=$content.useroptions key=text item=checked name=optionsloop}>
-  <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>"><{if $content.type == "radio"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input><{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input><{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>"></input></p>
+    <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>">
+    <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
+    <{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
+    <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>"></input></p>
   <{/foreach}>
 <{else}>
-  <p class="useroptions" name="0"><{if $content.type == "radio"}><input type="radio" name="defaultoption" value=0></input><{else}><input type="checkbox" name="defaultoption[0]" value=0></input><{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]"></input></p>
+  <p class="useroptions" name="0">
+  <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=0></input>
+  <{else}><input type="checkbox" name="defaultoption[0]" value=0></input>
+  <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]"></input></p>
 <{/if}>
 </div>
 
@@ -35,6 +41,7 @@
 </fieldset>
 
 <script type="text/javascript">
+  
   $("[name=addoption]").click(function (){
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
@@ -52,6 +59,51 @@
   $("[name=cleardef]").click(function () {
     $("[name=defaultoption]").attr('checked',0);
     $("[name=cleardef]").blur();
+  });
+  <{/if}>
+  
+  <{if $content.type eq "select"}>
+  var i=0;
+  var length=<{$content.useroptions|@count}>;
+  for(i=0;i<length;i++){
+    if (($("[name=ele_value["+i+"]]").val()=="{USERNAMES}" ||$("[name=ele_value["+i+"]]").val()=="{FULLNAMES}")&&$("[name=defaultoption["+i+"]]").is(":checked")){
+     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
+     $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
+     $("[name=addoption]").attr("disabled","disabled");
+     break;
+    }else {
+     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
+     if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
+        $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
+     }
+      if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
+        $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
+     }
+     $("[name=addoption]").attr("disabled",0);
+    }
+  }
+  var x=0;
+  for(x=0;x<length;x++){
+    if ($("[name=ele_value["+x+"]]").val()=="{USERNAMES}" ||$("[name=ele_value["+x+"]]").val()=="{FULLNAMES}"){
+      break;
+    }
+  }
+  
+  $("[name=defaultoption["+x+"]]").click(function(){
+    if($(this).is(':checked')){
+      $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
+      $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
+      $("[name=addoption]").attr("disabled","disabled");
+    } else {
+      $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
+      if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
+        $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
+      }
+      if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
+        $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
+      }
+      $("[name=addoption]").attr("disabled",0);
+    }
   });
   <{/if}>
 

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -7,13 +7,13 @@
     <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>">
     <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
-    <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>"></input></p>
+    <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text}>" onchange="checkNAMES()"></input></p>
   <{/foreach}>
 <{else}>
   <p class="useroptions" name="0">
   <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=0></input>
   <{else}><input type="checkbox" name="defaultoption[0]" value=0></input>
-  <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]"></input></p>
+  <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]" onchange="checkNAMES()"></input></p>
 <{/if}>
 </div>
 
@@ -41,18 +41,20 @@
 </fieldset>
 
 <script type="text/javascript">
+  var length=<{$content.useroptions|@count}>;   //option count it will change when add button clicked
   
   $("[name=addoption]").click(function (){
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
     appendContents1 = '<{if $content.type == "radio"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
-    appendContents2 = '<input type="text" name="ele_value['+number+']"></input>';
+    appendContents2 = '<input type="text" name="ele_value['+number+']" onchange="checkNAMES()"></input>';
     $(".optionlist").append('<p class="useroptions" name="'+number+'"></p>');
     $(".useroptions:last").append(appendContents1);
     $(".useroptions:last").append('&nbsp;&nbsp;');
     $(".useroptions:last").append(appendContents2);
     $("[name=addoption]").blur();
     setDisplay('savewarning','block');
+    length+=1;
   });
 
   <{if $content.type == "radio"}>
@@ -63,48 +65,63 @@
   <{/if}>
   
   <{if $content.type eq "select"}>
-  var i=0;
-  var length=<{$content.useroptions|@count}>;
-  for(i=0;i<length;i++){
-    if (($("[name=ele_value["+i+"]]").val()=="{USERNAMES}" ||$("[name=ele_value["+i+"]]").val()=="{FULLNAMES}")&&$("[name=defaultoption["+i+"]]").is(":checked")){
-     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
-     $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
-     $("[name=addoption]").attr("disabled","disabled");
-     break;
-    }else {
-     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
-     if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
-        $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
-     }
-      if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
-        $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
-     }
-     $("[name=addoption]").attr("disabled",0);
+  checkNAMES();
+  /**
+   *this function will consantly check for {USERNAMES} and {FULLNAMES}
+   */
+  function checkNAMES(){
+    var x=0,y=-1,z=-1;    //y for {FULLNAMES}  z for {USERNAMES}
+    for(x=0;x<length;x++){
+      if ($("[name=ele_value["+x+"]]").val()=="{USERNAMES}"){
+        z=x;
+        if ($("[name=defaultoption["+x+"]]").is(":checked")){
+          disableForAutocomplete();
+        }
+        alert("found username"+x);
+      }
+      if($("[name=ele_value["+x+"]]").val()=="{FULLNAMES}"){
+        y=x;     
+        if ($("[name=defaultoption["+x+"]]").is(":checked")) {
+          disableForAutocomplete();
+        }
+        alert("found fullname"+x);
+      }
     }
+    
+    $("[name=defaultoption["+z+"]]").click(function(){
+      if($(this).is(':checked')){
+        disableForAutocomplete();
+      } else {
+        enableForAutocomplete();
+      }
+    });
+
+    $("[name=defaultoption["+y+"]]").click(function(){
+      if($(this).is(':checked')){
+        disableForAutocomplete();
+      } else {
+        enableForAutocomplete();
+      }
+    });
   }
-  var x=0;
-  for(x=0;x<length;x++){
-    if ($("[name=ele_value["+x+"]]").val()=="{USERNAMES}" ||$("[name=ele_value["+x+"]]").val()=="{FULLNAMES}"){
-      break;
-    }
+
+  
+  function disableForAutocomplete(){
+    $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
+    $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
+    $("[name=addoption]").attr("disabled","disabled");
   }
   
-  $("[name=defaultoption["+x+"]]").click(function(){
-    if($(this).is(':checked')){
-      $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled","disabled");
+  function enableForAutocomplete(){
+    $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
+    if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
       $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
-      $("[name=addoption]").attr("disabled","disabled");
-    } else {
-      $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
-      if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
-        $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
-      }
-      if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
-        $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
-      }
-      $("[name=addoption]").attr("disabled",0);
     }
-  });
+    if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
+      $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
+    }
+    $("[name=addoption]").attr("disabled",0);
+  }
   <{/if}>
 
 </script>

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -77,14 +77,12 @@
         if ($("[name=defaultoption["+x+"]]").is(":checked")){
           disableForAutocomplete();
         }
-        alert("found username"+x);
       }
       if($("[name=ele_value["+x+"]]").val()=="{FULLNAMES}"){
         y=x;     
         if ($("[name=defaultoption["+x+"]]").is(":checked")) {
           disableForAutocomplete();
         }
-        alert("found fullname"+x);
       }
     }
     

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -81,12 +81,6 @@
   
   function enableForAutocomplete(){
     $("input[name=elements-ele_value[16]]:eq(1)").attr("disabled",0);
-    /*if($("input[name=elements-ele_value[16]]:eq(0)").is(":checked")) {
-      $("input[name=elements-ele_value[16]]:eq(0)").attr("checked","checked");
-    }
-    if($("input[name=elements-ele_value[16]]:eq(1)").is(":checked")) {
-      $("input[name=elements-ele_value[16]]:eq(1)").attr("checked","checked");
-    }*/
     $("[name=addoption]").attr("disabled",0);
   }
   <{/if}>

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -46,7 +46,7 @@
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
     appendContents1 = '<{if $content.type == "radio"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
-    appendContents2 = '<input type="text" name="ele_value['+number+']" onchange="checkForNAMES()"></input>';
+    appendContents2 = '<input type="text" name="ele_value['+number+']"></input>';
     $(".optionlist").append('<p class="useroptions" name="'+number+'"></p>');
     $(".useroptions:last").append(appendContents1);
     $(".useroptions:last").append('&nbsp;&nbsp;');

--- a/modules/formulize/templates/admin/element_type_select.html
+++ b/modules/formulize/templates/admin/element_type_select.html
@@ -33,7 +33,8 @@
 		<div class="form-radios">
 			<input type="radio" id="no" name="linked_yesno" value="0"<{if $content.islinked eq 0}> checked="checked"<{/if}>/>Use the options specified below:
 		</div>
-		<{include file="db:admin/element_optionlist.html"}>
+		<{include file="db:admin/element_optionlist.html"}>	
+		
 	</div>
 
 	<div class="form-item">


### PR DESCRIPTION
Before saving to database, autocomplete element option will be checked to make sure if there is {USERNAMES} or {FULLNAMES} selected, option will not allow new entries to be added.

also in element_optionlist.html , added javascript to make sure user doesn't break this rule. 