### PR TITLE
Always remove &ve from done dest

### DIFF
--- a/modules/formulize/include/formdisplaypages.php
+++ b/modules/formulize/include/formdisplaypages.php
@@ -273,14 +273,14 @@ function displayFormPages($formframe, $entry, $mainform, $pages, $conditions="",
                 }
             }
         }
-    } else {
-        // strip out any ve portion of a done destination, so we don't end up forcing the user back to this entry after they're done
-        if($vepos = strpos($done_dest,'&ve=')) {
-            if(is_numeric(substr($done_dest, $vepos+4))) {
-                $done_dest = substr($done_dest, 0, $vepos);
-            }
-        }
     }
+		// strip out any ve portion of a done destination, so we don't end up forcing the user back to this entry after they're done
+		if($done_dest AND $vepos = strpos($done_dest,'&ve=')) {
+				if(is_numeric(substr($done_dest, $vepos+4))) {
+						$done_dest = substr($done_dest, 0, $vepos);
+				}
+		}
+
 	$done_dest = substr($done_dest,0,4) == "http" ? $done_dest : "http://".$done_dest;
 
 	// display a form if that's what this page is...


### PR DESCRIPTION
When we get a &ve param in the URL, we show that entry. The form we show is determined by the screen id or form id in the URL. If the screen id is for a list, then we use the screen that is set to be used for showing entries in that list.

When the user clicks the "Save and Leave" button, we were previously leaving the &ve param in the URL. The list still appeared, because the ventry hidden field in the form was being emptied, so the list happily showed itself instead of booting the user back to the entry.

However, because the &ve param was still in the URL, subsequent submissions of the list would pickup the &ve param and send the user back to that entry. Super confusing for users, total bug.

This is fixed by always removing the &ve param from the done destination. Previously we were only doing this if a done destination was already declared/present when the form was being prepared, and otherwise we deduced the done destination from the current URL. Problem was, if the current URL contained a &ve param, we were never stripping that out. Now we always strip it as the last step in preparing the done destination.