### PR TITLE
TASK: Fixing use of deprecated docker-compose command in github actions e2e test run

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,7 +41,7 @@ jobs:
         chmod 777 trust uploads modules templates_c cache mainfile.php ~/work/formulize/formulize
     - name: Run Docker Compose up
       run: |
-        docker-compose up -d
+        docker compose up -d
     - name: Wait for mysql
       uses: smurfpandey/wait-for-it@main
       with:


### PR DESCRIPTION
deprecated `docker-compose` command was removed in favour of `docker compose`

https://github.com/actions/runner-images/issues/9692