### PR TITLE
Handling disabling textboxes in custom element class

### DIFF
--- a/modules/formulize/class/anonPasscodeElement.php
+++ b/modules/formulize/class/anonPasscodeElement.php
@@ -95,17 +95,7 @@ class formulizeAnonPasscodeElementHandler extends formulizeElementsHandler {
     // $element is the element object
     // $entry_id is the ID number of the entry where this particular element comes from
     // $screen is the screen object that is in effect, if any (may be null)
-    // $renderAsHiddenDefault is a flag to control what happens when we render as a hidden element for users who can't normally access the element -- typically we would set the default value inside a hidden element, or the current value if for some reason an entry is passed
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner, $renderAsHiddenDefault = false) {
-        global $xoopsUser;
-        // WHAT IS GOING ON HERE? DO WE NEED TO PASS A HIDDEN VALUE BACK TO EMBED THE CODE IN THE ENTRY???
-        if($renderAsHiddenDefault OR ($screen AND !$xoopsUser AND (!$entry_id OR $entry_id == 'new'))) {
-            //return new xoopsFormHidden($markupName, $screen->getVar('sid'));
-        }
-        if($xoopsUser) {
-            $ele_value = $ele_value ? $ele_value : '&mdash;';
-            //return new xoopsFormLabel($caption, $ele_value);
-        }
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
     }
 
     // this method returns any custom validation code (javascript) that should figure out how to validate this element
