### PR TITLE
When rendering elements inside lists, always use BR delimeter

### DIFF
--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -139,6 +139,7 @@ switch($op) {
 
   case 'get_element_html':
 		/*
+		Renders elements for display inside lists of entries, because the user clicked the icon
 		the GET param0 through param4 are:
 		1 - handle
 		2 - element_id

--- a/modules/formulize/include/elementdisplay.php
+++ b/modules/formulize/include/elementdisplay.php
@@ -67,6 +67,11 @@ function displayElement($formframe="", $ele=0, $entry="new", $noSave = false, $s
 		return "invalid_element";
 	}
 
+	// if rendering an inline element in a list of entries, because the user clicked the edit icon on the element...
+	if(isset($_GET['op']) AND $_GET['op'] == 'get_element_html' AND strstr(getCurrentURL(), 'formulize_xhr_responder.php')) {
+		$element = overrideSeparatorToLineBreak($element);
+	}
+
     $form_id = $element->getVar('id_form');
 
 	$deprefix = $noSave ? "denosave_" : "de_";
@@ -329,6 +334,20 @@ function elementIsAllowedForUserInEntry($elementObject, $entry_id, $groups = arr
 	$allowed = $allowed ? true : false;
 	$isDisabled = $isDisabled ? true : false;
 	return array($allowed, $isDisabled);
+}
+
+/**
+ * If this element has a separator setting (checkbox or radio), set to line break.
+ * @param object $elementObject The element that we are working with
+ * @param object The modified element with the alternate separator setting
+ */
+function overrideSeparatorToLineBreak($elementObject) {
+	$ele_delim = $elementObject->getVar('ele_delim');
+	if($ele_delim AND $ele_delim != 'br') {
+		$ele_delim = 'br';
+		$elementObject->setVar('ele_delim', $ele_delim);
+	}
+	return $elementObject;
 }
 
 /**

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -1757,7 +1757,9 @@ function drawEntries($fid, $cols, $searches, $frid, $scope, $standalone, $curren
                                                     } else {
                                                         if($deThisIntId) { print "\n<br />\n"; } // extra break to separate multiple form elements in the same cell, for readability/usability
                                                         // NEEDS DEBUG - ELEMENTS NOT DISPLAYING
-                                                        displayElement("", $colhandle, $internalID);
+																												$colHandleElementObject = $element_handler->get($colhandle);
+																												$colHandleElementObject = overrideSeparatorToLineBreak($colHandleElementObject);
+                                                        displayElement("", $colHandleElementObject, $internalID);
                                                     }
                                                     $deThisIntId = true;
                                                     $multiValueBRNeeded = true;


### PR DESCRIPTION
When radio buttons have space separator/delimeter, then rendering them in lists of entries leads to strange breaks, because the width is probably too narrow to show the entire element as intended. In lists we always display with line break separator/delimeter, so that the options appear cleanly to the user even when the columns are narrow.