### PR TITLE
Send notifications by cron

### DIFF
--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -2903,7 +2903,7 @@ function sendNotifications($fid, $event, $entries, $mid="", $groups=array()) {
         $extra_tags['SITEURL'] = XOOPS_URL;
 
         if (count($uids_real) > 0) {
-            formulize_processNotification($event, $extra_tags, $fid, $event, $uids_real, $mid, $omit_user);
+            formulize_processNotification($event, $extra_tags, $fid, $uids_real, $mid, $omit_user);
         }
         // reset for the potential processing of saved conditions
         if (isset($GLOBALS['formulize_notification_email'])) {
@@ -2945,7 +2945,7 @@ function sendNotifications($fid, $event, $entries, $mid="", $groups=array()) {
             }
             $uids_cust_real = compileNotUsers2($uids_cust_con, $uids_complete, $fid, $event, $mid);
             if (count($uids_cust_real) > 0) {
-                formulize_processNotification($event, $extra_tags, $fid, $event, $uids_cust_real, $mid, $omit_user, $thiscon['not_cons_subject'], $thiscon['not_cons_template']);
+                formulize_processNotification($event, $extra_tags, $fid, $uids_cust_real, $mid, $omit_user, $thiscon['not_cons_subject'], $thiscon['not_cons_template']);
             }
             // reset for the next runthrough of the loop
             if (isset($GLOBALS['formulize_notification_email'])) {
@@ -3155,19 +3155,30 @@ function compileNotUsers2($uids_conditions, $uids_complete, $fid, $event, $mid) 
 
 // send notifications, or cache notifications so they can be triggered by a cron job later
 // turn on the preference in the module to use the cron feature
-function formulize_processNotification($event, $extra_tags, $fid, $event, $uids_to_notify, $mid, $omit_user, $subject="", $template="") {
+function formulize_processNotification($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject="", $template="") {
     
 	$config_handler = xoops_gethandler('config');
     $formulizeConfig = $config_handler->getConfigsByCat(0, $mid);
     $notifyByCron = $formulizeConfig['notifyByCron'];
 
-    if(!$notifyByCron) {
-        include_once XOOPS_ROOT_PATH."/modules/formulize/notify.php";
-        formulize_notify($event, $extra_tags, $fid, $event, $uids_to_notify, $mid, $omit_user, $subject, $template);
+    if($notifyByCron) {
+        $notFile = fopen(XOOPS_ROOT_PATH."/cache/formulizeNotifications","a");
+        fwrite($notFile,
+            serialize($event)."19690509".
+            serialize($extra_tags)."19690509".
+            serialize($fid)."19690509".
+            serialize($uids_to_notify)."19690509".
+            serialize($mid)."19690509".
+            serialize($omit_user)."19690509".
+            serialize($subject)."19690509".
+            serialize($template)."19690509".
+            serialize($GLOBALS['formulize_notification_email'])."19690509"
+        );
+        fclose($notFile);
     } else {
-        // need to record all passed in variables, plus $GLOBALS['formulize_notification_email'] !!!!
+        include_once XOOPS_ROOT_PATH."/modules/formulize/notify.php";
+        formulize_notify($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject, $template);
     }
-            
 }
 
 

--- a/modules/formulize/language/english/modinfo.php
+++ b/modules/formulize/language/english/modinfo.php
@@ -83,6 +83,8 @@ define("_MI_formulize_PRINTVIEWSTYLESHEETSDESC", "Type the URL for each styleshe
 define("_MI_formulize_DEBUGDERIVEDVALUES", "Turn on debugging mode for working with derived values?");
 define("_MI_formulize_DEBUGDERIVEDVALUESDESC", "When this is on, derived values will be re-computed every time they are displayed. When this is off, derived values are computed on first display only, or when data is saved.");
 
+define("_MI_formulize_NOTIFYBYCRON", "Send notifications via a cron job?");
+define("_MI_formulize_NOTIFYBYCRONDESC", "When this is on, create a cron job that triggers '/modules/formulize/notify.php' and notifications will be sent behind the scenes. When this is off, notifications are sent as part of the pageload that generated them.");
 
 // The name of this module
 define("_MI_formulizeMENU_NAME","MyMenu");

--- a/modules/formulize/notify.php
+++ b/modules/formulize/notify.php
@@ -1,0 +1,103 @@
+<?php
+
+###############################################################################
+##     Formulize - ad hoc form creation and reporting module for XOOPS       ##
+##                    Copyright (c) 2005 Freeform Solutions                  ##
+###############################################################################
+##                    XOOPS - PHP Content Management System                  ##
+##                       Copyright (c) 2000 XOOPS.org                        ##
+##                          <http://www.xoops.org/>                          ##
+###############################################################################
+##  This program is free software; you can redistribute it and/or modify     ##
+##  it under the terms of the GNU General Public License as published by     ##
+##  the Free Software Foundation; either version 2 of the License, or        ##
+##  (at your option) any later version.                                      ##
+##                                                                           ##
+##  You may not change or alter any portion of this comment or credits       ##
+##  of supporting developers from this source code or any supporting         ##
+##  source code which is considered copyrighted (c) material of the          ##
+##  original comment or credit authors.                                      ##
+##                                                                           ##
+##  This program is distributed in the hope that it will be useful,          ##
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of           ##
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            ##
+##  GNU General Public License for more details.                             ##
+##                                                                           ##
+##  You should have received a copy of the GNU General Public License        ##
+##  along with this program; if not, write to the Free Software              ##
+##  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA ##
+###############################################################################
+##  Author of this file: Freeform Solutions 		                         ##
+##  Project: Formulize                                                       ##
+###############################################################################
+
+// read data out of the notification cache if this is called by a direct URL request, that includes the GET param 'readFormulizeNotificationCache'
+if(isset($_GET['readFormulizeNotificationCache'])) {
+    include '../../mainfile.php';
+    print "reading cache!"; // formulize_scandirAndClean($dir, $filter="", $timeWindow=21600) {
+    // later unlink($dir.$fileName); after we've read the data from the file
+    // TODO read the cached data, loop through what we find and call the formulize_notify function once per set of data
+    // $GLOBALS['formulize_notification_email'] needs to be populated!!!!
+}
+
+// send the notifications
+// this file must be included in the context of the formulize_processNotification function, or called by a cron job that triggers reading of the cache
+// if it is not included in those contexts, then the required variables will not be set and nothing will happen
+
+function formulize_notify($event, $extra_tags, $fid, $event, $uids_to_notify, $mid, $omit_user, $subject="", $template="") {
+    
+    $notification_handler = xoops_gethandler('notification');
+    $module_handler = xoops_gethandler('module');
+    $formulizeModule = $module_handler->getByDirname("formulize");
+    $not_config = $formulizeModule->getInfo('notification');
+    
+    if($subject OR $template) {
+    
+        switch ($event) {
+            case "new_entry":
+                $evid = 1;
+                break;
+            case "update_entry":
+                $evid = 2;
+                break;
+            case "delete_entry":
+                $evid = 3;
+                break;
+        }
+        $oldsubject = $not_config['event'][$evid]['mail_subject'];
+        $oldtemp = $not_config['event'][$evid]['mail_template'];
+        // rewrite the notification with the subject and template we want, then reset
+        $GLOBALS['formulize_notificationTemplateOverride'] = $template == "" ? $not_config['event'][$evid]['mail_template'] : $template;
+        $GLOBALS['formulize_notificationSubjectOverride'] = $subject == "" ? $not_config['event'][$evid]['mail_subject'] : trans($subject);
+        $not_config['event'][$evid]['mail_template'] = $template == "" ? $not_config['event'][$evid]['mail_template'] : $template;
+        $not_config['event'][$evid]['mail_subject'] = $subject == "" ? $not_config['event'][$evid]['mail_subject'] : trans($subject);
+        // loop through the variables and do replacements in the subject, if any
+        if (strstr($not_config['event'][$evid]['mail_subject'], "{ELEMENT")) {
+            foreach ($extra_tags as $tag=>$value) {
+                str_replace("{".$tag."}",$value, $not_config['event'][$evid]['mail_subject']);
+                str_replace("{".$tag."}",$value, $GLOBALS['formulize_notificationSubjectOverride']);
+            }
+        }
+        $mailSubject = $not_config['event'][$evid]['mail_subject'];
+        $mailTemplate = $not_config['event'][$evid]['mail_template'];
+        
+    } else {
+        $mailSubject = "";
+        $mailTemplate = "";
+    }
+    
+    // trigger the event
+    if (in_array(-1, $uids_to_notify)) {
+        sendNotificationToEmail($GLOBALS['formulize_notification_email'], $event, $extra_tags, $mailSubject, $mailTemplate);
+        unset( $uids_to_notify[array_search(-1, $uids_to_notify)]); // now remove the special flag before triggering the event
+    }
+    $notification_handler->triggerEvent("form", $fid, $event, $extra_tags, $uids_to_notify, $mid, $omit_user);
+    
+    if($subject OR $template) {
+        $not_config['event'][$evid]['mail_subject'] = $oldsubject;
+        $not_config['event'][$evid]['mail_template'] = $oldtemp;
+        unset($GLOBALS['formulize_notificationTemplateOverride']);
+        unset($GLOBALS['formulize_notificationSubjectOverride']);
+    }
+    
+}

--- a/modules/formulize/notify.php
+++ b/modules/formulize/notify.php
@@ -34,17 +34,27 @@
 // read data out of the notification cache if this is called by a direct URL request, that includes the GET param 'readFormulizeNotificationCache'
 if(isset($_GET['readFormulizeNotificationCache'])) {
     include '../../mainfile.php';
-    print "reading cache!"; // formulize_scandirAndClean($dir, $filter="", $timeWindow=21600) {
-    // later unlink($dir.$fileName); after we've read the data from the file
-    // TODO read the cached data, loop through what we find and call the formulize_notify function once per set of data
-    // $GLOBALS['formulize_notification_email'] needs to be populated!!!!
+    $notFile = fopen(XOOPS_ROOT_PATH."/cache/formulizeNotifications","r");
+    $notData = file($notFile);
+    fclose($notFile);
+    foreach($notData as $thisNot) {
+        $thisNot = explode("19690509",$thisNot);
+        $event = unserialize($thisNot[0]);
+        $extra_tags = unserialize($thisNot[0]);
+        $fid = unserialize($thisNot[0]);
+        $uids_to_notify = unserialize($thisNot[0]);
+        $mid = unserialize($thisNot[0]);
+        $omit_user = unserialize($thisNot[0]);
+        $subject = unserialize($thisNot[0]);
+        $template = unserialize($thisNot[0]);
+        $GLOBALS['formulize_notification_email'] = unserialize($thisNot[0]);
+        formulize_notify($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject, $template);
+    }
+    unlink(XOOPS_ROOT_PATH."/cache/formulizeNotifications");
 }
 
 // send the notifications
-// this file must be included in the context of the formulize_processNotification function, or called by a cron job that triggers reading of the cache
-// if it is not included in those contexts, then the required variables will not be set and nothing will happen
-
-function formulize_notify($event, $extra_tags, $fid, $event, $uids_to_notify, $mid, $omit_user, $subject="", $template="") {
+function formulize_notify($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject="", $template="") {
     
     $notification_handler = xoops_gethandler('notification');
     $module_handler = xoops_gethandler('module');

--- a/modules/formulize/notify.php
+++ b/modules/formulize/notify.php
@@ -32,25 +32,52 @@
 ###############################################################################
 
 // read data out of the notification cache if this is called by a direct URL request, that includes the GET param 'readFormulizeNotificationCache'
+// record which row we're reading and if we get to the end, unlink the file
+// if for some reason we haven't unlinked the file, then pick up reading the file from where we left off last time.
 if(isset($_GET['readFormulizeNotificationCache'])) {
+    ini_set("max_execution_time",2000);
     include '../../mainfile.php';
-    $notFile = fopen(XOOPS_ROOT_PATH."/cache/formulizeNotifications","r");
-    $notData = file($notFile);
-    fclose($notFile);
-    foreach($notData as $thisNot) {
-        $thisNot = explode("19690509",$thisNot);
-        $event = unserialize($thisNot[0]);
-        $extra_tags = unserialize($thisNot[0]);
-        $fid = unserialize($thisNot[0]);
-        $uids_to_notify = unserialize($thisNot[0]);
-        $mid = unserialize($thisNot[0]);
-        $omit_user = unserialize($thisNot[0]);
-        $subject = unserialize($thisNot[0]);
-        $template = unserialize($thisNot[0]);
-        $GLOBALS['formulize_notification_email'] = unserialize($thisNot[0]);
-        formulize_notify($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject, $template);
+    include_once XOOPS_ROOT_PATH."/modules/formulize/include/functions.php";
+    if($start = intval(file_get_contents(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotificationsIndex.txt"))) {
+        // since the queue is not fully sent, we'll truncate to the appropriate point, and start from there...
+        $notFile = fopen(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotifications.txt","a");
+        formulize_getLock($notFile);
+        $notData = file(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotifications.txt");
+        ftruncate($notFile, 0); // erase the file contents, we're going to rewrite them now starting with the next record to send...
+        $i = $start;
+        while(isset($notData[$i])) {
+            fwrite($notFile, $notData[$i]);
+            $i++;
+        }
+        file_put_contents(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotificationsIndex.txt", "0"); // reset the counter since we've removed the lines that were already sent
+        fclose($notFile);
     }
-    unlink(XOOPS_ROOT_PATH."/cache/formulizeNotifications");
+    $notData = file(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotifications.txt");
+    $i = $start;
+    while(isset($notData[$i])) {
+        if(trim($notData[$i])) {
+            $thisNot = explode("19690509",$notData[$i]);
+            $event = unserialize($thisNot[0]);
+            $extra_tags = unserialize($thisNot[1]);
+            $fid = unserialize($thisNot[2]);
+            $uids_to_notify = unserialize($thisNot[3]);
+            $mid = unserialize($thisNot[4]);
+            $omit_user = unserialize($thisNot[5]);
+            $subject = unserialize($thisNot[6]);
+            $template = unserialize($thisNot[7]);
+            $GLOBALS['formulize_notification_email'] = unserialize($thisNot[8]);
+            formulize_notify($event, $extra_tags, $fid, $uids_to_notify, $mid, $omit_user, $subject, $template);
+        }
+        $i++;
+        file_put_contents(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotificationsIndex.txt", "$i"); // save the next row number so we know where to pickup next time if we timeout or whatever.
+    }
+    if(!isset($notData[$i])) {
+        // check if in fact we've sent everything that is now in the cache file, and if so, unlink the file...
+        if(count(file(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotifications.txt")) <= $i) {
+            unlink(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotifications.txt");
+            file_put_contents(XOOPS_ROOT_PATH."/modules/formulize/cache/formulizeNotificationsIndex.txt", "0");
+        }
+    } 
 }
 
 // send the notifications

--- a/modules/formulize/xoops_version.php
+++ b/modules/formulize/xoops_version.php
@@ -507,6 +507,15 @@ $modversion['config'][] = array(
 	'default' => '0',
 );
 
+$modversion['config'][] = array(
+	'name' => 'notifyByCron',
+	'title' => '_MI_formulize_NOTIFYBYCRON',
+	'description' => '_MI_formulize_NOTIFYBYCRONDESC',
+	'formtype' => 'yesno',
+	'valuetype' => 'int',
+	'default' => '0',
+);
+
 
 //bloc
 $modversion['blocks'][1] = array(


### PR DESCRIPTION
Moves sending of notification messages into a queue that will be processed by hitting a file, and which handles failures by restarting from the next message in the queue if necessary the next time.

Adds a config option to control whether this is being used or not. It requires setting up a cron job on the server of course.