### PR TITLE
TASK: No longer delete installation files after install is completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ themes/formulize_mobile_app/.sass-cache/
 formulize-docs/_site
 .DS_Store
 libraries/php-saml/settings.php
-
+install.lock

--- a/install/common.inc.php
+++ b/install/common.inc.php
@@ -43,6 +43,12 @@ icms_Autoloader::setup();
 
 error_reporting( E_ALL );
 
+// Exit early if the system has already been installed
+if (file_exists(ICMS_ROOT_PATH.'/install.lock')) {
+	header('Location: /');
+	exit();
+}
+
 class XoopsInstallWizard {
 
 	var $pages = array();
@@ -258,3 +264,4 @@ if (!@is_array( $_SESSION['settings'] )) {
 }
 
 ?>
+

--- a/install/install_tpl.php
+++ b/install/install_tpl.php
@@ -121,7 +121,7 @@ echo '<body>';
 				</button>
 				<?php } ?>
 				<?php if ($wizard->currentPage == end(array_keys($wizard->pages))) { ?>
-				<button  id="hmo" title="<?php echo BUTTON_SHOW_SITE; ?>" type="button" onclick="location.href='<?php echo $wizard->pageURI('end'); ?>?success=true'" class="finish">
+				<button  id="hmo" title="<?php echo BUTTON_SHOW_SITE; ?>" type="button" onclick="location.href='<?php ICMS_URL; ?>'" class="finish">
 					<img src="img/Home.png" alt="<?php echo BUTTON_SHOW_SITE; ?>" title="<?php echo BUTTON_SHOW_SITE; ?>" width="32" />
 				</button>
 				<?php } ?>

--- a/install/page_end.php
+++ b/install/page_end.php
@@ -86,7 +86,7 @@ foreach(explode(";\r",str_replace(array("\n","\n\r","\r\n"), "\r", $formulizeSta
 }
 
 // write a lock file so the install folder is inaccessible (if not deleted automatically)
-icms_core_Filesystem::writeFile('', 'install', 'lock', ICMS_ROOT_PATH);
+file_put_contents(ICMS_ROOT_PATH . '/install.lock', '');
 
 // END OF MODIFIED CODE
 include 'install_tpl.php';

--- a/install/page_end.php
+++ b/install/page_end.php
@@ -23,9 +23,6 @@ if (!defined( 'XOOPS_INSTALL' ) )	exit();
 $success = isset($_GET['success']) ? trim($_GET['success']) : false;
 if ($success) {
 	if (is_dir(ICMS_ROOT_PATH.'/install')) {
-		// @todo currently this area only runs when the user clicks on the house icon.
-		// This should be made more robust so the operation is completed without user intervention.
-		icms_core_Filesystem::writeFile('', 'install', 'lock', ICMS_ROOT_PATH);
 		header('Location: '.ICMS_URL.'/index.php');
 	}
 	$_SESSION = array();
@@ -84,9 +81,12 @@ foreach(explode(";\r",str_replace(array("\n","\n\r","\r\n"), "\r", $formulizeSta
 		if(!$formulizeResult = $dbm->query($sql)) {
 			$content = "<h3>Error:</h3><p>Some of the configuration settings were not saved properly in the database.  The website will still work, but it will behave more like a generic ImpressCMS+Formulize website, and not like a dedicated Formulize system.   Please send the following information to <a href=\"mailto:formulize@freeformsolutions.ca?subject=Formulize%20Standalone%20Install%20Error\">formulize@freeformsolutions.ca</a>:</p>
 			<p><pre>".$dbm->db->error()."</pre></p>".$content;
-		} else {
-        }
+		}
 	}
 }
+
+// write a lock file so the install folder is inaccessible (if not deleted automatically)
+icms_core_Filesystem::writeFile('', 'install', 'lock', ICMS_ROOT_PATH);
+
 // END OF MODIFIED CODE
 include 'install_tpl.php';

--- a/install/page_end.php
+++ b/install/page_end.php
@@ -20,10 +20,12 @@
 require_once 'common.inc.php';
 if (!defined( 'XOOPS_INSTALL' ) )	exit();
 
-$success = isset($_GET['success'])?trim($_GET['success']):false;
+$success = isset($_GET['success']) ? trim($_GET['success']) : false;
 if ($success) {
 	if (is_dir(ICMS_ROOT_PATH.'/install')) {
-		icms_core_Filesystem::deleteRecursive(ICMS_ROOT_PATH.'/install', true);
+		// @todo currently this area only runs when the user clicks on the house icon.
+		// This should be made more robust so the operation is completed without user intervention.
+		icms_core_Filesystem::writeFile('', 'install', 'lock', ICMS_ROOT_PATH);
 		header('Location: '.ICMS_URL.'/index.php');
 	}
 	$_SESSION = array();


### PR DESCRIPTION
There is no need to delete the installation files once formulize install is completed. This is often laborous for local development where installation is necessary, or for maintaining separate codebases which rebase with master.

This approach will now write an empty `install.lock` file to the file system once installation is completed. All installation files will now check for the presence of a lock file and if one is found will redirect back to the home page. To re-install simply delete the lock file. 