### PR TITLE
Multi values in LOE cells look better and link properly

### DIFF
--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -6097,7 +6097,7 @@ function getHTMLForList($value, $handle, $entryId, $deDisplay=0, $textWidth=200,
     $fid = $cachedFormIds[$handle];
     $element_type = $cached_object_type[$handle];
     foreach ($value as $valueId=>$v) {
-        $elstyle = 'style="width: 100%;text-align: ';
+        $elstyle = 'style="text-align: ';
         if (is_numeric($v)) {
             $elstyle .= 'right;"'; // and if there is a width that pushes the right edge over then it looks nice, sort of, but more formatting controls on table and whitespace between cells, etc... is necessary
         } else {
@@ -6114,11 +6114,8 @@ function getHTMLForList($value, $handle, $entryId, $deDisplay=0, $textWidth=200,
             $dateStringFormat = ($handle == "mod_datetime" OR $handle == "creation_datetime") ? _MEDIUMDATESTRING : _SHORTDATESTRING; // constants set in /language/english/global.php
             $v = (false === $time_value) ? "" : date($dateStringFormat, ($time_value)+$offset);
         }
-        $output .= '<span '.$elstyle.'>' . formulize_numberFormat(str_replace("\n", "<br>", formatLinks($v, $handle, $textWidth, $thisEntryId)), $handle);
+        $output .= '<span '.$elstyle.'>' . formulize_numberFormat(str_replace("\n", "<br>", formatLinks($v, $handle, $textWidth, $thisEntryId, $fid)), $handle);
         $output .= '</span>';
-        if ($counter<$countOfValue) {
-            $output .= "<br>";
-        }
         $counter++;
     }
 		if ($deDisplay AND $element_type != 'derived') {

--- a/themes/Anari/css/style.css
+++ b/themes/Anari/css/style.css
@@ -3196,6 +3196,12 @@ input[name='pickdiffgroup'] {
     width: auto;
 }
 
+#listofentries div.main-cell-div > span {
+	display: block;
+	padding-bottom: 0.3em;
+}
+
+
 .list-of-entries table.outer td.formulize-controls {
     border-bottom: 1px dotted #d1d1df;
     left: 0px;
@@ -3287,11 +3293,11 @@ table.outer th {
 }
 
 table.outer td {
-  padding: 24px;
+  padding: 1.2em;
 }
 @media print {
   table.outer td {
-    padding: 20px 0;
+    padding: 1em 0;
   }
 }
 


### PR DESCRIPTION
If there are multiple values in a cell, spacing was too close.

Also, if they were linked, and you wanted them to show up as links, the links didn't lead to the right place. They all linked to the first entry, and the links were target=_blank so you left your window behind.

This fixes all that.