### PR TITLE
Refinements to handling start page settings

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 /**
  * Site index aka home page.
  * redirects to installation, if ImpressCMS is not installed yet
- * 
+ *
  * @copyright	http://www.impresscms.org/ The ImpressCMS Project
  * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License(GPL)
  * @package		core
@@ -26,13 +26,24 @@ if(isset($_SESSION['google_xoops_redirect'])) {
 
 // added failover to default startpage for the registered users group -- JULIAN EGELSTAFF Apr 3 2017
 $groups = @is_object(icms::$user) ? icms::$user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
-if(($icmsConfig['startpage'][$group] == "" OR $icmsConfig['startpage'][$group] == "--") 
-AND in_array(XOOPS_GROUP_USERS, $groups) 
-AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "" 
+if(($icmsConfig['startpage'][$group] == "" OR $icmsConfig['startpage'][$group] == "--")
+AND in_array(XOOPS_GROUP_USERS, $groups)
+AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != ""
 AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "--") {
     $icmsConfig['startpage'] = $icmsConfig['startpage'][XOOPS_GROUP_USERS];
 } else {
     $icmsConfig['startpage'] = $icmsConfig['startpage'][$group];
+}
+
+// See if they actually have a Formulize start page declared. If not, nullify the startpage since we have no where to take them
+if($icmsConfig['startpage'] == 'formulize') {
+	include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
+  $includeMenuURLs = true;
+	$followMenuURLs = false;
+	list($startFid,$startSid,$startURL) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser($includeMenuURLs, $followMenuURLs);
+	if(!$startFid AND !$startSid AND !$startURL) {
+		$icmsConfig['startpage'] = '--';
+	}
 }
 
 if (isset($icmsConfig['startpage']) && $icmsConfig['startpage'] != "" && $icmsConfig['startpage'] != "--") {
@@ -49,8 +60,8 @@ if (isset($icmsConfig['startpage']) && $icmsConfig['startpage'] != "" && $icmsCo
 			$xoopsOption['show_cblock'] = 1;
 			/** Included to start page rendering */
 			include "header.php";
-            global $xoopsTpl;
-            $xoopsTpl->assign('openClass', 'site-layout__sidebar--open');
+			global $xoopsTpl;
+			$xoopsTpl->assign('openClass', 'site-layout__sidebar--open');
 			/** Included to complete page rendering */
 			include "footer.php";
 		}

