### PR TITLE
Add Relationships tab to Template screens and awareness of relationship data

### DIFF
--- a/modules/formulize/admin/save/screen_relationships_save.php
+++ b/modules/formulize/admin/save/screen_relationships_save.php
@@ -71,6 +71,8 @@ if($screens['type'] == 'multiPage') {
   $screen_handler = xoops_getmodulehandler('formScreen', 'formulize');
 } else if($screens['type'] == 'calendar') {
   $screen_handler = xoops_getmodulehandler('calendarScreen', 'formulize');
+} else if($screens['type'] == 'template') {
+  $screen_handler = xoops_getmodulehandler('templateScreen', 'formulize');
 }
 
 if ("new" != $sid) {

--- a/modules/formulize/admin/screen.php
+++ b/modules/formulize/admin/screen.php
@@ -565,7 +565,7 @@ $adminPage['tabs'][1] = array(
 );
 
 
-if ($screen_id != "new" AND $settings['type'] != 'template') {
+if ($screen_id != "new") {
     $adminPage['tabs'][] = array(
         'name' => _AM_APP_RELATIONSHIPS,
         'template' => "db:admin/screen_relationships.html",

--- a/modules/formulize/class/templateScreen.php
+++ b/modules/formulize/class/templateScreen.php
@@ -250,12 +250,22 @@ class formulizeTemplateScreenHandler extends formulizeScreenHandler {
 
         // make this a configuration option on the Templates tab!!!
         if (!empty($entry_id)) {
-            $templateScreenData = getData('', $screen->getVar('fid'), $entry_id);
-            $form_handler = xoops_getmodulehandler('forms', 'formulize');
-            $formObject = $form_handler->get($screen->getVar('fid'));
-            foreach($formObject->getVar('elementHandles') as $thisHandle) {
-                $$thisHandle = display($templateScreenData[0], $thisHandle);
-            }
+            $templateScreenData = getData($screen->getVar('frid'), $screen->getVar('fid'), $entry_id);
+						$formIds = array();
+						if($screen->getVar('frid')) {
+							$form_relationship_handler = xoops_getmodulehandler('frameworks', 'formulize');
+							$formRelationship = $form_relationship_handler->get($screen->getVar('frid'));
+							$formIds = $formRelationship->getVar('fids');
+						} else {
+							$formIds = array($screen->getVar('fid'));
+						}
+						$form_handler = xoops_getmodulehandler('forms', 'formulize');
+						foreach($formIds as $thisFid) {
+            	$formObject = $form_handler->get($thisFid);
+							foreach($formObject->getVar('elementHandles') as $i=>$thisHandle) {
+								$$thisHandle = display($templateScreenData[0], $thisHandle);
+							}
+						}
             $entry = $templateScreenData[0];
         }
 


### PR DESCRIPTION
If a relationship is specified for the template screen, then when an entry is displayed in the template, gather all the related data from the relationship for that entry.