### PR TITLE
Alter CSS to prevent Overlapping

### DIFF
--- a/modules/formulize/admin/home.php
+++ b/modules/formulize/admin/home.php
@@ -106,7 +106,8 @@ function readApplicationData($aid, $apps) {
 <a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=application&aid='.$aid.'&tab=screens"><i class="icon-screen"></i> Screens</a>
 <a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=application&aid='.$aid.'&tab=relationships"><i class="icon-connection"></i> Relationships</a>
 <a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=application&aid='.$aid.'&tab=menu%20entries"><i class="icon-menu"></i> Menu Entries</a>
-<a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=export&aid='.$aid.'"><i class="icon-download"></i> Export (beta!)</a>';
+<a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=export&aid='.$aid.'"><i class="icon-download"></i> Export (beta!)</a>
+<a href="'.XOOPS_URL.'/modules/formulize/admin/ui.php?page=form&aid='.$aid.'&tab=settings&fid=new"><i class="icon-add"></i> Add a Form</a>';
   if($aid>0) {
     $apps[$i]['header'] .= '<a href="" class="deleteapplink" target="'.$aid.'"><i class="icon-delete"></i> Delete</a>';
   }

--- a/modules/formulize/templates/admin/home_sections.html
+++ b/modules/formulize/templates/admin/home_sections.html
@@ -4,9 +4,7 @@
 <div class="description homepage-description"><p><{$sectionContent.description}></p></div>
 <{/if}>
 
-<span class="formulize-toolbar left-toolbar">
-    <a href="<{$xoops_url}>/modules/formulize/admin/ui.php?page=form&aid=<{$sectionContent.aid}>&tab=settings&fid=new"><i class="icon-add"></i> Add a Form</a>&emsp;
-</span>
+
 <{if count($sectionContent.forms) == 0}>
 <p>No forms.</p>
 <{else}>

--- a/modules/formulize/templates/admin/ui-accordion.html
+++ b/modules/formulize/templates/admin/ui-accordion.html
@@ -35,7 +35,7 @@
         <h3><a href="#"><span class="accordion-name"><{$section.name}></span></a></h3>
 		<div class="accordion-content content">
 			<{if $section.header}>
-			<div style="position: absolute; top: 10px; right: 10px;">
+			<div style="position: absolute; max-width: 50%; top: 10px; right: 10px;">
 				<{$section.header}>
 			</div>
 			<{/if}>

--- a/modules/formulize/templates/admin/ui-accordion.html
+++ b/modules/formulize/templates/admin/ui-accordion.html
@@ -35,7 +35,7 @@
         <h3><a href="#"><span class="accordion-name"><{$section.name}></span></a></h3>
 		<div class="accordion-content content">
 			<{if $section.header}>
-			<div style="position: absolute; max-width: 50%; top: 10px; right: 10px;">
+			<div style="position: absolute; top: 10px; right: 10px;">
 				<{$section.header}>
 			</div>
 			<{/if}>

--- a/modules/formulize/templates/css/formulize-admin.css
+++ b/modules/formulize/templates/css/formulize-admin.css
@@ -1552,6 +1552,7 @@ div.description {
   text-align: left !important; }
 
 .homepage-description {
+  max-width: 45%;
   margin-bottom: 1em;
   margin-top: -20px; }
 

--- a/modules/formulize/templates/css/formulize-admin.css
+++ b/modules/formulize/templates/css/formulize-admin.css
@@ -356,6 +356,7 @@ h6 {
   margin-bottom: -19px; }
 
 #xo-canvas-content {
+  min-width: 782px;
   margin-left: 30px;
   margin-right: 30px; }
 
@@ -1552,9 +1553,8 @@ div.description {
   text-align: left !important; }
 
 .homepage-description {
-  max-width: 45%;
   margin-bottom: 1em;
-  margin-top: -20px; }
+  margin-top: 5px; }
 
 form textarea {
   width: 80%; }


### PR DESCRIPTION
The formulize-admin.css file contained one div (homepage-description)
which was to be limited in its width. The other div which contained the
toolbar, had no name or space in the stylesheet, as it was hard-coded
into ui-accordion.html. I added a width limit to this as well, and now
the elements do not overlap (see below image).

![fixedoverlap](https://cloud.githubusercontent.com/assets/10062206/6560128/81e06e44-c666-11e4-838e-ac9f97ee4dc9.png)