--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ if($icmsConfig['startpage'] == 'formulize') {
 	include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
   $includeMenuURLs = true;
 	$followMenuURLs = false;
-	list($startFid,$startSid,$startURL) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser($includeMenuURLs, $followMenuURLs);
+	list($startFid,$startSid,$startURL) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser();
 	if(!$startFid AND !$startSid AND !$startURL) {
 		$icmsConfig['startpage'] = '--';
 	}

--- a/modules/formulize/blocks/mymenu.php
+++ b/modules/formulize/blocks/mymenu.php
@@ -206,7 +206,14 @@ function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
 			$target = (!$url OR strstr($url, XOOPS_URL)) ? "" : " target='_blank' ";
             $menuSubActive="";
             if(getCurrentURL() == XOOPS_URL.'/modules/formulize/index.php?'.$menulink->getVar("screen")
-                OR getCurrentURL() == $url) {
+                OR getCurrentURL() == $url
+								OR (getCurrentURL() == XOOPS_URL.'/modules/formulize/'
+									AND (
+										$menulink->getVar("screen") == 'sid='.$defaultSid
+										OR $menulink->getVar("screen") == 'fid='.$defaultFid
+									)
+								)
+							) {
                 $menuSubActive=" menuSubActive";
             }
             $text = $menulink->getVar("text");

--- a/modules/formulize/blocks/mymenu.php
+++ b/modules/formulize/blocks/mymenu.php
@@ -23,11 +23,11 @@
 function block_formulizeMENU_show() {
         global $xoopsDB, $xoopsUser, $xoopsModule, $myts;
 		    $myts =& MyTextSanitizer::getInstance();
-			
+
 		if(!defined('_AM_NOFORMS_AVAIL')) {
 				include_once XOOPS_ROOT_PATH.'/modules/formulize/language/english/main.php';
 		}
-			
+
 
         $block = array();
         $groups = array();
@@ -47,19 +47,19 @@ function block_formulizeMENU_show() {
 	$allApplications = $application_handler->getAllApplications();
 	$menuTexts = array();
 	$i = 0;
-    
+
         foreach($allApplications as $thisApplication) {
-        
+
         		$links = $thisApplication->getVar('links');
-        
+
         		if(count((array) $links) > 0){
-            
+
             			$menuTexts[$i]['application'] = $thisApplication;
-            
+
             			$menuTexts[$i]['links'] = $links;
-            
+
             			$i++;
-            
+
             		}
  	}
 	$links = $application_handler->getMenuLinksForApp(0);
@@ -78,16 +78,16 @@ function block_formulizeMENU_show() {
                 $block['content'] .= $content;
                 $menuData[] = $data;
 	}
-	
+
   $block['content'] .= "</td></tr></table>";
-  
+
   $module_handler = xoops_gethandler('module');
   $config_handler = xoops_gethandler('config');
   $formulizeModule = $module_handler->getByDirname("formulize");
   $formulizeConfig = $config_handler->getConfigsByCat(0, $formulizeModule->getVar('mid'));
   if($formulizeConfig['f7MenuTemplate']) {
     $block['content'] = $menuData;
-  } 
+  }
 
   return $block;
 
@@ -100,35 +100,35 @@ function getMenuTextsForForms($forms, $form_handler) {
 								if($menuText = $thisFormObject->getVar('menutext')) {
 												$menuTexts[$thisFormObject->getVar('id_form')] = html_entity_decode($menuText, ENT_QUOTES) == "Use the form's title" ? $thisFormObject->getVar('title') : $menuText;
 								}
-								
+
 				}
 				return $menuTexts;
 }
 
 function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
-        
+
         $data = array();
-        
+
         if($application == 0) {
-            
+
             $aid = 0;
-            
+
             $name = _AM_CATGENERAL;
-            
+
             $forms = $form_handler->getFormsByApplication(0,true); // true forces ids, not objects, to be returned
-            
+
         } else {
             $aid = intval($application->getVar('appid'));
-                
+
             $name = printSmart($application->getVar('name'), 200);
-                
+
             $forms = $application->getVar('forms');
-                
+
         }
         static $topwritten = false;
-        
+
         $itemurl = XOOPS_URL."/modules/formulize/application.php?id=$aid";
-        
+
         $menuActive = '';
         if(
            $forceOpen
@@ -154,21 +154,21 @@ function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
          }
 
         $data = array('url'=>$itemurl, 'title'=>$name, 'active'=>($menuActive ? 1 : 0));
-        
+
         $isThisSubMenu = false;
-        
+
 		include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
-		list($defaultFid,$defaultSid) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser();
-		
+		list($defaultFid,$defaultSid,$defaultURL) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser();
+
         $getMenuId = isset($_GET['menuid']) ? $_GET['menuid'] : null;
         $getSid = isset($_GET['sid']) ? $_GET['sid'] : null;
         $getFid = isset($_GET['fid']) ? $_GET['fid'] : null;
 
 
         foreach($menulinks as $menulink) {
-		
+
             $url = buildMenuLinkURL($menulink);
-        
+
             if($menulink->getVar("menu_id") == $getMenuId
 				OR $menulink->getVar("screen") == 'sid='.$getSid
 				OR $menulink->getVar("screen") == 'fid='.$getFid
@@ -179,13 +179,13 @@ function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
 				OR $menulink->getVar("screen") == 'fid='.$defaultFid
 				))
 				){
-                
+
                 $isThisSubMenu = true;
-    
+
             }
-            
-        }        
-		
+
+        }
+
         if(
            $forceOpen
            OR (
@@ -199,7 +199,7 @@ function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
                )
            OR $isThisSubMenu
         ) { // if we're viewing this application or a form in this application, or this is the being forced open (only application)...
-        
+
 		foreach($menulinks as $menulink) {
 		    $url = buildMenuLinkURL($menulink);
             $suburl = $url ? $url : XOOPS_URL."/modules/formulize/index.php?".$menulink->getVar("screen");
@@ -212,7 +212,7 @@ function drawMenuSection($application, $menulinks, $forceOpen, $form_handler){
             $text = $menulink->getVar("text");
 			$block .= "<a class=\"menuSub$menuSubActive\" $target href='$suburl'>".$text."</a>";
             $data['subs'][] = array('url'=>$suburl, 'title'=>$text, 'active'=>($menuSubActive ? 1 : 0));
-		}	
+		}
 	}
 	return array($block, $data);
 }

