### PR TITLE
TASK: Github action to build and push php development image to dockerhub

### DIFF
--- a/.github/workflows/build-docker-dev-image.yaml
+++ b/.github/workflows/build-docker-dev-image.yaml
@@ -1,0 +1,32 @@
+name: Publish PHP Development Docker image
+
+on:
+  push:
+    branches:
+      - 'TASK/dockerhub-image'
+    # paths:
+    #   - 'docker/php/Dockerfile'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/php
+          push: true
+          tags: formulize/php-dev:latest

--- a/.github/workflows/build-docker-dev-image.yaml
+++ b/.github/workflows/build-docker-dev-image.yaml
@@ -27,6 +27,6 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./docker/php
+          context: docker/php
           push: true
           tags: formulize/php-dev:latest

--- a/.github/workflows/build-docker-dev-image.yaml
+++ b/.github/workflows/build-docker-dev-image.yaml
@@ -8,25 +8,23 @@ on:
     #   - 'docker/php/Dockerfile'
 
 jobs:
-  docker:
+  deploy-dev-image:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: docker/php
+          context: ./docker/php
           push: true
           tags: formulize/php-dev:latest

--- a/.github/workflows/build-docker-dev-image.yaml
+++ b/.github/workflows/build-docker-dev-image.yaml
@@ -3,9 +3,9 @@ name: Publish PHP Development Docker image
 on:
   push:
     branches:
-      - 'TASK/dockerhub-image'
-    # paths:
-    #   - 'docker/php/Dockerfile'
+      - 'master'
+    paths:
+      - 'docker/php/Dockerfile'
 
 jobs:
   deploy-dev-image:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,7 @@ version: "3"
 
 services:
   web:
-    build:
-      context: ./docker/php
-      dockerfile: Dockerfile
+    image: "formulize/php-dev:latest"
     restart: 'no'
     depends_on:
       - mariadb
@@ -17,7 +15,7 @@ services:
     links:
       - mariadb
   mariadb:
-    image: "mariadb"
+    image: "mariadb:lts"
     restart: 'no'
     ports:
       - 3306:3306


### PR DESCRIPTION
This PR adds the following. 

* A github action to push a php image for local development up to dockerhub so we don't need to keep bulding it from scratch every time.
* Updating the docker-compose to point to the new image
* UPdating docker compose to pin mariadb to `lts`