### PR TITLE
If admin key matches a system element, only skip saving if we're saving an element!

### DIFF
--- a/modules/formulize/admin/save.php
+++ b/modules/formulize/admin/save.php
@@ -38,11 +38,7 @@ while(ob_get_level()) {
 
 $module_handler = xoops_gethandler('module');
 $config_handler = xoops_gethandler('config');
-$element_handler = xoops_getmodulehandler('elements', 'formulize');
-$elementObject = $element_handler->get(intval($_POST['formulize_admin_key']));
-if($elementObject->isSystemElement) {
-    exit();
-}
+
 $formulizeModule = $module_handler->getByDirname("formulize");
 $formulizeConfig = $config_handler->getConfigsByCat(0, $formulizeModule->getVar('mid'));
 if ($formulizeConfig['isSaveLocked']){

--- a/modules/formulize/admin/save/element_advanced_save.php
+++ b/modules/formulize/admin/save/element_advanced_save.php
@@ -95,6 +95,9 @@ if(!$ele_id = intval($_GET['ele_id'])) { // on new element saves, new ele_id can
 
 // get the element object with the right handler, ie: check if it's a custom type
 $element = $element_handler->get($ele_id);
+if($element->isSystemElement) {
+	exit();
+}
 $ele_type = $element->getVar('ele_type');
 if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$ele_type."Element.php")) {
 	$customTypeHandler = xoops_getmodulehandler($ele_type."Element", 'formulize');
@@ -135,7 +138,7 @@ if($_POST['original_handle']) {
 }
 
 if($databaseElement AND (!$_POST['original_handle'] OR $form_handler->elementFieldMissing($ele_id, $_POST['original_handle']))) { // ele_id is only in the URL when we're on the first save for a new element
-    
+
 	global $xoopsDB;
 	  // figure out what the data type should be.
 	  // the rules:
@@ -242,7 +245,7 @@ if(isset($_POST['exportoptions_onoff']) AND $_POST['exportoptions_onoff']) {
         $options = array_keys($ele_value[2]);
     }
     $element->setVar('ele_exportoptions', array(
-       'columns'=>$options, 'indicators'=>array('hasValue'=>$_POST['exportoptions_hasvalue'], 'doesNotHaveValue'=>$_POST['exportoptions_doesnothavevalue']) 
+       'columns'=>$options, 'indicators'=>array('hasValue'=>$_POST['exportoptions_hasvalue'], 'doesNotHaveValue'=>$_POST['exportoptions_doesnothavevalue'])
     ));
 } else {
     $element->setVar('ele_exportoptions', array());

--- a/modules/formulize/admin/save/element_display_save.php
+++ b/modules/formulize/admin/save/element_display_save.php
@@ -47,6 +47,10 @@ if(!$ele_id = intval($_GET['ele_id'])) { // on new element saves, new ele_id can
   }
 }
 $element = $element_handler->get($ele_id);
+if($element->isSystemElement) {
+    exit();
+}
+
 $fid = $element->getVar('id_form');
 
 $form_handler = xoops_getmodulehandler('forms', 'formulize');

--- a/modules/formulize/admin/save/element_names_save.php
+++ b/modules/formulize/admin/save/element_names_save.php
@@ -85,7 +85,7 @@ if($_POST['formulize_admin_key'] == "new") {
 }
 
 if($element->isSystemElement) {
-	return;
+	exit();
 }
 
 $element->setVar('ele_order', figureOutOrder($_POST['orderpref'], $element->getVar('ele_order'), $fid));

--- a/modules/formulize/admin/save/element_names_save.php
+++ b/modules/formulize/admin/save/element_names_save.php
@@ -69,9 +69,6 @@ $ele_type = $_POST['element_type'];
 $element_handler = xoops_getmodulehandler('elements','formulize');
 if($_POST['formulize_admin_key'] == "new") {
   $element = $element_handler->create();
-  if($element->isSystemElement) {
-    return;
-  }
   $fid = intval($_POST['formulize_form_id']);
   $element->setVar('id_form', $fid);
   $element->setVar('ele_type', $ele_type);
@@ -85,6 +82,10 @@ if($_POST['formulize_admin_key'] == "new") {
   $element = $element_handler->get(intval($_POST['formulize_admin_key']));
   $fid = $element->getVar('id_form');
   $original_handle = $element->getVar('ele_handle');
+}
+
+if($element->isSystemElement) {
+	return;
 }
 
 $element->setVar('ele_order', figureOutOrder($_POST['orderpref'], $element->getVar('ele_order'), $fid));
@@ -127,7 +128,7 @@ if(!$ele_id = $element_handler->insert($element)) {
   print "Error: could not save the element: ".$xoopsDB->error();
 }
 
-if($original_handle) { 
+if($original_handle) {
 	if($ele_handle != $original_handle) {
         // rewrite references in other elements to this handle (linked selectboxes)
         $ele_handle_len = strlen($ele_handle) + 5 + strlen($fid);
@@ -174,6 +175,6 @@ if($_POST['reload_names_page'] OR $isNew) {
   if($isNew) {
     $url = XOOPS_URL . "/modules/formulize/admin/ui.php?page=element&fid=$fid&aid=".intval($_POST['aid'])."&ele_id=$ele_id";
     $ele_id_to_send = $ele_id;
-  } 
+  }
   print "/* evalnow */ ele_id = $ele_id_to_send; redirect = \"reloadWithScrollPosition('$url');\";";
 }

--- a/modules/formulize/admin/save/element_options_save.php
+++ b/modules/formulize/admin/save/element_options_save.php
@@ -72,7 +72,7 @@ if(!$ele_id = intval($_GET['ele_id'])) { // on new element saves, new ele_id can
 }
 $element = $element_handler->get($ele_id);
 if($element->isSystemElement) {
-	return;
+	exit();
 }
 $ele_type = $element->getVar('ele_type');
 $fid = $element->getVar('id_form');

--- a/modules/formulize/admin/save/element_options_save.php
+++ b/modules/formulize/admin/save/element_options_save.php
@@ -71,6 +71,9 @@ if(!$ele_id = intval($_GET['ele_id'])) { // on new element saves, new ele_id can
   }
 }
 $element = $element_handler->get($ele_id);
+if($element->isSystemElement) {
+	return;
+}
 $ele_type = $element->getVar('ele_type');
 $fid = $element->getVar('id_form');
 


### PR DESCRIPTION
Anon passcodes are system elements. Part of a form but not editable by users. We have a block on saving elements if they are system elements. It was mistakenly operating at too high a level and would bail on saving if the item we were saving happened to have an id that matched the id of a system element (ie: element 22 is a system element, we're saving form 22, so nothing in form 22 saves!)