### PR TITLE
Fix a miss matched element type

### DIFF
--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -1042,7 +1042,7 @@ class formulizeElementRenderer{
 			break;
 
 
-			case 'upload':
+			case 'fileUpload':
 				$form_ele = new XoopsFormFile (
 					$ele_caption,
 					$form_ele_id,

--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -1042,7 +1042,7 @@ class formulizeElementRenderer{
 			break;
 
 
-			case 'fileUpload':
+			case 'upload':
 				$form_ele = new XoopsFormFile (
 					$ele_caption,
 					$form_ele_id,
@@ -1116,6 +1116,7 @@ class formulizeElementRenderer{
 			} else {
 				$elementCue = "";
 			}
+			
 			$form_ele->setExtra(" onchange=\"javascript:formulizechanged=1;\"");
 			// reuse caption, put two spaces between element and previous entry UI
 			$form_ele_new = new xoopsFormLabel($form_ele->getCaption(), $form_ele->render().$previousEntryUIRendered.$elementCue);

--- a/modules/formulize/class/fileUploadElement.php
+++ b/modules/formulize/class/fileUploadElement.php
@@ -172,8 +172,8 @@ class formulizeFileUploadElementHandler extends formulizeElementsHandler {
             } else {
                 $introToUploadBox = "<div id='formulize_fileStatus_".$element->getVar('ele_id')."_$entry_id' class='no-print'>" . _AM_UPLOAD . "</div>";
             }
-            $htmlForUpload = "$introToUploadBox<div><input type='hidden' name='MAX_FILE_SIZE' value='".($ele_value[0]*1048576)."' /><input type='file' name='fileupload_".$markupName."' size=50 id='".$markupName."' class='no-print' /><input type='hidden' id='$markupName' name='$markupName' value='$markupName' /></div>";
-            $formElement = new xoopsFormLabel($caption, $htmlForUpload); 
+            $htmlForUpload = "$introToUploadBox<div><input type='hidden' name='MAX_FILE_SIZE' value='".($ele_value[0]*1048576)."' /><input type='file' name='fileupload_".$markupName."' size=50 id='".$markupName."' onchange=\"javascript:formulizechanged=1;\"  class='no-print' /><input type='hidden' id='$markupName' name='$markupName' value='$markupName' /></div>";
+            $formElement = new xoopsFormLabel($caption, $htmlForUpload);
         }
         return $formElement;
     }


### PR DESCRIPTION
Due to this miss matched type, when the file upload box is rendered, it
will be treated as xoopsFormLabel rather than XoopsFormFile object. When
it comes to xoopsFormLabel object, it will not contain
onchange="javascript:formulizechanged=1"  for file upload box, but this
part is the key to tell if there is a value changed.

I think this will fix the problem.