### PR TITLE
Fix for bidirectional LIKE linked conditions

### DIFF
--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -5817,7 +5817,7 @@ function _buildConditionsFilterSQL($filterId, &$filterOps, &$filterTerms, $filte
 						}
 						// establish the literal (human readable) value
 						if (isset($GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$curlyBracketEntry][$bareFilterTerm])) {
-								$literalTermToUse = "'".formulize_db_escape($GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$curlyBracketEntry][$bareFilterTerm])."'";
+								$literalTermToUse = $GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$curlyBracketEntry][$bareFilterTerm];
 						} elseif($curlyBracketEntry != 'new') {
 								$preppedFormatValue = prepvalues($dbValueOfTerm, $bareFilterTerm, $curlyBracketEntry); // will be an array
 								if(is_array($preppedFormatValue) AND count((array) $preppedFormatValue)==1) {
@@ -5836,6 +5836,7 @@ function _buildConditionsFilterSQL($filterId, &$filterOps, &$filterTerms, $filte
 							}
 							$subQueryWhereClause = "(".$subQueryWhereClause; // add opening bracket to enclose ORs
 							foreach($literalTermToUse as $thisLiteralTermToUse) {
+								$thisLiteralTermToUse = formulize_db_escape($thisLiteralTermToUse);
 								$literalQuotes = (is_numeric($thisLiteralTermToUse) AND !$likebits) ? "" : "'";
 								$literalTermInSQL = "`$targetSourceHandle` ".$subQueryOp.$literalQuotes.$likebits.$thisLiteralTermToUse.$likebits.$literalQuotes;
 								$specialCharsTerm = htmlspecialchars($thisLiteralTermToUse, ENT_QUOTES);


### PR DESCRIPTION
Sometimes people specify conditions involving multi-select linked fields. This gets confusing.

Because generally you're matching a single value against the list. But sometimes the single value is on the left side and sometimes it's on the right.

For example, when filtering the entries included in a linked element, you might have a dynamic filter that picks up the value of another field in the form, and that value is used to filter the entries in the source form for the linked element.

Well, the dynamic filter element could allow multiple selections, and the filter element in the source form could be a single value. Or it could be vice versa, the dynamic filter element might be a single value and the filter element in the source form might have multiple values.

Generally we use LIKE in situations where there are multiple values involved, because the basic SQL you want to generate is more or less: " source value LIKE filter value "

But in cases where the question of which is single and which is multiple is reversed, then you may need to do " filter value LIKE source value "

This PR addresses that. In a rather ugly way. But the permutations of filter conditions are many and varied and short of a complete top to bottom refactor of the entire thing, this is probably as good as it gets now.

This PR also addresses handling such filters when there's an asynchronous value being inserted into the query, because of a conditional element, etc. In those cases, multiple literal values are present as a string, so we actually have to switch from LIKE to IN, just to make things extra complicated. But it works like a charm!