### PR TITLE
FIX: Using a global constant for setting the default view scope permission

### DIFF
--- a/modules/formulize/admin/screen.php
+++ b/modules/formulize/admin/screen.php
@@ -231,7 +231,7 @@ if ($screen_id != "new" && $settings['type'] == 'listOfEntries') {
   $entries['defaultview'] = $screen->getVar('defaultview');
   // Convert to arrays if a legacy value
   if(!is_array($entries['defaultview'])) {
-    $entries['defaultview'] = array(XOOPS_GROUP_USERS => $entries['defaultview']);
+    $entries['defaultview'] = array(XOOPS_GROUP_USERS => FORMULIZE_QUERY_SCOPE_GLOBAL);
   }
   $entries['viewoptions'] = $viewOptions;
   $entries['usecurrentviewlist'] = $screen->getVar('usecurrentviewlist');

--- a/modules/formulize/class/listOfEntriesScreen.php
+++ b/modules/formulize/class/listOfEntriesScreen.php
@@ -347,7 +347,7 @@ class formulizeListOfEntriesScreenHandler extends formulizeScreenHandler {
     {
         global $xoopsConfig;
         // View
-        $defaultListScreen->setVar('defaultview', 'all');
+        $defaultListScreen->setVar('defaultview', array(XOOPS_GROUP_USERS => FORMULIZE_QUERY_SCOPE_GLOBAL));
         $defaultListScreen->setVar('usecurrentviewlist', _formulize_DE_CURRENT_VIEW);
         $defaultListScreen->setVar('limitviews', serialize(array(0 => 'allviews')));
         $defaultListScreen->setVar('useworkingmsg', 1);

--- a/modules/formulize/include/common.php
+++ b/modules/formulize/include/common.php
@@ -43,6 +43,7 @@ include_once XOOPS_ROOT_PATH."/class/xoopsformloader.php";
 $formulize_mgr =& xoops_getmodulehandler('elements', 'formulize');
 include_once formulize_ROOT_PATH.'class/elementrenderer.php';
 
+include_once formulize_ROOT_PATH.'include/constants.php';
 include_once formulize_ROOT_PATH.'include/functions.php';
 include_once formulize_ROOT_PATH.'include/formdisplay.php';
 include_once formulize_ROOT_PATH.'include/entriesdisplay.php';
@@ -50,6 +51,7 @@ include_once formulize_ROOT_PATH.'include/graphdisplay.php';
 include_once formulize_ROOT_PATH.'include/calendardisplay.php';
 include_once formulize_ROOT_PATH.'include/elementdisplay.php';
 include_once formulize_ROOT_PATH.'include/extract.php';
+include_once formulize_ROOT_PATH.'class/usersGroupsPerms.php';
 include_once formulize_ROOT_PATH.'class/data.php';
 
 //Add the language constants

--- a/modules/formulize/include/constants.php
+++ b/modules/formulize/include/constants.php
@@ -1,0 +1,32 @@
+<?php
+###############################################################################
+##     Formulize - ad hoc form creation and reporting module for XOOPS       ##
+##                    Copyright (c) 2010 Freeform Solutions                  ##
+###############################################################################
+##  This program is free software; you can redistribute it and/or modify     ##
+##  it under the terms of the GNU General Public License as published by     ##
+##  the Free Software Foundation; either version 2 of the License, or        ##
+##  (at your option) any later version.                                      ##
+##                                                                           ##
+##  You may not change or alter any portion of this comment or credits       ##
+##  of supporting developers from this source code or any supporting         ##
+##  source code which is considered copyrighted (c) material of the          ##
+##  original comment or credit authors.                                      ##
+##                                                                           ##
+##  This program is distributed in the hope that it will be useful,          ##
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of           ##
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            ##
+##  GNU General Public License for more details.                             ##
+##                                                                           ##
+##  You should have received a copy of the GNU General Public License        ##
+##  along with this program; if not, write to the Free Software              ##
+##  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA ##
+###############################################################################
+##  Author of this file: Freeform Solutions                                  ##
+##  URL: http://www.formulize.org                           ##
+##  Project: Formulize                                                       ##
+###############################################################################
+
+define('FORMULIZE_QUERY_SCOPE_GROUP', 'group');
+define('FORMULIZE_QUERY_SCOPE_MINE', 'mine');
+define('FORMULIZE_QUERY_SCOPE_GLOBAL', 'all');

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -61,10 +61,7 @@ if (typeof jQuery.ui == 'undefined') {
 }
 ";
 
-include_once XOOPS_ROOT_PATH . "/modules/formulize/class/data.php";
-include_once XOOPS_ROOT_PATH . "/modules/formulize/class/usersGroupsPerms.php";
-include_once XOOPS_ROOT_PATH . "/modules/formulize/include/extract.php";
-
+include_once XOOPS_ROOT_PATH . "/modules/formulize/include/common.php";
 
 function getFormFramework($formframe, $mainform=0) {
     static $cachedToReturn = array();


### PR DESCRIPTION
Adds the following:
* New constants file for formulize
* Re-arranging includes so everything is imported into common.php
* Using new global scope constant instead of literal string `'all'` 

![Screenshot 2023-11-01 at 10 19 57 AM](https://github.com/jegelstaff/formulize/assets/645082/b0c8eda2-0e3d-4d0c-b71b-f7fabb7aaa29)
