### PR TITLE
Save custom code through tab only, not everytime app is inserted to DB

### DIFF
--- a/modules/formulize/admin/save/application_code_save.php
+++ b/modules/formulize/admin/save/application_code_save.php
@@ -11,11 +11,5 @@ if(!isset($processedValues)) {
     return;
 }
 
-$application_handler = xoops_getmodulehandler('applications', 'formulize');
-$appObject = $application_handler->get($_POST['formulize_admin_key']);
-
-foreach($processedValues['applications'] as $property=>$value) {
-    $appObject->setVar($property, $value);
-}
-
-$application_handler->insert($appObject);
+$filename=XOOPS_ROOT_PATH."/modules/formulize/custom_code/application_custom_code_".intval($_POST['formulize_admin_key']).".php";
+file_put_contents($filename,$processedValues['applications']['custom_code']);

--- a/modules/formulize/class/applications.php
+++ b/modules/formulize/class/applications.php
@@ -367,10 +367,6 @@ class formulizeApplicationsHandler {
         $sql = "UPDATE ".$this->db->prefix("formulize_applications") . " SET `name` = ".$this->db->quoteString($name).", `description` = ".$this->db->quoteString($description).", `custom_code` = ".$this->db->quoteString($custom_code)." WHERE appid = ".intval($appid);
     }
 
-    //after executing insertion or updating, we put file in the following path with custom_code
-    $filename=XOOPS_ROOT_PATH."/modules/formulize/custom_code/application_custom_code_".$appid.".php";
-    file_put_contents($filename,$custom_code);
-
     if( false != $force ){
         $result = $this->db->queryF($sql);
     }else{


### PR DESCRIPTION
This fixes a nasty issue where if an error in code is saved, then that bad code is written over and over to the application's custom code file, every time the application object goes through the insert method! This prevents saving a good copy of code overtop of bad. Custom code is now only saved via the tab when the admin page saves, much cleaner. But still an opportunity for bad code to be saved. Need to validate the code better. See https://github.com/jegelstaff/formulize/issues/499