### PR TITLE
Get grid elements based on grid count alone

### DIFF
--- a/modules/formulize/admin/save/element_display_save.php
+++ b/modules/formulize/admin/save/element_display_save.php
@@ -230,17 +230,20 @@ if(!$ele_id = $element_handler->insert($element)) {
   print "Error: could not save the display settings for element: ".$xoopsDB->error();
 }
 
-// if this is a grid element, set the display conditions for the contained elements
+// if this is a grid element, set the display conditions for the contained elements, if they have no conditions already!
 if($element->getVar('ele_type')=='grid') {
 	$ele_value = $element->getVar('ele_value');
 	$gridCount = count(explode(",", $ele_value[1])) * count(explode(",", $ele_value[2]));
 	include_once XOOPS_ROOT_PATH.'/modules/formulize/include/griddisplay.php';
 	foreach(elementsInGrid($ele_value[4], $element->getVar('id_form'), $gridCount) as $gridElementId) {
 		$gridElementObject = $element_handler->get($gridElementId);
-		$gridElementObject->setVar('ele_filtersettings', $parsedFilterSettings);
-		if(!$element_handler->insert($gridElementObject)) {
-			$elementLabel = $gridElementObject->getVar('ele_colhead') ? $gridElementObject->getVar('ele_colhead') : $gridElementObject->getVar('ele_caption');
-			print "Error: could not apply grid display settings to the element ".$elementLabel."\n";
+		$gridElementFilterSettings = $gridElementObject->getVar('ele_filtersettings');
+		if(!is_array($gridElementFilterSettings[0]) OR count((array) $gridElementFilterSettings[0]) == 0) {
+			$gridElementObject->setVar('ele_filtersettings', $parsedFilterSettings);
+			if(!$element_handler->insert($gridElementObject)) {
+				$elementLabel = $gridElementObject->getVar('ele_colhead') ? $gridElementObject->getVar('ele_colhead') : $gridElementObject->getVar('ele_caption');
+				print "Error: could not apply grid display settings to the element ".$elementLabel."\n";
+			}
 		}
 	}
 }

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -1618,6 +1618,7 @@ class formulizeFormsHandler {
 		  	$screens[$sid]['pages'] = $screenData->getVar('pages');
 		  	$screens[$sid]['pagetitles'] = $screenData->getVar('pagetitles');
             // find the pages that contain all elements in this form, and add 'new' as an element on that page, so the page will be selected when creating new elements
+						ksort($screens[$sid]['pages']);
             foreach($screens[$sid]['pages'] as $i=>$page) {
                 foreach($formObject->getVar('elements') as $ele_id) { // check for all elements (but ignore 'display to no group' elements which are not included in the object by default)
                     if(!in_array($ele_id, $page)) {

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -2794,7 +2794,7 @@ function calcValuePlusText($value, $handle, $col, $calc, $groupingValue) {
 	}
   }
   $uitexts = $element->getVar('ele_uitext');
-  $value = isset($uitexts[$value]) ? $uitexts[$value] : $value;
+  $value = formulize_swapUIText($value, $uitexts);
   if(substr($value, 0, 6)=="{OTHER") { $value = _formulize_OPT_OTHER; }
   if($element->getVar('ele_type')=='yn') {
 	if($value == "1") {

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -3146,6 +3146,7 @@ function writeHiddenSettings($settings, $form = null, $entries = array(), $sub_e
             $form->addElement (new XoopsFormHidden ('originalReloadBlank', $screen->getVar('reloadblank')));
         }
         $form->addElement (new XoopsFormHidden ('formulize_entry_lock_token', getEntryLockSecurityToken()));
+				$form->addElement (new XoopsFormHidden ('formulize_entriesPerPage', intval($_POST['formulize_entriesPerPage'])));
 		return $form;
 	} else { // write as HTML
 		print "<input type=hidden name=sort value='" . $sort . "'>";
@@ -3203,6 +3204,7 @@ function writeHiddenSettings($settings, $form = null, $entries = array(), $sub_e
             print "<input type=hidden name=originalReloadBlank value='" . $screen->getVar('reloadblank') . "'>";
         }
         print "<input type='hidden' name='formulize_entry_lock_token' value='".getEntryLockSecurityToken()."'>";
+				print "<input type='hidden' name='formulize_entriesPerPage' value='".intval($_POST['formulize_entriesPerPage'])."'>";
 	}
 }
 

--- a/modules/formulize/include/import_functions.php
+++ b/modules/formulize/include/import_functions.php
@@ -440,7 +440,7 @@ function importCsvValidate(&$importSet, $id_reqs, $regfid, $validateOverride=fal
                                                 // last option causes strict matching by type
                                                 $foundit = false;
                                                 foreach ($options as $thisoption=>$default_value) {
-                                                
+
                                                     if (trim($item_value) == trim(trans($thisoption))) {
                                                         $foundit = true;
                                                         break;
@@ -619,6 +619,7 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
         $form_proxyid = $xoopsUser->getVar('uid');
     }
 
+		$element_handler = xoops_getmodulehandler('elements', 'formulize');
     $form_handler = xoops_getmodulehandler('forms','formulize');
     $formObject = $form_handler->get($importSet[4]);
     $data_handler = new formulizeDataHandler($importSet[4]);
@@ -640,7 +641,7 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
             $xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))." WRITE";
             // include the revisions table if necessary
             if($formObject->getVar('store_revisions') AND $form_handler->revisionsTableExists($formObject->getVar('id_form'))) {
-                $lockSQL .= ", ".$xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))."_revisions WRITE";    
+                $lockSQL .= ", ".$xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))."_revisions WRITE";
             }
     } else {
             $lockSQL = "LOCK TABLES " . $xoopsDB->prefix("formulize_".$importSet[8]) . " WRITE, ".
@@ -654,7 +655,7 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
             $xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))." WRITE";
             // include the revisions table if necessary
             if($formObject->getVar('store_revisions') AND $form_handler->revisionsTableExists($formObject->getVar('id_form'))) {
-                $lockSQL .= ", ".$xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))."_revisions WRITE";    
+                $lockSQL .= ", ".$xoopsDB->prefix("formulize_".$formObject->getVar('form_handle'))."_revisions WRITE";
             }
     }
     $xoopsDB->query($lockSQL);