--- a/modules/formulize/class/applications.php
+++ b/modules/formulize/class/applications.php
@@ -61,7 +61,7 @@ global $xoopsDB;
 
     }
 
-    class formulizeApplicationMenuLinksHandler  {
+  class formulizeApplicationMenuLinksHandler  {
 
         var $db;
         function __construct(&$db) {
@@ -140,53 +140,68 @@ global $xoopsDB;
             return $linksArray;
         }
 
-		// returns an array of the fid,sid applicable to the current user, based on menu settings and permissions
-		static function getDefaultScreenForUser($includeMenuURLs=false) {
+		/**
+		 * Returns an array of the fid,sid of default menu links applicable to the current user, based on menu settings and permissions
+		 * @param boolean $includeMenuURLs indicates if URLs declared in the Formulize menu settings should be interpretted
+		 * @param boolean $followMenuURLs indicates if user should be redirected to any menu URLs that were found. Only has an effect if $includeMenuURLs is true
+		 * @return array An array containing the form id and screen id of any default menu link found
+		 */
+		static function getDefaultScreenForUser($includeMenuURLs=false, $followMenuURLs=true) {
 
-            global $xoopsUser, $xoopsDB;
-            $fid = null;
-            $sid = null;
-            $groups = $xoopsUser ? $xoopsUser->getGroups() : array(0=>XOOPS_GROUP_ANONYMOUS);
-            $groupSQL = "";
-            foreach($groups as $group) {
-                if(strlen($groupSQL) == 0){
-                    $groupSQL .= " AND ( perm.group_id=". $group . " ";
-                }else{
-                    $groupSQL .= " OR perm.group_id=". $group . " ";
-                }
-            }
-            $groupSQL .= ")";
+			global $xoopsUser, $xoopsDB;
+			static $cachedResults = array();
+			$fid = null;
+			$sid = null;
+			$groups = $xoopsUser ? $xoopsUser->getGroups() : array(0=>XOOPS_GROUP_ANONYMOUS);
+			$cacheKey = serialize($groups);
+			if(!isset($cachedResults[$cacheKey])) {
+				$groupSQL = "";
+				foreach($groups as $group) {
+					if(strlen($groupSQL) == 0){
+							$groupSQL .= " AND ( perm.group_id=". $group . " ";
+					}else{
+							$groupSQL .= " OR perm.group_id=". $group . " ";
+					}
+				}
+				$groupSQL .= ")";
+				$sql = 'SELECT links.screen, links.url FROM '.$xoopsDB->prefix("formulize_menu_links").' AS links ';
+				$sql .= ' LEFT JOIN '.$xoopsDB->prefix("formulize_menu_permissions").' AS perm ON links.menu_id = perm.menu_id ';
+				$sql .= ' WHERE  default_screen = 1'. $groupSQL . 'ORDER BY links.rank LIMIT 0,1';
+				$res = $xoopsDB->query ( $sql ) or die('SQL Error !<br />'.$sql.'<br />'.$xoopsDB->error());
+				$cachedResults[$cacheKey] = $res;
+			} else {
+				$res = $cachedResults[$cacheKey];
+			}
+			$url = '';
+			$fid = 0;
+			$sid = 0;
+			if ( $res ) {
+				if($row = $xoopsDB->fetchArray ( $res )) {
+					if($includeMenuURLs AND $row['url']) {
+						if(substr($row['url'],0,1)=='/') {
+								$url = XOOPS_URL . $row['url'];
+						} elseif(!strstr($row['url'],'://')) {
+								$url = 'http://' . $row['url'];
+						} else {
+								$url = $row['url'];
+						}
+					}
+					if($url AND $followMenuURLs) {
+						header('Location: '.$url);
+						exit();
+					}
+					$screenID = $row['screen'];
+					if ( strpos($screenID,"fid=") !== false){
+						$fid = substr($screenID, strpos($screenID,"=")+1 );
+					} else {
+						$sid = substr($screenID, strpos($screenID,"=")+1 );
+					}
+				}
+			}
+			return array($fid,$sid,$url);
+		}
 
-            $sql = 'SELECT links.screen, links.url FROM '.$xoopsDB->prefix("formulize_menu_links").' AS links ';
-            $sql .= ' LEFT JOIN '.$xoopsDB->prefix("formulize_menu_permissions").' AS perm ON links.menu_id = perm.menu_id ';
-            $sql .= ' WHERE  default_screen = 1'. $groupSQL . 'ORDER BY links.rank LIMIT 0,1';
-
-            $res = $xoopsDB->query ( $sql ) or die('SQL Error !<br />'.$sql.'<br />'.$xoopsDB->error());
-
-            if ( $res ) {
-                if($row = $xoopsDB->fetchArray ( $res )) {
-                    if($includeMenuURLs AND $row['url']) {
-                        if(substr($row['url'],0,1)=='/') {
-                            header('Location: ' . XOOPS_URL . $row['url']);
-                        } elseif(!strstr($row['url'],'://')) {
-                            header('Location: ' . 'http://' . $row['url']);
-                        } else {
-                            header('Location: ' . $row['url']);
-                        }
-                        exit();
-                    }
-                    $screenID = $row['screen'];
-                    if ( strpos($screenID,"fid=") !== false){
-                        $fid = substr($screenID, strpos($screenID,"=")+1 );
-                    } else {
-                        $sid = substr($screenID, strpos($screenID,"=")+1 );
-                    }
-                }
-            }
-            return array($fid,$sid);
-        }
-
-    }
+  }
 
 
 class formulizeApplication extends XoopsObject {

--- a/modules/formulize/class/applications.php
+++ b/modules/formulize/class/applications.php
@@ -141,12 +141,10 @@ global $xoopsDB;
         }
 
 		/**
-		 * Returns an array of the fid,sid of default menu links applicable to the current user, based on menu settings and permissions
-		 * @param boolean $includeMenuURLs indicates if URLs declared in the Formulize menu settings should be interpretted
-		 * @param boolean $followMenuURLs indicates if user should be redirected to any menu URLs that were found. Only has an effect if $includeMenuURLs is true
-		 * @return array An array containing the form id and screen id of any default menu link found
+		 * Returns an array of the fid,sid,url representing the default menu link for the current user
+		 * @return array An array containing the form id and screen id and url of any default menu link found
 		 */
