### PR TITLE
FEATURE/Remote-Inclusion

### DIFF
--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -3336,7 +3336,7 @@ function addNew(flag) {
 	} else {
 		window.document.controls.ventry.value = 'addnew';
 	}
-	window.document.controls.submit();
+	submitControls();
 }
 
 function goDetails(viewentry, screen) {
@@ -3344,7 +3344,7 @@ function goDetails(viewentry, screen) {
 	if(screen>0) {
 		window.document.controls.overridescreen.value = screen;
 	}
-	window.document.controls.submit();
+	submitControls();
 }
 
 function cancelCalcs() {
@@ -3423,7 +3423,15 @@ function showLoading() {
 		}
 	?>
 	window.document.controls.ventry.value = '';
-	window.document.controls.submit();
+	submitControls();
+}
+
+function submitControls() {
+    if (window.formulize_remoteSubmitList) {
+        window.formulize_remoteSubmitList();
+    } else {
+        window.document.controls.submit();
+    }
 }
 
 function showLoadingReset() {

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -3522,7 +3522,11 @@ if(!$nosave) { // need to check for add or update permissions on the current use
         if (leave=='leave') {
             jQuery('#save_and_leave').val(1);
         }
-        window.document.formulize_mainform.submit();
+        if (window.formulize_remoteSubmitForm) {
+            window.formulize_remoteSubmitForm();
+        } else {
+            window.document.formulize_mainform.submit();
+        }
     } else {
         hideSavingGraphic();
     }
@@ -3583,6 +3587,9 @@ function formulize_javascriptForAfterRemovingLocks(action) {
 	if(action == 'submitGoParent') {
 			window.document.go_parent.submit();
 	} else if(action == 'rewritePage') {
+		if (window.formulize_remoteSubmitForm) {
+            window.formulize_remoteSubmitForm();
+        } else {
 		var formAction = jQuery('form[name=formulize_mainform]').attr('action');
 		var formData = jQuery('form[name=formulize_mainform]').serialize();
 		jQuery.ajax({
@@ -3597,6 +3604,7 @@ function formulize_javascriptForAfterRemovingLocks(action) {
 			}
 		});
 	}
+}
 }
 
 <?php

--- a/modules/formulize/index.php
+++ b/modules/formulize/index.php
@@ -52,6 +52,18 @@ if(!isset($formulize_screen_id) OR !is_numeric($formulize_screen_id)) {
     require_once "../../mainfile.php";
 }
 
+// ajax request from a different server, so set $formulize_screen_id now, and we won't use the theme to render the contents of the page
+if(!strstr($_SERVER['HTTP_REFERER'], XOOPS_URL)
+    AND isset($_SERVER['HTTP_FORMULIZE_REMOTE_INCLUDE']) 
+    AND isset($_GET['sid'])
+    AND intval($_GET['sid'])) {
+        $formulize_screen_id = $_GET['sid'];
+}
+
+// need to declare the allowable CORS locations -- must be configurable
+header('Access-Control-Allow-Origin: https://polygon.red');
+header('Access-Control-Allow-Headers: formulize-remote-include, x-requested-with, Content-Type, referer');
+        
 include_once XOOPS_ROOT_PATH.'/header.php';
 
 include_once XOOPS_ROOT_PATH.'/modules/formulize/include/common.php';

--- a/modules/formulize/templates/css/formulize-icons/.htaccess
+++ b/modules/formulize/templates/css/formulize-icons/.htaccess
@@ -1,0 +1,5 @@
+<FilesMatch "\.(ttf|otf|eot|woff|woff2)$">
+  <IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*"
+  </IfModule>
+</FilesMatch>

--- a/remote.html
+++ b/remote.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Formulize remote include test</title>
+        <script id='formulize.remote.js' src='https://julian.formulize.net/remote.js'></script>
+    </head>
+    
+    <body>
+    
+        <div id='formulize'></div>
+        
+        <script>
+            window.onload = function() {
+                formulize_remoteRenderScreen(2, 'formulize');
+            }
+        </script>
+        
+    </body>
+</html>

--- a/remote.js
+++ b/remote.js
@@ -1,0 +1,77 @@
+/*
+ * Formulize remote include javascript library
+ * Copyright the Formulize Project 2023
+ */
+
+var formulize = {url:''};
+formulize.url = document.getElementById('formulize.remote.js').getAttribute('src').replace('/remote.js', '');
+if (formulize.url == '') {
+    console.log('Formulize Remote Error: could not determine url for your Formulize instance. Check that the <script> tag that includes the remote.js file has the id "formulize.remote.js".');
+}
+
+if(typeof window.jQuery == 'undefined') {
+    var dochead = document.getElementsByTagName('head')[0];
+    const formulize_jQueryScript = document.createElement('script');
+    formulize_jQueryScript.src = 'https://code.jquery.com/jquery-1.12.4.js';
+    formulize_jQueryScript.crossorigin = 'anonymous';
+    dochead.appendChild(formulize_jQueryScript);
+    const formulize_jQueryUIScript = document.createElement('script');
+    formulize_jQueryUIScript.src = 'https://code.jquery.com/ui/1.12.1/jquery-ui.min.js';
+    formulize_jQueryUIScript.crossorigin = 'anonymous';
+    dochead.appendChild(formulize_jQueryUIScript);
+    /*const formulize_styles = document.createElement('style');
+    var css = '@font-face { font-family: "formulize-icons"; src: url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.eot"); src: url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.eot?#iefix") format("embedded-opentype"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.woff") format("woff"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.ttf") format("truetype"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.svg#formulize-icons") format("svg"); font-weight: normal; font-style: normal; }';
+    formulize_styles.appendChild(document.createTextNode(css));
+    dochead.appendChild(formulize_styles);*/
+    const formulize_moduleCSS = document.createElement('link');
+    formulize_moduleCSS.rel = 'stylesheet'; 
+    formulize_moduleCSS.href = formulize.url+'/modules/formulize/templates/css/formulize.css';
+    formulize_moduleCSS.type = 'text/css';
+    dochead.appendChild(formulize_moduleCSS);
+    const formulize_themeCSS = document.createElement('link');
+    formulize_themeCSS.rel = 'stylesheet'; 
+    formulize_themeCSS.href = formulize.url+'/themes/Anari/css/style.css';
+    formulize_themeCSS.type = 'text/css';
+    dochead.appendChild(formulize_themeCSS);
+    
+}
+
+var lastLoadedScreenId = 0;
+var lastUsedDomTarget = '';
+function formulize_remoteRenderScreen(screen_id, dom_id, formData='') {
+    lastLoadedScreenId = parseInt(screen_id);
+    lastUsedDomTarget = dom_id;
+    jQuery.ajax({
+        type: "POST",
+        data: formData,
+        url: formulize.url+'/modules/formulize/index.php?sid='+screen_id,
+        headers: { 'formulize-remote-include': 1 },
+        success: function(html) {
+                jQuery('#'+dom_id).empty();
+				jQuery('#'+dom_id).append(html).ready(function() {
+                    jQuery('body').show(200, function() {
+                        jQuery('.formulizeThemeForm').each(function() {
+                            jQuery(this).show();
+                        });
+                        jQuery(window).keydown(function(event){
+                            if(event.keyCode == 13) {
+                                event.preventDefault();
+                                formulize_remoteSubmitList();
+                            }
+                            return true;
+                        });
+                        var formulize_pageShown = new CustomEvent('formulize_pageShown');
+                        window.dispatchEvent(formulize_pageShown);    
+                    });
+                });
+            }
+    });
+}
+
+function formulize_remoteSubmitList() {
+    formulize_remoteRenderScreen(lastLoadedScreenId, lastUsedDomTarget, jQuery('#controls').serialize());
+}
+
+function formulize_remoteSubmitForm() {
+    formulize_remoteRenderScreen(lastLoadedScreenId, lastUsedDomTarget, jQuery('#formulize_mainform').serialize());
+}

--- a/remote.js
+++ b/remote.js
@@ -19,21 +19,22 @@ if(typeof window.jQuery == 'undefined') {
     formulize_jQueryUIScript.src = 'https://code.jquery.com/ui/1.12.1/jquery-ui.min.js';
     formulize_jQueryUIScript.crossorigin = 'anonymous';
     dochead.appendChild(formulize_jQueryUIScript);
-    /*const formulize_styles = document.createElement('style');
-    var css = '@font-face { font-family: "formulize-icons"; src: url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.eot"); src: url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.eot?#iefix") format("embedded-opentype"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.woff") format("woff"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.ttf") format("truetype"), url("'+formulize.url+'/modules/formulize/templates/css/formulize-icons/formulize-icons.svg#formulize-icons") format("svg"); font-weight: normal; font-style: normal; }';
-    formulize_styles.appendChild(document.createTextNode(css));
-    dochead.appendChild(formulize_styles);*/
     const formulize_moduleCSS = document.createElement('link');
-    formulize_moduleCSS.rel = 'stylesheet'; 
+    formulize_moduleCSS.rel = 'stylesheet';
     formulize_moduleCSS.href = formulize.url+'/modules/formulize/templates/css/formulize.css';
     formulize_moduleCSS.type = 'text/css';
     dochead.appendChild(formulize_moduleCSS);
     const formulize_themeCSS = document.createElement('link');
-    formulize_themeCSS.rel = 'stylesheet'; 
+    formulize_themeCSS.rel = 'stylesheet';
     formulize_themeCSS.href = formulize.url+'/themes/Anari/css/style.css';
     formulize_themeCSS.type = 'text/css';
     dochead.appendChild(formulize_themeCSS);
-    
+		const poppinsFont = document.createElement('link');
+    poppinsFont.rel = 'stylesheet';
+    poppinsFont.href = 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap';
+    poppinsFont.type = 'text/css';
+    dochead.appendChild(poppinsFont);
+
 }
 
 var lastLoadedScreenId = 0;
@@ -61,7 +62,7 @@ function formulize_remoteRenderScreen(screen_id, dom_id, formData='') {
                             return true;
                         });
                         var formulize_pageShown = new CustomEvent('formulize_pageShown');
-                        window.dispatchEvent(formulize_pageShown);    
+                        window.dispatchEvent(formulize_pageShown);
                     });
                 });
             }


### PR DESCRIPTION
remote.html goes into other website that you want to pull Formulize content into.

Much to do here. But possibly this could just be used as the way Formulize works in general? ie: have javascript calls handle all submissions and reloads, get away from the architecture that relies on the browser behaviour of submitting forms and reloading pages? Then there would be just one unified mechanism of action for all page display and submission handling.