@@ -724,9 +725,9 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
 
                 if ($importSet[6][$link] != -1) {
                     $element = $importSet[5][0][$importSet[6][$link]];
-                    
+
                     $id_form = $importSet[4];
-                    
+
                     if ($link == ($links-1)) {
                         // remove some really odd line endings if present, only happens when dealing with legacy outputs of really old/odd systems
                         $row_value = str_replace(chr(19).chr(16), "", $row[$link]);
@@ -736,10 +737,10 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
 
                     if ($row_value != "") {
                         switch($element["ele_type"]) {
-                            
+
                             case "derived":
                                 break; // ignore derived values for importing
-                            
+
                             case "select":
                             $ele_value = unserialize($element["ele_value"]);
                             if ($importSet[5][1][$link] AND !strstr($row_value, ",")
@@ -757,7 +758,7 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
                                     if($ele_value['snapshot']) {
                                         $row_value = '';
                                         if(count((array) $items)>1) {
-                                            $row_value .= '*=+*:';  
+                                            $row_value .= '*=+*:';
                                         }
                                         $row_value .= implode('*=+*:',$items);
                                     } else {
@@ -977,7 +978,11 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
 
                         // record the values for inserting as part of this record
                         // prior to 3.0 we did not do the htmlspecialchars conversion if this was a linked selectbox...don't think that's a necessary exception in 3.0 with new data structure
-                        $fieldValues[$element['ele_handle']] = $myts->htmlSpecialChars($row_value);
+
+												$elementObject = $element_handler->get($element['ele_handle']);
+												if($elementObject->hasData) {
+                        	$fieldValues[$element['ele_handle']] = $myts->htmlSpecialChars($row_value);
+												}
 
                     } // end of if there's a value in the current column
                 } elseif (isset($importSet[7]['usethisentryid']) AND $link == $importSet[7]['usethisentryid']) {
@@ -988,10 +993,10 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
 
             // now that we've recorded all the values, do the actual updating/inserting of this record
             if ($this_id_req) {
-                
+
                 // first, record a revisions if necessary
                 formulize_updateRevisionData($formObject, $this_id_req, true);
-                
+
                 // updating an entry
                 $form_uid = $this_uid;
                 $updateSQL = "UPDATE " . $xoopsDB->prefix("formulize_".$importSet[8])." SET ";
@@ -1084,7 +1089,7 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
     }
     // fid is $importSet[4] ?!!
     $GLOBALS['formulize_snapshotRevisions'][$importSet[4]] = formulize_getCurrentRevisions($importSet[4], $entriesMap);
-    
+
     if(isset($_POST['updatederived']) AND $_POST['updatederived']) {
     // update derived values based on the form only
         $ele_types = $formObject->getVar('elementTypes');
@@ -1097,12 +1102,12 @@ function importCsvProcess(& $importSet, $id_reqs, $regfid, $validateOverride) {
     }
         }
     }
-    
+
     if(isset($_POST['sendnotifications']) AND $_POST['sendnotifications']) {
     // send notifications
     foreach($notEntriesList as $notEvent=>$notDetails) {
         foreach($notDetails as $notFid=>$notEntries) {
-            $notEntries = array_unique($notEntries); 
+            $notEntries = array_unique($notEntries);
             sendNotifications($notFid, $notEvent, $notEntries);
         }
     }

--- a/modules/formulize/initialize.php
+++ b/modules/formulize/initialize.php
@@ -245,20 +245,7 @@ if ($screen) {
 // 3 displayForm
 
 if (!$rendered AND $uid) {
-    if (isset($frid) AND is_numeric($frid) AND $frid AND isset($fid) AND is_numeric($fid) AND $fid) {
-        // this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
-        include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
-        if (((!$singleentry AND $xoopsUser) OR $view_globalscope OR ($view_groupscope AND $singleentry != "group")) AND !$entry AND (!isset($_GET['iform']) OR $_GET['iform'] != "e") AND !isset($_GET['showform'])) { // if it's multientry and there's a xoopsUser, or the user has globalscope, or the user has groupscope and it's not a one-per-group form, and after all that, no entry has been requested, then show the list (note that anonymous users default to the form view...to provide them lists of their own entries....well you can't, but groupscope and globalscope will show them all entries by anons or by everyone) ..... unless there is an override in the URL that is meant to force the form itself to display .... iform is "interactive form", devised by Feratech.
-            include_once XOOPS_ROOT_PATH . "/modules/formulize/include/entriesdisplay.php";
-            // if it's a multi, or if a single and they have group or global scope
-            displayEntries($frid, $fid);
-        } else {
-            // otherwise, show the form
-            include_once XOOPS_ROOT_PATH . "/modules/formulize/include/formdisplay.php";
-            // if it's a single and they don't have group or global scope, OR if an entry was specified in particular
-            displayForm($frid, $entry, $fid, "", "{NOBUTTON}");
-        }
-    } elseif (isset($fid) AND is_numeric($fid) AND $fid) {
+    if (isset($fid) AND is_numeric($fid) AND $fid) {
         $form_handler = xoops_getmodulehandler('forms', 'formulize');
         $formObject = $form_handler->get($fid);
         $defaultFormScreen = $formObject->getVar('defaultform');
@@ -273,12 +260,17 @@ if (!$rendered AND $uid) {
                 include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
                 $renderedFormulizeScreen = $finalscreenObject;
                 $finalscreen_handler->render($finalscreenObject, $entry, $loadThisView);
+						// no screen to show, go with the basics...
             } else {
-                // this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
-                include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
-                include_once XOOPS_ROOT_PATH . "/modules/formulize/include/entriesdisplay.php";
-                // if it's a multi, or if a single and they have group or global scope
-                displayEntries($fid);
+								if (isset($frid) AND is_numeric($frid) AND $frid) {
+										// this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
+										include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
+										displayEntries($frid, $fid);
+								} else {
+                		// this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
+                		include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
+									  displayEntries($fid);
+								}
             }
         } else {
             // otherwise, show the form
@@ -291,12 +283,18 @@ if (!$rendered AND $uid) {
                 include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
                 $renderedFormulizeScreen = $finalscreenObject;
                 $finalscreen_handler->render($finalscreenObject, $entry);
+						// no screen to show, go with the basics...
             } else {
-                // this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
-                include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
-                include_once XOOPS_ROOT_PATH . "/modules/formulize/include/formdisplay.php";
-                displayForm($fid, $entry, "", "", "{NOBUTTON}"); // if it's a single and they don't have group or global scope, OR if an entry was specified in particular
-            }
+								if (isset($frid) AND is_numeric($frid) AND $frid) {
+										// this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
+										include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
+										displayForm($frid, $entry, $fid, "", "{NOBUTTON}");
+								} else {
+										// this will only be included once, but we need to do it after the fid and frid for the current page load have been determined!!
+										include_once XOOPS_ROOT_PATH . "/modules/formulize/include/readelements.php";
+										displayForm($fid, $entry, "", "", "{NOBUTTON}"); // if it's a single and they don't have group or global scope, OR if an entry was specified in particular
+								}
+						}
         }
     } else {
         // if no form is specified, then show the General Forms category

--- a/modules/formulize/language/english/main.php
+++ b/modules/formulize/language/english/main.php
@@ -99,8 +99,8 @@ define("_AM_FORMUL","Forms");
 
 //added by jwe - 7/28/04
 define("_AM_FORM_TITLE", "Form Access Permissions"); // not used
-define("_AM_FORM_CURPERM", "Current Permission:"); 
-define("_AM_FORM_CURPERMLINKS", "Current Linked Selectbox:"); 
+define("_AM_FORM_CURPERM", "Current Permission:");
+define("_AM_FORM_CURPERMLINKS", "Current Linked Selectbox:");
 define("_AM_FORM_PERMVIEW", "View");
 define("_AM_FORM_PERMADD", "Add/Update");
 define("_AM_FORM_PERMADMIN", "Admin");
@@ -129,7 +129,7 @@ define("_AM_FRAME_AVAILFORMS1", "Form One:");
 define("_AM_FRAME_AVAILFORMS2", "Form Two:");
 define("_AM_FRAME_DELETE", "Delete an Existing Framework:");
 define("_AM_FRAME_SUBFORM_OF", "Make it a subform of:");
-define("_AM_FRAME_NOPARENTS", "No Forms in Framework"); 
+define("_AM_FRAME_NOPARENTS", "No Forms in Framework");
 define("_AM_FRAME_TYPENEWFORMNAME", "Type a short name here");
 define("_AM_FRAME_NEWFORMBUTTON", "Add Forms!");
 define("_AM_FRAME_NOKEY", "none specified!");
@@ -397,7 +397,7 @@ define("_formulize_DB_EXPORT_TO_EXCEL", "Use compatibility mode for some version
 define("_formulize_DB_EXPORT_NULL_OPTION", "Use this value in place of all NULL values: ");
 define("_formulize_EXPORT_FILENAME_TEXT", "Exported_data_from");
 
-       
+
 define("_formulize_DE_EXPORT_CALCS", "Export Calcs");
 define("_formulize_DE_SAVE", "Save view");
 define("_formulize_DE_DELETE", "Delete view");
@@ -444,7 +444,7 @@ define("_formulize_DE_CALCSUB", "Add Calculation(s) to list");
 define("_formulize_DE_CALC_CALCS", "Calculations to perform on the column(s):");
 define("_formulize_DE_CALCGO", "Perform Requested Calculations");
 define("_formulize_DE_REQDCALCS", "Requested Calculations:");
-define("_formulize_DE_CALCALL", "Include blanks/zeros"); 
+define("_formulize_DE_CALCALL", "Include blanks/zeros");
 define("_formulize_DE_CALCNOBLANKS", "Exclude blanks/zeros");
 define("_formulize_DE_CALCONLYBLANKS", "Include only blanks/zeros");
 define("_formulize_DE_CALCJUSTNOBLANKS", "Exclude blanks");
@@ -592,7 +592,7 @@ define("_formulize_USERNAME_HELP3", " characters long)");
 define("_formulize_PASSWORD_HELP1", " characters long)");
 
 // "Other" for checkboxes and radio buttons:
-define("_formulize_OPT_OTHERWORD", "Other"); 
+define("_formulize_OPT_OTHERWORD", "Other");
 define("_formulize_OPT_OTHER", _formulize_OPT_OTHERWORD.": ");
 
 // Notifications
@@ -700,11 +700,11 @@ define("_AM_FORMULIZE_LOE_TOTAL", "Showing entries %d to %d of %d");
 define("_formulize_DE_LOE_LIMIT_REACHED1", "There are");
 define("_formulize_DE_LOE_LIMIT_REACHED2", "entries in the list.  It would take a long time to retrieve them.  You can use search terms to limit the number of entries, or");
 define("_formulize_DE_LOE_LIMIT_REACHED3", "you can click here to have the system retrieve all the entries.");
-       
+
 define("_formulize_OUTOFRANGE_DATA","Keep this other value found in the database: ");
 
 define("_AM_FORMULIZE_PREVIOUS_OPTION", "Use a previous answer:");
-define("_formulize_VALUE_WILL_BE_CALCULATED_AFTER_SAVE","This value will be calculated after the data is saved");
+define("_formulize_VALUE_WILL_BE_CALCULATED_AFTER_SAVE","This will be determined after the form is saved");
 
 define("_formulize_QSF_DefaultText", "Any");
 define("_formulize_QDR_to", "to");

--- a/themes/Anari/css/style.css
+++ b/themes/Anari/css/style.css
@@ -947,6 +947,11 @@ input[type=checkbox] {
   transform: scale(1.25);
 }
 
+div.form-row input[type=checkbox],
+div.form-row input[type=radio] {
+	margin-bottom: 0.3em;
+}
+
 table.formulize-subform-table {
     /*width: 100%;*/
 }


### PR DESCRIPTION
This is kind of important now. In the beginning, no conditional elements, and grids were designed to always be full, and if an element wasn't displayed to a user, we kept going till we found an element in the form that the user could see, and the grids were always full. This is kind of dumb when there are conditional elements and other intricate ways of organizing a form now. There are certain elements meant for the grid, and other elements are absolutely not meant for the grid!

So grids always get their elements based on count and only display those and that's it. This also created problems when dealing with the assignment of grid conditions to the constituent elements, and so doing things this way keeps stuff nicely inside the grid only.