-		static function getDefaultScreenForUser($includeMenuURLs=false, $followMenuURLs=true) {
+		static function getDefaultScreenForUser() {
 
 			global $xoopsUser, $xoopsDB;
 			static $cachedResults = array();
@@ -168,16 +166,11 @@ global $xoopsDB;
 				$sql .= ' LEFT JOIN '.$xoopsDB->prefix("formulize_menu_permissions").' AS perm ON links.menu_id = perm.menu_id ';
 				$sql .= ' WHERE  default_screen = 1'. $groupSQL . 'ORDER BY links.rank LIMIT 0,1';
 				$res = $xoopsDB->query ( $sql ) or die('SQL Error !<br />'.$sql.'<br />'.$xoopsDB->error());
-				$cachedResults[$cacheKey] = $res;
-			} else {
-				$res = $cachedResults[$cacheKey];
-			}
-			$url = '';
-			$fid = 0;
-			$sid = 0;
-			if ( $res ) {
+				$url = '';
+				$fid = 0;
+				$sid = 0;
 				if($row = $xoopsDB->fetchArray ( $res )) {
-					if($includeMenuURLs AND $row['url']) {
+					if($row['url']) {
 						if(substr($row['url'],0,1)=='/') {
 								$url = XOOPS_URL . $row['url'];
 						} elseif(!strstr($row['url'],'://')) {
@@ -186,10 +179,6 @@ global $xoopsDB;
 								$url = $row['url'];
 						}
 					}
-					if($url AND $followMenuURLs) {
-						header('Location: '.$url);
-						exit();
-					}
 					$screenID = $row['screen'];
 					if ( strpos($screenID,"fid=") !== false){
 						$fid = substr($screenID, strpos($screenID,"=")+1 );
@@ -197,12 +186,11 @@ global $xoopsDB;
 						$sid = substr($screenID, strpos($screenID,"=")+1 );
 					}
 				}
+				$cachedResults[$cacheKey] = array($fid,$sid,$url);
 			}
-			return array($fid,$sid,$url);
+			return $cachedResults[$cacheKey];
 		}
-
   }
