### PR TITLE
Listen for asynch values when parsing dynamic captions

### DIFF
--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -1115,7 +1115,11 @@ class formulizeElementRenderer{
 				$term = substr($text, $bracketPos+1, $endBracketPos-$bracketPos-1);
                 $elementObject = $element_handler->get($term);
                 if($elementObject) {
-                    $replacementTerm = display($entryData, $term, '', $entry_id);
+					if(isset($GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entry_id][$term])) {
+						$replacementTerm = $GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entry_id][$term];
+					} else {
+                    	$replacementTerm = display($entryData, $term, '', $entry_id);
+					}
 					// get the uitext value if necessary
 					$replacementTerm = formulize_swapUIText($replacementTerm, $elementObject->getVar('ele_uitext'));
                     $replacementTerm = formulize_numberFormat($replacementTerm, $term);


### PR DESCRIPTION
Just drop in the reference to the asynch GLOBAL that we care about, and use that instead of data from the DB. Simple.

This allows a conditional element A that depends on the value in another element B, to reference the value of element B in the caption for element A. ie:

Order size is: Small Medium Large

[conditional element when order is not small] Should your {order_size} be wrapped in tinfoil? yes/no

The {order_size} will pick up the selected value in the element, so the caption can be specific to the user's context.