### PR TITLE
TASK: Adding docker support including xdebug profile for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "log": false,
+            "pathMappings": {
+                "/var/www/html/": "${workspaceFolder}"
+            }
+        }
+    ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+  web:
+    build:
+      context: ./docker/php
+      dockerfile: Dockerfile
+    restart: 'always'
+    depends_on:
+      - mariadb
+    volumes:
+      - .:/var/www/html/
+      - ./trust:/var/www/trust
+      - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - ./docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
+    ports:
+      - '8080:80'
+    links:
+      - mariadb
+  mariadb:
+    image: "mariadb"
+    restart: 'always'
+    ports:
+      - 3306:3306
+    expose:
+      - "3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "abc123"
+      MYSQL_DATABASE: "formulize"
+      MYSQL_USER: "user"
+      MYSQL_PASSWORD: "password"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.1-apache
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev
+RUN docker-php-ext-configure gd --with-jpeg=/usr/include/
+RUN docker-php-ext-install mysqli pdo pdo_mysql gd
+RUN pecl install xdebug
+RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/docker/php/conf.d/error_reporting.ini
+++ b/docker/php/conf.d/error_reporting.ini
@@ -1,0 +1,1 @@
+error_reporting=E_ALL

--- a/docker/php/conf.d/xdebug.ini
+++ b/docker/php/conf.d/xdebug.ini
@@ -1,0 +1,7 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.discover_client_host=true
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes


### PR DESCRIPTION
Adds ability to run a Formulize instance locally via Docker

* docker-compose file to run formulize in a php/apache container as well as a mariadb for the database
* custom php docker file which installs php extensions
*  xdebug and error_reporting ini files
* Simple vscode launch.json for debugging via xdebug

Since the xdebug config uses `host.docker.internal` it's unknown if this will work correctly in Windows. But since we're also setting `discover_client_host` hopefully that won't be a problem.