### PR TITLE
DOCKER: Improvements for additional functionality

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,9 +11,7 @@ services:
     volumes:
       - .:/var/www/html/
       - ./trust:/var/www/trust
-      - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-      - ./docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
-      - ./docker/php/conf.d/memory_limit.ini:/usr/local/etc/php/conf.d/memory_limit.ini
+      - ./docker/php/conf.d/formulize.ini:/usr/local/etc/php/conf.d/formulize.ini
     ports:
       - '8080:80'
     links:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - ./trust:/var/www/trust
       - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - ./docker/php/conf.d/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini
+      - ./docker/php/conf.d/memory_limit.ini:/usr/local/etc/php/conf.d/memory_limit.ini
     ports:
       - '8080:80'
     links:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./docker/php
       dockerfile: Dockerfile
-    restart: 'always'
+    restart: 'no'
     depends_on:
       - mariadb
     volumes:
@@ -19,7 +19,7 @@ services:
       - mariadb
   mariadb:
     image: "mariadb"
-    restart: 'always'
+    restart: 'no'
     ports:
       - 3306:3306
     expose:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.1-apache
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libzip-dev zip
 RUN docker-php-ext-configure gd --with-jpeg=/usr/include/
-RUN docker-php-ext-install mysqli pdo pdo_mysql gd
+RUN docker-php-ext-install mysqli pdo pdo_mysql gd zip
 RUN pecl install xdebug
-RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug
+RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug zip
 RUN a2enmod rewrite
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -4,4 +4,5 @@ RUN docker-php-ext-configure gd --with-jpeg=/usr/include/
 RUN docker-php-ext-install mysqli pdo pdo_mysql gd
 RUN pecl install xdebug
 RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug
+RUN a2enmod rewrite
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.1-apache
-RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libzip-dev zip
-RUN docker-php-ext-configure gd --with-jpeg=/usr/include/
+RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libzip-dev zip libfreetype6-dev
+RUN docker-php-ext-configure gd --with-jpeg=/usr/include/ --with-freetype=/usr/include/
 RUN docker-php-ext-install mysqli pdo pdo_mysql gd zip
 RUN pecl install xdebug
 RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug zip

--- a/docker/php/conf.d/error_reporting.ini
+++ b/docker/php/conf.d/error_reporting.ini
@@ -1,1 +1,0 @@
-error_reporting=E_ALL

--- a/docker/php/conf.d/formulize.ini
+++ b/docker/php/conf.d/formulize.ini
@@ -1,3 +1,10 @@
+; Error Reporting
+error_reporting=E_ALL
+
+; Memory Limit
+memory_limit = 256M
+
+; XDebug
 zend_extension=xdebug
 
 [xdebug]

--- a/docker/php/conf.d/memory_limit.ini
+++ b/docker/php/conf.d/memory_limit.ini
@@ -1,0 +1,1 @@
+memory_limit = 256M

--- a/docker/php/conf.d/memory_limit.ini
+++ b/docker/php/conf.d/memory_limit.ini
@@ -1,1 +1,0 @@
-memory_limit = 256M


### PR DESCRIPTION
* Enables [mod_rewrite](https://httpd.apache.org/docs/current/mod/mod_rewrite.html) in the docker apache instance so we support url rewriting and clean urls.
* Adds libzip and php zip extension to support the formulize synchronization feature
* Sets docker-compose restart policy for services to `no`. This prevents the containers from automatically starting locally when the docker engine started.
* Adding libfreetype and Adding freetype and the freetype php extension
* Adds memory_limit.ini file to increase the base php memory limit to 256M