@@ -118,7 +108,7 @@ class formulizeAnonPasscodeElementHandler extends formulizeElementsHandler {
     // You can return {WRITEASNULL} to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
-	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
+		// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
     // $subformBlankCounter is the instance of a blank subform entry we are saving. Multiple blank subform values can be saved on a given pageload and the counter differentiates the set of data belonging to each one prior to them being saved and getting an entry id of their own.
     function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
         if($value) {

--- a/modules/formulize/class/checkboxElement.php
+++ b/modules/formulize/class/checkboxElement.php
@@ -300,8 +300,7 @@ class formulizeCheckboxElementHandler extends formulizeElementsHandler {
     // $element is the element object
     // $entry_id is the ID number of the entry where this particular element comes from
     // $screen is the screen object that is in effect, if any (may be null)
-    // $renderAsHiddenDefault is a flag to control what happens when we render as a hidden element for users who can't normally access the element -- typically we would set the default value inside a hidden element, or the current value if for some reason an entry is passed
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null, $renderAsHiddenDefault = false) {
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null) {
 
 		$ele_value = $this->backwardsCompatibility($ele_value);
 
@@ -360,8 +359,6 @@ class formulizeCheckboxElementHandler extends formulizeElementsHandler {
 		global $myts;
 		$selected = array();
 		$options = array();
-		$disabledHiddenValue = array();
-		$disabledHiddenValues = "";
 		$disabledOutputText = array();
 		$opt_count = 1;
 
@@ -372,7 +369,6 @@ class formulizeCheckboxElementHandler extends formulizeElementsHandler {
 			$options[$valueToUse] = $key;
 			if( $value > 0 ){
 				$selected[] = $valueToUse;
-				$disabledHiddenValue[] = "<input type=hidden name=\"".$markupName."[]\" value=\"$opt_count\">";
 			}
 			$opt_count++;
 		}
@@ -459,13 +455,9 @@ class formulizeCheckboxElementHandler extends formulizeElementsHandler {
 		}
 
         if($isDisabled) {
-			$disabledHiddenValues = implode("\n", $disabledHiddenValue); // glue the individual value elements together into a set of values
 			$renderedElement = implode(", ", $disabledOutputText);
         } else {
 			$renderedElement = $form_ele1->render();
-            if($renderAsHiddenDefault) {
-                $renderedElement .= "\n$renderedHoorvs\n$disabledHiddenValues\n";
-            }
         }
 
 		$form_ele = new XoopsFormLabel(

--- a/modules/formulize/class/dummyElement-example.php
+++ b/modules/formulize/class/dummyElement-example.php
@@ -141,8 +141,7 @@ class formulizeDummyElementHandler extends formulizeElementsHandler {
     // $entry_id is the ID number of the entry where this particular element comes from
     // $screen is the screen object that is in effect, if any (may be null)
     // $owner is the user id of the owner of the entry
-    // $renderAsHiddenDefault is a flag to control what happens when we render as a hidden element for users who can't normally access the element -- typically we would set the default value inside a hidden element, or the current value if for some reason an entry is passed
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner, $renderAsHiddenDefault = false) {
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
         // dummy element is rendered as a textboxes, with the values set by the user in the admin side smushed together as the default value for the textbox
         if($isDisabled) {
             $formElement = new xoopsFormLabel($caption, $ele_value[0] . $ele_value[1]);

--- a/modules/formulize/class/googleFilePickerElement.php
+++ b/modules/formulize/class/googleFilePickerElement.php
@@ -119,8 +119,7 @@ class formulizeGoogleFilePickerElementHandler extends formulizeElementsHandler {
     // $entry_id is the ID number of the entry where this particular element comes from
     // $screen is the screen object that is in effect, if any (may be null)
     // $owner is the user id of the owner of the entry
-    // $renderAsHiddenDefault is a flag to control what happens when we render as a hidden element for users who can't normally access the element -- typically we would set the default value inside a hidden element, or the current value if for some reason an entry is passed
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner, $renderAsHiddenDefault = false) {
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
 
         $eleId = $element->getVar('ele_id');
 

--- a/modules/formulize/class/textElement.php
+++ b/modules/formulize/class/textElement.php
@@ -123,8 +123,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
     // $element is the element object
     // $entry_id is the ID number of the entry where this particular element comes from
     // $screen is the screen object that is in effect, if any (may be null)
-    // $renderAsHiddenDefault is a flag to control what happens when we render as a hidden element for users who can't normally access the element -- typically we would set the default value inside a hidden element, or the current value if for some reason an entry is passed
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null, $renderAsHiddenDefault = false) {
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null) {
 
 			$ele_value[2] = stripslashes($ele_value[2]);
 			$ele_value[2] = interpretTextboxValue($element, $entry_id, $ele_value[2]);
@@ -134,26 +133,26 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 				$placeholder = $rawEleValue[2];
 				$ele_value[2] = "";
 			}
-			if (!strstr(getCurrentURL(),"printview.php")) {
+			if (!strstr(getCurrentURL(),"printview.php") AND !$isDisabled) {
 				$form_ele = new XoopsFormText(
-				$caption,
-				$markupName,
-				$ele_value[0],	//	box width
-				$ele_value[1],	//	max width
-				$ele_value[2],	//	value
-				false,					// autocomplete in browser
-				$ele_value[3]		// numbers only
+					$caption,
+					$markupName,
+					$ele_value[0],	//	box width
+					$ele_value[1],	//	max width
+					$ele_value[2],	//	value
+					false,					// autocomplete in browser
+					$ele_value[3]		// numbers only
 				);
+				//if placeholder value is set
+				if($ele_value[11]) {
+					$form_ele->setExtra("placeholder='".$placeholder."'");
+				}
+				//if numbers-only option is set
+				if ($ele_value[3]) {
+					$form_ele->setExtra("class='numbers-only-textbox'");
+				}
 			} else {
 				$form_ele = new XoopsFormLabel ($caption, formulize_numberFormat($ele_value[2], $element->getVar('ele_handle')), $markupName);
-			}
-			//if placeholder value is set
-			if($ele_value[11]) {
-				$form_ele->setExtra("placeholder='".$placeholder."'");
-			}
-			//if numbers-only option is set
-			if ($ele_value[3]) {
-				$form_ele->setExtra("class='numbers-only-textbox'");
 			}
 			return $form_ele;
     }

--- a/modules/formulize/include/readelements.php
+++ b/modules/formulize/include/readelements.php
@@ -149,9 +149,9 @@ foreach($_POST as $k=>$v) {
 		// store values according to form, entry and element ID
 		// prep them all for writing
 		$elementMetaData = explode("_", $k);
-        $elementObject = $element_handler->get($elementMetaData[3]);
+      $elementObject = $element_handler->get($elementMetaData[3]);
 		if(isset($_POST["de_".$elementMetaData[1]."_".$elementMetaData[2]."_".$elementMetaData[3]])) {
-            $v = prepDataForWrite($elementObject, $_POST["de_".$elementMetaData[1]."_".$elementMetaData[2]."_".$elementMetaData[3]], $elementMetaData[2]);
+      $v = prepDataForWrite($elementObject, $_POST["de_".$elementMetaData[1]."_".$elementMetaData[2]."_".$elementMetaData[3]], $elementMetaData[2]);
 			$formulize_elementData[$elementMetaData[1]][$elementMetaData[2]][$elementMetaData[3]] = $v;
 		} elseif(is_numeric($elementMetaData[1]) AND $elementObject->getVar('ele_type') != 'anonPasscode') {
 			$formulize_elementData[$elementMetaData[1]][$elementMetaData[2]][$elementMetaData[3]] = "{WRITEASNULL}"; // no value returned for this element that was included (cue was found) so we write it as blank to the db


### PR DESCRIPTION
Also, some refactoring of how the "rendered" element is prepared for passing back to the form object for inclusion. And removing the deprecated hidden-for-users-who-can't-access feature.