### PR TITLE
Entry identifiers with clean URLs

### DIFF
--- a/index.php
+++ b/index.php
@@ -43,6 +43,15 @@ if($icmsConfig['startpage'] == 'formulize') {
 	list($startFid,$startSid,$startURL) = formulizeApplicationMenuLinksHandler::getDefaultScreenForUser();
 	if(!$xoopsUser AND !$startFid AND !$startSid AND !$startURL) {
 		$icmsConfig['startpage'] = '--';
+	} elseif($startSid) {
+		// start pages with rewrite URLs only work when the Formulize start page system points directly to a screen, not a fid. We're not going to do all the interpretation here to figure out the valid screen for the fid and user, that's what half of modules/formulize/initialize.php is for.
+		$screen_handler = xoops_getmodulehandler('screen', 'formulize');
+		if($screenObject = $screen_handler->get($startSid)) {
+			if($screenObject->getVar('rewriteruleAddress')) {
+				header('Location: '.ICMS_URL.'/'.urlencode(strip_tags($screenObject->getVar('rewriteruleAddress'))));
+				exit();
+			}
+		}
 	}
 }
 

--- a/modules/formulize/admin/formindex.php
+++ b/modules/formulize/admin/formindex.php
@@ -83,8 +83,8 @@ function patch40() {
      *
      * IT IS ALSO CRITICAL THAT THE PATCH PROCESS CAN BE RUN OVER AND OVER AGAIN NON-DESTRUCTIVELY */
 
-    $checkThisTable = 'formulize_saved_views';
-		$checkThisField = 'sv_use_features';
+    $checkThisTable = 'formulize_screen';
+		$checkThisField = 'rewriteruleElement';
 		$checkThisProperty = '';
 		$checkPropertyForValue = '';
 
@@ -466,6 +466,7 @@ function patch40() {
 				$sql['ele_disabledconditions'] = "ALTER TABLE ".$xoopsDB->prefix("formulize"). " ADD `ele_disabledconditions` text NOT NULL";
 				$sql['update_module_name'] = "UPDATE ".$xoopsDB->prefix("modules")." SET name = 'Formulize' WHERE dirname = 'formulize' AND name = 'Forms'";
 				$sql['rewriteruleAddress'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen"). " ADD `rewriteruleAddress` varchar(255) NULL default NULL";
+                $sql['rewriteruleElement'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen"). " ADD `rewriteruleElement` smallint(5) unsigned NOT NULL default 0";
 				$sql['screenTableIndex1'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen"). " ADD FULLTEXT i_rewrite (`rewriteruleAddress`)";
 				$sql['screenTableIndex2'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen"). " ADD INDEX i_fid (`fid`)";
 				$sql['screenTableIndex3'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen"). " ADD INDEX i_frid (`frid`)";
@@ -587,17 +588,19 @@ function patch40() {
                     print "On Delete already added. result: OK<br>";
                 } elseif($key === "viewentryscreen_templates") {
                     print "View entry screen option for template screens already added. result: OK<br>";
-								} elseif($key === "ele_disabledconditions") {
+				} elseif($key === "ele_disabledconditions") {
                     print "Disabled conditions already added. result: OK<br>";
 								} elseif($key === "sv_use_features") {
 										print "'Use which features' option already added to saved views. result: OK<br>";
 								} elseif($key === "searches_are_fundamental") {
 									print "'Searches-are-fundamental' option already added to saved views. result: OK<br>";
-								} elseif($key === "rewriteruleAddress") {
-										print "RewriteRule address already added. result: OK<br>";
-								} elseif(strstr($key, 'screenTableIndex')) {
-										print "Screen table index already added. result: OK<br>";
-								}else {
+				} elseif($key === "rewriteruleAddress") {
+                    print "RewriteRule address already added. result: OK<br>";
+                } elseif($key === "rewriteruleElement") {
+                    print "RewriteRule element already added. result: OK<br>";
+                } elseif(strstr($key, 'screenTableIndex')) {
+                    print "Screen table index already added. result: OK<br>";
+            }else {
                     exit("Error patching DB for Formulize $versionNumber. SQL dump:<br>" . $thissql . "<br>".$xoopsDB->error()."<br>Please contact <a href=mailto:info@formulize.org>info@formulize.org</a> for assistance.");
                 }
             } elseif($key === "on_delete") {

--- a/modules/formulize/admin/save/screen_settings_save.php
+++ b/modules/formulize/admin/save/screen_settings_save.php
@@ -103,6 +103,7 @@ $screen->setVar('type',$screens['type']);
 $screen->setVar('useToken',$screens['useToken']);
 $screen->setVar('anonNeedsPasscode',$screens['anonNeedsPasscode']);
 $screen->setVar('rewriteruleAddress',formulizeForm::sanitize_handle_name(str_replace(" ", "_", $screens['rewriteruleAddress'])));
+$screen->setVar('rewriteruleElement', intval($screens['rewriteruleElement']));
 
 if(!$sid = $screen_handler->insert($screen)) {
   print "Error: could not save the screen properly: ".$xoopsDB->error();

--- a/modules/formulize/admin/screen.php
+++ b/modules/formulize/admin/screen.php
@@ -31,6 +31,7 @@
 
 include_once XOOPS_ROOT_PATH."/modules/formulize/include/functions.php";
 
+$form_handler = xoops_getmodulehandler('forms', 'formulize');
 $framework_handler = xoops_getmodulehandler('frameworks', 'formulize');
 $screen_id = $_GET['sid'];
 // screen settings data
@@ -67,8 +68,18 @@ if ($screen_id == "new") {
     $settings['frid'] = $screen->getVar('frid');
     $settings['useToken'] = $screen->getVar('useToken');
     $settings['anonNeedsPasscode'] = $screen->getVar('anonNeedsPasscode');
-		$settings['rewriteruleAddress'] = $screen->getVar('rewriteruleAddress');
-		$settings['alternateURLsOn'] = $formulizeConfig['formulizeRewriteRulesEnabled'];
+	$settings['alternateURLsOn'] = $formulizeConfig['formulizeRewriteRulesEnabled'];
+    if($settings['alternateURLsOn']) {
+        $settings['rewriteruleAddress'] = $screen->getVar('rewriteruleAddress');
+        $settings['rewriteruleElement'] = $screen->getVar('rewriteruleElement');
+        $formObject = $form_handler->get($form_id);
+        $elementColheads = $formObject->getVar('elementColheads');
+        $settings['rewriteruleElements'][0] = 'Entry ID';
+        foreach($formObject->getVar('elementCaptions') as $elementId=>$elementLabel) {
+            $elementLabel = $elementColheads[$elementId] ? $elementColheads[$elementId] : $elementLabel;
+            $settings['rewriteruleElements'][$elementId] = $elementLabel;
+        }
+    }
 
     if ($settings['type'] == 'listOfEntries') {
         $screen_handler = xoops_getmodulehandler('listOfEntriesScreen', 'formulize');
@@ -98,7 +109,6 @@ if (!$aid) {
 }
 
 if ($form_id != "new") {
-    $form_handler = xoops_getmodulehandler('forms', 'formulize');
     $formObject = $form_handler->get($form_id);
     $formName = $formObject->getVar('title');
     $singleentry = $formObject->getVar('single');

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -618,6 +618,9 @@ class formulizeElementsHandler {
         return false;
     }
 
+	function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
+		return $value;
+	}
 }
 
 function optionIsValidForElement($option, $elementHandleOrId) {

--- a/modules/formulize/class/fileUploadElement.php
+++ b/modules/formulize/class/fileUploadElement.php
@@ -360,7 +360,7 @@ class formulizeFileUploadElementHandler extends formulizeElementsHandler {
 
     // this method will take a text value that the user has specified at some point, and convert it to a value that will work for comparing with values in the database.  This is used primarily for preparing user submitted text values for saving in the database, or for comparing to values in the database.  The typical user submitted values would be coming from a condition form (ie: fieldX = [term the user typed in]) or other situation where the user types in a value that needs to interact with the database.
     // this would be where a Yes value would be converted to a 1, for example, in the case of a yes/no element, since 1 is how yes is represented in the database for that element type
-    function prepareLiteralTextForDB($value, $element) {
+    function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
         return $value;
     }
 

--- a/modules/formulize/class/screen.php
+++ b/modules/formulize/class/screen.php
@@ -48,6 +48,7 @@ class formulizeScreen extends xoopsObject {
     $this->initVar('anonNeedsPasscode', XOBJ_DTYPE_INT);
     $this->initVar('theme', XOBJ_DTYPE_TXTBOX, '', true, 100);
 		$this->initVar('rewriteruleAddress', XOBJ_DTYPE_TXTBOX, '', false, 255);
+        $this->initVar('rewriteruleElement', XOBJ_DTYPE_INT, '', true);
 	}
 
     static function normalize_values($key, $value) {
@@ -259,9 +260,9 @@ class formulizeScreenHandler {
             ${$k} = $v;
         }
         if (!$sid) {
-            $sql = sprintf("INSERT INTO %s (title, fid, frid, type, useToken, anonNeedsPasscode, theme, rewriteruleAddress) VALUES (%s, %u, %u, %s, %u, %u, %s, %s)", $this->db->prefix('formulize_screen'), $this->db->quoteString($title), $fid, $frid, $this->db->quoteString($type), $useToken, $anonNeedsPasscode, $this->db->quoteString($theme), $this->db->quoteString($rewriteruleAddress));
+            $sql = sprintf("INSERT INTO %s (title, fid, frid, type, useToken, anonNeedsPasscode, theme, rewriteruleAddress, rewriteruleElement) VALUES (%s, %u, %u, %s, %u, %u, %s, %s, %u)", $this->db->prefix('formulize_screen'), $this->db->quoteString($title), $fid, $frid, $this->db->quoteString($type), $useToken, $anonNeedsPasscode, $this->db->quoteString($theme), $this->db->quoteString($rewriteruleAddress), $rewriteruleElement);
         } else {
-            $sql = sprintf("UPDATE %s SET title = %s, fid = %u, frid = %u, type = %s, useToken = %u, anonNeedsPasscode = %u, theme = %s, rewriteruleAddress = %s WHERE sid = %u", $this->db->prefix('formulize_screen'), $this->db->quoteString($title), $fid, $frid, $this->db->quoteString($type), $useToken, $anonNeedsPasscode, $this->db->quoteString($theme), $this->db->quoteString($rewriteruleAddress), $sid);
+            $sql = sprintf("UPDATE %s SET title = %s, fid = %u, frid = %u, type = %s, useToken = %u, anonNeedsPasscode = %u, theme = %s, rewriteruleAddress = %s, rewriteruleElement = %u WHERE sid = %u", $this->db->prefix('formulize_screen'), $this->db->quoteString($title), $fid, $frid, $this->db->quoteString($type), $useToken, $anonNeedsPasscode, $this->db->quoteString($theme), $this->db->quoteString($rewriteruleAddress), $rewriteruleElement, $sid);
         }
         $result = $this->db->query($sql);
         if (!$result) {

--- a/modules/formulize/class/templateScreen.php
+++ b/modules/formulize/class/templateScreen.php
@@ -218,6 +218,9 @@ class formulizeTemplateScreenHandler extends formulizeScreenHandler {
             // no viewEntryLink etc in the template, so away we go like normal, just the template
             } else {
                 $xoopsTpl->display("file:".$template_filename);
+                if($code = updateAlternateURLIdentifierCode($screen, $entry_id)) {
+                    print "\n<script>\n$code\n</script>\n";
+                }
             }
 
             // determine proper admin link

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -1831,7 +1831,11 @@ function drawEntries($fid, $cols, $searches, $frid, $scope, $standalone, $curren
 						$viewEntryLinkCode = "<a href='" . trim($currentURL, '/');
 						global $formulizeCanonicalURI;
 						if($formulizeCanonicalURI) {
-							$viewEntryLinkCode .= '/'.$entry_id.'/';
+							$entryIdentifier = $entry_id;
+							if($rewriteruleElement = $element_handler->get($screen->getVar('rewriteruleElement'))) {
+								$entryIdentifier = urlencode(display($entry, $rewriteruleElement->getVar('ele_handle')));
+							}
+							$viewEntryLinkCode .= '/'.$entryIdentifier.'/';
 						} else {
 							if(strstr($currentURL, "?")) { // if params are already part of the URL...
 								$viewEntryLinkCode .= "&";

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -1506,7 +1506,7 @@ function displayForm($formframe, $entry="", $mainform="", $done_dest="", $button
                 $form->addElement (new XoopsFormHidden ('clonesubsflag', 0));
 			}
 
-			drawJavascript($nosave, $entry); // must be called after compileElements, for entry locking to work, and probably other things!
+			drawJavascript($nosave, $entry, $screen); // must be called after compileElements, for entry locking to work, and probably other things!
             $form->addElement(new xoopsFormHidden('save_and_leave', 0));
 		// lastly, put in a hidden element, that will tell us what the first, primary form was that we were working with on this form submission
 		$form->addElement (new XoopsFormHidden ('primaryfid', $fids[0]));
@@ -3207,7 +3207,7 @@ function writeHiddenSettings($settings, $form = null, $entries = array(), $sub_e
 
 // draw in javascript for this form that is relevant to subforms
 // $nosave indicates that the user cannot save this entry, so we shouldn't check for formulizechanged
-function drawJavascript($nosave=false, $entry=null) {
+function drawJavascript($nosave=false, $entryId=null, $screen=null) {
 
 global $xoopsUser, $xoopsConfig, $actionFunctionName;
 
@@ -3355,7 +3355,7 @@ print $codeToIncludejQueryWhenNecessary;
 
 // a bit hacky... check the intval of the currentPage and the prevPage, prevPage may be (always is?) "page number hyphen screen id number"
 // so if someone jumps from one screen to another but lands on same ordinal page, this will be true, but really it's false because they're different screens
-if($entry != 'new' AND isset($_POST['yposition']) AND
+if($entryId != 'new' AND isset($_POST['yposition']) AND
    intval($_POST['yposition'])>0 AND
    (!isset($_POST['formulize_currentPage']) OR intval($_POST['formulize_currentPage']) == intval($_POST['formulize_prevPage']))
    ) {
@@ -3883,11 +3883,9 @@ function check_date_limits(element_id) {
 
 <?php
 // replace the history and URL with a more canonical URL that is human readable, if alternate URLs are in effect
-// NEED MORE PARAMS/CONTEXT SETUP FOR THIS TO WORK!!
-// NEED TO CONSIDER 'NEW' ENTRIES TOO
-/*if($code = updateAlternateURLIdentifierCode($screen, $entry_id)) {
+if($code = updateAlternateURLIdentifierCode($screen, $entryId)) {
     print "\n$code\n";
-}*/
+}
 
     if(isset($GLOBALS['formulize_specialValidationLogicHook'])) {
         ?>

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -3882,6 +3882,12 @@ function check_date_limits(element_id) {
 }
 
 <?php
+// replace the history and URL with a more canonical URL that is human readable, if alternate URLs are in effect
+// NEED MORE PARAMS/CONTEXT SETUP FOR THIS TO WORK!!
+// NEED TO CONSIDER 'NEW' ENTRIES TOO
+/*if($code = updateAlternateURLIdentifierCode($screen, $entry_id)) {
+    print "\n$code\n";
+}*/
 
     if(isset($GLOBALS['formulize_specialValidationLogicHook'])) {
         ?>

--- a/modules/formulize/sql/mysql.sql
+++ b/modules/formulize/sql/mysql.sql
@@ -261,6 +261,7 @@ CREATE TABLE `formulize_screen` (
   `anonNeedsPasscode` tinyint(1) NOT NULL,
   `theme` varchar(101) NOT NULL default '',
 	`rewriteruleAddress` varchar(255) NULL default NULL,
+  `rewriteruleElement` smallint(5) unsigned NOT NULL default 0,
 	FULLTEXT i_rewrite (`rewriteruleAddress`),
 	INDEX i_fid (`fid`),
 	INDEX i_frid (`frid`),

--- a/modules/formulize/templates/admin/screen_settings.html
+++ b/modules/formulize/templates/admin/screen_settings.html
@@ -41,9 +41,11 @@
 	<fieldset>
 		<legend>URLs for this screen</legend>
 		<p>The default URL for this screen: <a href="<{$xoops_url}>/modules/formulize/index.php?sid=<{$content.sid}>" target="_blank"><{$xoops_url}>/modules/formulize/index.php?sid=<{$content.sid}></a></p>
-		<{if $content.alternateURLsOn eq 1}><p>Set an alternate URL for accessing this screen: <{$xoops_url}>/<input type='text' name='screens-rewriteruleAddress' value='<{$content.rewriteruleAddress}>'</p><{/if}>
+		<{if $content.alternateURLsOn eq 1}><p>Set an alternate URL for accessing this screen: <{$xoops_url}>/<input type='text' name='screens-rewriteruleAddress' value='<{$content.rewriteruleAddress}>'</p>
+        <p>With an alternate URL, identify entries based on their value in this element: <{html_options name='screens-rewriteruleElement' options=$content.rewriteruleElements selected=$content.rewriteruleElement}></p>
+        <{/if}>
 	</fieldset>
-
+ 
 	<fieldset>
 		<legend>PHP code for including this screen anywhere</legend>
 		<p>You can embed this screen in any PHP application or web page that is running on the same web server.<br />Use this snippet of PHP code to include it:</p>


### PR DESCRIPTION
This adds the option to select a field in a form, that is used to generate an identifier for the entry, when clean URLs are being used. Must be set on both form and list / template and list screens in order to work as expected.