### PR TITLE
Keeping notification queue history for a week

### DIFF
--- a/modules/formulize/cache/queue_history/index.html
+++ b/modules/formulize/cache/queue_history/index.html
@@ -1,0 +1,1 @@
+ <script>history.go(-1);</script> 


### PR DESCRIPTION
Instead of deleting the notification queue when it is all processed, move the file into a queue_history folder. Keep up to one week of files in the folder.