-
 
 class formulizeApplication extends XoopsObject {
 

--- a/modules/formulize/initialize.php
+++ b/modules/formulize/initialize.php
@@ -93,9 +93,9 @@ $formulizeConfig =& $config_handler->getConfigsByCat(0, $mid);
 // get the default menu link for the current user, and set the fid or sid based on it
 
 if( !$fid AND !$sid) {
-    include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
-    $includeMenuURLs = true;
-	list($fid,$sid) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser($includeMenuURLs);
+	include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
+	$includeMenuURLs = true;
+	list($fid,$sid,$url) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser($includeMenuURLs);
 }
 
 $screen_handler =& xoops_getmodulehandler('screen', 'formulize');
@@ -241,7 +241,7 @@ if ($screen) {
 // 3 displayForm
 
 if (!$rendered AND $uid) {
-    if (isset($frid) AND is_numeric($frid) AND isset($fid) AND is_numeric($fid)) {
+    if (isset($frid) AND is_numeric($frid) AND $frid AND isset($fid) AND is_numeric($fid) AND $fid) {
         // this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
         include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
         if (((!$singleentry AND $xoopsUser) OR $view_globalscope OR ($view_groupscope AND $singleentry != "group")) AND !$entry AND (!isset($_GET['iform']) OR $_GET['iform'] != "e") AND !isset($_GET['showform'])) { // if it's multientry and there's a xoopsUser, or the user has globalscope, or the user has groupscope and it's not a one-per-group form, and after all that, no entry has been requested, then show the list (note that anonymous users default to the form view...to provide them lists of their own entries....well you can't, but groupscope and globalscope will show them all entries by anons or by everyone) ..... unless there is an override in the URL that is meant to force the form itself to display .... iform is "interactive form", devised by Feratech.
@@ -254,7 +254,7 @@ if (!$rendered AND $uid) {
             // if it's a single and they don't have group or global scope, OR if an entry was specified in particular
             displayForm($frid, $entry, $fid, "", "{NOBUTTON}");
         }
-    } elseif (isset($fid) AND is_numeric($fid)) {
+    } elseif (isset($fid) AND is_numeric($fid) AND $fid) {
         $form_handler = xoops_getmodulehandler('forms', 'formulize');
         $formObject = $form_handler->get($fid);
         $defaultFormScreen = $formObject->getVar('defaultform');

--- a/modules/formulize/initialize.php
+++ b/modules/formulize/initialize.php
@@ -95,7 +95,11 @@ $formulizeConfig =& $config_handler->getConfigsByCat(0, $mid);
 if( !$fid AND !$sid) {
 	include_once XOOPS_ROOT_PATH."/modules/formulize/class/applications.php";
 	$includeMenuURLs = true;
-	list($fid,$sid,$url) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser($includeMenuURLs);
+	list($fid,$sid,$defaultMenuLinkUrl) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser();
+	if($defaultMenuLinkUrl) {
+		header('Location: '.$defaultMenuLinkUrl);
+		exit();
+	}
 }
 
 $screen_handler =& xoops_getmodulehandler('screen', 'formulize');


### PR DESCRIPTION
Anon users now default to Formulize like anyone else. (Due to commit c7ae4bca34af3fd4db1eb31ef2d820afef6021cd)

Problem is that the login block is in the sidebar, which only opens automatically when the user is on the homepage of the site, or on the application.php page in Formulize.

Solution: make the home page detection of whether the user has a start page declared, smarter so it only directs to a Formulize page if the user actually has a start page declared. If they don't stay on home page, and the login block will appear because the sidebar will open.

Typically, anon users won't have a Formulize default page. But now they could thanks to that prior commit, so if they do, great, they get it. If they don't, they stay put and get the login block.