### PR TITLE
Revert from masquerade button

### DIFF
--- a/themes/formulize_standalone/theme.html
+++ b/themes/formulize_standalone/theme.html
@@ -134,6 +134,7 @@
     <br /> *}>
     <{$icms_footer}>
     <{ if $masquerade_username }>
+		<br>
         <div id="formulize-masquerade-block">
             Masquerading as <b><{$masquerade_username}></b>
             <form method="post" action="<{$smarty.const.XOOPS_URL}>/modules/formulize/">

--- a/themes/formulize_standalone/theme.html
+++ b/themes/formulize_standalone/theme.html
@@ -134,7 +134,7 @@
     <br /> *}>
     <{$icms_footer}>
     <{ if $masquerade_username }>
-		<br>
+        <br>
         <div id="formulize-masquerade-block">
             Masquerading as <b><{$masquerade_username}></b>
             <form method="post" action="<{$smarty.const.XOOPS_URL}>/modules/formulize/">


### PR DESCRIPTION
The Issue, when masquerading is on:
 - (For me, on Chrome) clicking on the revert button did nothing.
 - The usual footer would not be exactly in the middle, it got shifted to the left

This fix adds a simple line break after the usual footer before displaying the revert button (if masquerading is on). 