### PR TITLE
Enable PHP syntax checking

### DIFF
--- a/docker/php/conf.d/formulize.ini
+++ b/docker/php/conf.d/formulize.ini
@@ -4,9 +4,6 @@ error_reporting=E_ALL
 ; Memory Limit
 memory_limit = 256M
 
-; XDebug
-zend_extension=xdebug
-
 [xdebug]
 xdebug.mode=develop,debug
 xdebug.discover_client_host=true

--- a/modules/formulize/admin/ui.php
+++ b/modules/formulize/admin/ui.php
@@ -35,7 +35,7 @@ define('_FORMULIZE_UI_PHP_INCLUDED', 1);
 // include necessary Formulize files/functions
 include_once XOOPS_ROOT_PATH . "/modules/formulize/include/functions.php";
 
-global $xoopsTpl, $xoopsDB;
+global $xoopsTpl, $xoopsDB, $xoopsUser;
 
 // check that each screen has a valid relationship setting
 $sql = "SELECT * FROM ".$xoopsDB->prefix('formulize_screen')." as s WHERE NOT EXISTS(SELECT 1 FROM ".$xoopsDB->prefix('formulize_framework_links')." as l WHERE s.frid = l.fl_frame_id AND (s.fid = l.fl_form1_id OR s.fid = l.fl_form2_id)) AND s.frid != 0";
@@ -93,7 +93,7 @@ if(isset($_POST['seedtemplates']) AND $_POST['seedtemplates'] AND isset($_GET['s
     $screen = $screen_handler->get($_GET['sid']);
     $themeDefaultPath = XOOPS_ROOT_PATH."/modules/formulize/templates/screens/".$screen->getVar('theme')."/default/".$screen->getVar('type')."/";
     if(!file_exists($themeDefaultPath)) {
-        $themeDefaultPath = str_replace($screen->getVar('theme'), '', $themeDefaultPath);    
+        $themeDefaultPath = str_replace($screen->getVar('theme'), '', $themeDefaultPath);
     }
     if(!file_exists($themeDefaultPath)) {
         exit('Error: could not locate a valid default template path for "'.$screen->getVar('type').'" screens.');
@@ -189,6 +189,8 @@ if(SDATA_DB_PREFIX == 'selenium') {
     $xoopsTpl->assign('allowFloatingSave', '');
 }
 
+$xoopsTpl->assign('XOOPS_URL', XOOPS_URL);
+$xoopsTpl->assign('UID', $xoopsUser->getVar('uid'));
 $xoopsTpl->display("db:admin/ui.html");
 
 xoops_cp_footer();

--- a/modules/formulize/language/english/modinfo.php
+++ b/modules/formulize/language/english/modinfo.php
@@ -68,6 +68,9 @@ define("_MI_formulize_NUMBER_SEP", "By default, what punctuation should be used 
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY', "Show empty form elements when displaying forms in read-only mode");
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY_DESC', "When form elements are rendered in read-only mode, and there is no value to display, the element is skipped by default and not shown. If you want to show all elements even empty ones when users cannot edit the entry, turn this setting on.");
 
+define('_MI_formulize_VALIDATECODE', 'Check code blocks for syntax errors?');
+define('_MI_formulize_VALIDATECODE_DESC', 'When this is turned on, then Formulize will check most places where you can enter PHP code, to make sure the code has no syntax errors. This can be time consuming and if you are an experienced developer you may prefer to turn it off. This setting will have no effect if the shell_exec command is not available to PHP on your server.');
+
 define("_MI_formulize_HEADING_HELP_LINK", "Should the help link ([?]) and lock icons appear at the top of each column in a list of entries?");
 define("_MI_formulize_HEADING_HELP_LINK_DESC", "The help link provides a popup window that shows details about the question in the form, such as the full text of the question, the choice of options if the question is a radio button, etc. The lock icon allows the user to keep a column visible on screen as they scroll to the right, like 'Freeze Panes' in Excel.");
 

--- a/modules/formulize/language/french/modinfo.php
+++ b/modules/formulize/language/french/modinfo.php
@@ -96,3 +96,6 @@ define("_MI_formulize_rewriteRulesEnabledDESC", "When this is enabled, you can s
 
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY', "Show empty form elements when displaying forms in read-only mode");
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY_DESC', "When form elements are rendered in read-only mode, and there is no value to display, the element is skipped by default and not shown. If you want to show all elements even empty ones when users cannot edit the entry, turn this setting on.");
+
+define('_MI_formulize_VALIDATECODE', 'Check code blocks for syntax errors?');
+define('_MI_formulize_VALIDATECODE_DESC', 'When this is turned on, then Formulize will check most places where you can enter PHP code, to make sure the code has no syntax errors. This can be time consuming and if you are an experienced developer you may prefer to turn it off. This setting will have no effect if the shell_exec command is not available to PHP on your server.');

--- a/modules/formulize/libraries/formulize-admin.js
+++ b/modules/formulize/libraries/formulize-admin.js
@@ -18,25 +18,25 @@ jQuery(document).ready(function() {
 
 });
 
-async function fz_check_php_code(custom_code, block_name) {
+function fz_check_php_code(custom_code) {
 	let validateCode = new Promise(function(resolve, reject) {
     jQuery.ajax({
         type: "POST",
         url: window.icms_url+"/modules/formulize/formulize_xhr_responder.php?uid="+window.icms_userid+"&op=validate_php_code",
         data: {the_code: custom_code},
         success: function(result) {
-            if (result.length > 0) {
-              resolve("The "+block_name+" has an error:\n\n"+result+".");
-            } else {
-							resolve('');
-						}
+							resolve({
+								valid: result.length > 0 ? false : true,
+								result: result
+							})
         	},
 				error: function() {
-					reject('The validation request to the server failed.');
+					reject({
+						valid: false,
+						result: 'The validation request to the server failed.'
+					})
 				}
     });
 	});
-	return validateCode.then(result => {
-		return result;
-	});
+	return validateCode;
 }

--- a/modules/formulize/libraries/formulize-admin.js
+++ b/modules/formulize/libraries/formulize-admin.js
@@ -15,19 +15,28 @@ jQuery(document).ready(function() {
         }
         hidden_section.toggle();
     });
-    
+
 });
 
-function fz_check_php_code(custom_code, block_name, icms_url, icms_userid) {
+async function fz_check_php_code(custom_code, block_name) {
+	let validateCode = new Promise(function(resolve, reject) {
     jQuery.ajax({
         type: "POST",
-        url: icms_url+"/modules/formulize/formulize_xhr_responder.php?uid="+icms_userid+"&op=validate_php_code",
+        url: window.icms_url+"/modules/formulize/formulize_xhr_responder.php?uid="+window.icms_userid+"&op=validate_php_code",
         data: {the_code: custom_code},
         success: function(result) {
             if (result.length > 0) {
-                alert("The "+block_name+" has an error:\n\n"+result+".");
-            }
-        },
-        async: false
+              resolve("The "+block_name+" has an error:\n\n"+result+".");
+            } else {
+							resolve('');
+						}
+        	},
+				error: function() {
+					reject('The validation request to the server failed.');
+				}
     });
+	});
+	return validateCode.then(result => {
+		return result;
+	});
 }

--- a/modules/formulize/libraries/formulize-admin.js
+++ b/modules/formulize/libraries/formulize-admin.js
@@ -27,7 +27,7 @@ function fz_check_php_code(custom_code) {
         success: function(result) {
 							resolve({
 								valid: result.length > 0 ? false : true,
-								result: result
+								result
 							})
         	},
 				error: function() {

--- a/modules/formulize/templates/admin/application_code.html
+++ b/modules/formulize/templates/admin/application_code.html
@@ -8,7 +8,7 @@
         <div class="form-item">
             <fieldset>
                 <legend>Code Template</legend>
-                <textarea id="applications-custom_code"  name="applications-custom_code" class="code-textarea" rows="20"/>
+                <textarea id="applications-custom_code"  name="applications-custom_code" class="code-textarea canValidate" rows="20"/>
 <{$content.custom_code}></textarea>
                 <div class="description">
                     <p>PHP code you enter here is included in every Formulize page.</p>
@@ -20,10 +20,3 @@
     </div>
 </form>
 
-<script>
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#applications-custom_code").val(), "Code template", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
-</script>

--- a/modules/formulize/templates/admin/form_advanced_calculations.html
+++ b/modules/formulize/templates/admin/form_advanced_calculations.html
@@ -17,7 +17,7 @@
     <fieldset>
 			<legend>Before Saving</legend>
     	<p>This special procedure runs before an entry is saved. Values that are about to be saved are available as PHP variables using the element handle name. The current values in the database (prior to this save) are available as $currentValues['handle_name'], so you can check if something is about to change. The ID of the current entry (or 'new') is available as $entry_id. If you return <i>false</i> then the save operation will not proceed.</p><br />
-    	<textarea id="forms-on_before_save" name="forms-on_before_save" class="code-textarea"><{$content.form_object->on_before_save}>
+    	<textarea id="forms-on_before_save" name="forms-on_before_save" class="code-textarea canValidate"><{$content.form_object->on_before_save}>
 			</textarea><{* closing tag on a new line so the textarea has a blank line at the bottom *}>
 			<{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
 		</fieldset>
@@ -25,7 +25,7 @@
     <fieldset>
 			<legend>After Saving</legend>
 			<p>This special procedure runs after an entry is saved. Values are available as PHP variables using the element handle name. The prior values are available as $currentValues['handle_name'], so you can check if something has actually changed. The ID of the entry is available as $entry_id. This will be the new ID if the entry was newly saved. A variable \$newEntry is available and will be true or false, depending if this is the first time the entry was saved or not.</p><br />
-			<textarea id="forms-on_after_save" name="forms-on_after_save" class="code-textarea"><{$content.form_object->on_after_save}>
+			<textarea id="forms-on_after_save" name="forms-on_after_save" class="code-textarea canValidate"><{$content.form_object->on_after_save}>
 			</textarea><{* closing tag on a new line so the textarea has a blank line at the bottom *}>
 			<{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
 		</fieldset>
@@ -33,7 +33,7 @@
     <fieldset>
 			<legend>On Delete</legend>
 			<p>This special procedure runs when an entry is deleted. The ID of the entry is available as $entry_id. The values that were in the database, prior to this deletion, are available as PHP variables using the element handle name.</p><br />
-			<textarea id="forms-on_delete" name="forms-on_delete" class="code-textarea"><{$content.form_object->on_delete}>
+			<textarea id="forms-on_delete" name="forms-on_delete" class="code-textarea canValidate"><{$content.form_object->on_delete}>
 			</textarea><{* closing tag on a new line so the textarea has a blank line at the bottom *}>
 			<{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
 		</fieldset>
@@ -41,7 +41,7 @@
     <fieldset>
 			<legend>Enable / Disable Entry Editing</legend>
 			<p>This special procedure allows for a custom condition to be set to decide whether a user can edit an entry or not. Variables will be available in the code: $entry_id can be used to identify an entry, $user_id for identifying the logged in user, $form_id to indicate the form, and $allow_editing (true or false) to determine if the user can make changes or not. Do not include a return value after the code: the value of $allow_editing will be returned. </p><br />
-			<textarea id="forms-custom_edit_check" name="forms-custom_edit_check" class="code-textarea"><{$content.form_object->custom_edit_check}>
+			<textarea id="forms-custom_edit_check" name="forms-custom_edit_check" class="code-textarea canValidate"><{$content.form_object->custom_edit_check}>
 			</textarea><{* closing tag on a new line so the textarea has a blank line at the bottom *}>
 			<a name="elementhandles"></a>
 			<{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
@@ -100,11 +100,4 @@ $(".cloneadvanced_calculation").click(function() {
 	return false;
 })
 
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#forms-on_before_save").val(), "Before Save", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#forms-on_after_save").val(), "After Save", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#forms-custom_edit_check").val(), "Disable Entry Editing", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
 </script>

--- a/modules/formulize/templates/admin/screen_calendar_templates.html
+++ b/modules/formulize/templates/admin/screen_calendar_templates.html
@@ -42,11 +42,4 @@
 
     </div>
 </form>
-<script>
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#screens-toptemplate").val(), "Top template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#screens-bottomtemplate").val(), "Bottom template", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
-</script>
+

--- a/modules/formulize/templates/admin/screen_form_template_boxes.html
+++ b/modules/formulize/templates/admin/screen_form_template_boxes.html
@@ -1,7 +1,7 @@
 <div class="form-item">
             <fieldset>
                 <legend>Top Template</legend>
-                <textarea id="toptemplate"  name="toptemplate" class="code-textarea" rows="20"/>
+                <textarea id="toptemplate"  name="toptemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.toptemplate}></textarea>
             </fieldset>
         </div>
@@ -11,17 +11,17 @@
         <div class="form-item">
             <fieldset>
             <legend>Element Container Template (opening)</legend>
-                <textarea id="elementcontainero" name="elementcontainero" class="code-textarea" rows="5"/>
+                <textarea id="elementcontainero" name="elementcontainero" class="code-textarea canValidate" rows="5"/>
 <{$content.elementcontainero}></textarea>
             </fieldset>
         </div>
         <div class='description'>All form elements are contained inside other markup with a consistent id. Use the variable $elementContainerId for the id, ie: "&lt;div id='$elementContainerId' ..."<br>This id is used by the conditional element logic to show and hide elements. Conditional elements won't work unless you use this id.<br>You can use a table row, a div, even a series of divs or whatever you want. You just have to make sure the HTML works seamlessly between the top, container, element, and bottom templates, and the $elementContainerId is used on the parent item in the DOM that contains the form elements.</div>
         <br />
-        
+
         <div class="form-item">
             <fieldset>
             <legend>Element Template (two columns)</legend>
-                <textarea id="elementtemplate2" name="elementtemplate2" class="code-textarea" rows="20"/>
+                <textarea id="elementtemplate2" name="elementtemplate2" class="code-textarea canValidate" rows="20"/>
 <{$content.elementtemplate2}></textarea>
             </fieldset>
         </div>
@@ -41,22 +41,22 @@
         <div class="form-item">
             <fieldset>
             <legend>Element Template (one column)</legend>
-                <textarea id="elementtemplate1" name="elementtemplate1" class="code-textarea" rows="20"/>
+                <textarea id="elementtemplate1" name="elementtemplate1" class="code-textarea canValidate" rows="20"/>
 <{$content.elementtemplate1}></textarea>
             </fieldset>
         </div>
         <div class='description'>The element template is used to render each element in the form.<br>The one column version is used when the one column option is selected on the Options tab, and is intended for situations where you want captions and the form elements in a single column vertically. This is usually a good layout for mobile devices.</div>
         <br />
-        
+
         <div class="form-item">
             <fieldset>
             <legend>Element Container Template (closing)</legend>
-                <textarea id="elementcontainerc" name="elementcontainerc" class="code-textarea" rows="5"/>
+                <textarea id="elementcontainerc" name="elementcontainerc" class="code-textarea canValidate" rows="5"/>
 <{$content.elementcontainerc}></textarea>
             </fieldset>
         </div>
         <div class='description'>The element container (closing) ends the element container started above.<br>If you opened a table row above and show each element in a table cell, you would need to use a &lt;/tr> here, for example.</div>
-        
+
         <!--
             displayType not actually used yet. Might be relevant in more complex themes? The js for displaying conditional elements simply sets the display property in css to null, and the browser figures out what is appropriate, but that's sort of a hack and might not work in all cases.
             <div class="form-item">
@@ -67,11 +67,11 @@
         </div>
         <div class='description'>When conditional elements are shown, the CSS display setting is set to this value.</div>-->
         <br />
-        
+
         <div class="form-item">
             <fieldset>
                 <legend>Bottom Template</legend>
-                <textarea id="bottomtemplate"  name="bottomtemplate" class="code-textarea" rows="20"/>
+                <textarea id="bottomtemplate"  name="bottomtemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.bottomtemplate}></textarea>
             </fieldset>
         </div>

--- a/modules/formulize/templates/admin/screen_form_templates.html
+++ b/modules/formulize/templates/admin/screen_form_templates.html
@@ -11,26 +11,17 @@
     <div class="panel-content content">
         <p><b>Showing templates for use with this theme:</b> <{html_options name=screens-theme options=$content.themes selected=$content.selectedTheme}></p>
         <p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_TOPTEMPLATE3}></p><br />
-        
+
         <{if !$content.usingTemplates}>
-            <p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES1}><{$content.seedtemplates}><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES2}></p><br /><p><input type="button" value="<{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES3}>" id="seedtemplates"></p><br />        
+            <p><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES1}><{$content.seedtemplates}><{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES2}></p><br /><p><input type="button" value="<{$smarty.const._AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES3}>" id="seedtemplates"></p><br />
         <{/if}>
-        
+
         <{if $content.usingTemplates}>
-        
+
             <{include file="db:admin/screen_form_template_boxes.html"}>
-        
+
         <{/if}>
 
     </div>
 </form>
-<script>
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#bottomtemplate").val(), "Bottom Template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#toptemplate").val(), "Top Template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#elementtemplate1").val(), "Element Template (one column)", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#elementtemplate2").val(), "Element Template (two columns)", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
-</script>
+

--- a/modules/formulize/templates/admin/screen_list_custom_sections.html
+++ b/modules/formulize/templates/admin/screen_list_custom_sections.html
@@ -51,7 +51,7 @@
 			<div class="customeffect">
 				<p><a class="removeeffectbutton" href="" target="<{$sectionContent.id}>_<{$id}>"><img src="../images/editdelete.gif"> Remove this effect</a></p>
 				<{if $sectionContent.applyto == 'custom_code' OR $sectionContent.applyto == 'custom_code_once'}>
-				<textarea name="code_<{$sectionContent.id}>[<{$id}>]" class="code-textarea" rows=8><{if $effect.code == ''}><?php
+				<textarea name="code_<{$sectionContent.id}>[<{$id}>]" class="code-textarea canValidate" rows=8><{if $effect.code == ''}><?php
 <{else}><{$effect.code}><{/if}></textarea>
 				<{elseif $sectionContent.applyto == 'custom_html'}>
 				<textarea name="html_<{$sectionContent.id}>[<{$id}>]" class="code-textarea" rows=8><{if $effect.html == ''}><?php

--- a/modules/formulize/templates/admin/screen_list_templates.html
+++ b/modules/formulize/templates/admin/screen_list_templates.html
@@ -32,7 +32,7 @@
         <div class="form-item">
             <fieldset>
                 <legend>Top Template</legend>
-                <textarea id="screens-toptemplate"  name="screens-toptemplate" class="code-textarea" rows="20"/>
+                <textarea id="screens-toptemplate"  name="screens-toptemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.toptemplate}></textarea>
             </fieldset>
         </div>
@@ -40,7 +40,7 @@
         <div class="form-item">
             <fieldset>
                 <legend>Open List Template</legend>
-                <textarea id="screens-openlisttemplate"  name="screens-openlisttemplate" class="code-textarea" rows="20"/>
+                <textarea id="screens-openlisttemplate"  name="screens-openlisttemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.openlisttemplate}></textarea>
             </fieldset>
         </div>
@@ -48,7 +48,7 @@
         <div class="form-item">
             <fieldset>
                 <legend>List Item Template</legend>
-                <textarea id="screens-listtemplate" name="screens-listtemplate" class="code-textarea" rows="20"/>
+                <textarea id="screens-listtemplate" name="screens-listtemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.listtemplate}></textarea>
                 <br />
                 <{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
@@ -58,7 +58,7 @@
         <div class="form-item">
             <fieldset>
                 <legend>Close List Template</legend>
-                <textarea id="screens-closelisttemplate"  name="screens-closelisttemplate" class="code-textarea" rows="20"/>
+                <textarea id="screens-closelisttemplate"  name="screens-closelisttemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.closelisttemplate}></textarea>
             </fieldset>
         </div>
@@ -66,7 +66,7 @@
         <div class="form-item">
             <fieldset>
             <legend>Bottom Template</legend>
-                <textarea id="screens-bottomtemplate" name="screens-bottomtemplate" class="code-textarea" rows="20"/>
+                <textarea id="screens-bottomtemplate" name="screens-bottomtemplate" class="code-textarea canValidate" rows="20"/>
 <{$content.bottomtemplate}></textarea>
             </fieldset>
         </div>
@@ -75,14 +75,4 @@
 
     </div>
 </form>
-<script>
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#screens-toptemplate").val(), "Top template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#screens-listtemplate").val(), "List Item template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#screens-bottomtemplate").val(), "Bottom template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#screens-openlisttemplate").val(), "Open List template", "<{$icms_url}>", <{$icms_userid}>);
-        fz_check_php_code(jQuery("#screens-closelisttemplate").val(), "Close List template", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
-</script>
+

--- a/modules/formulize/templates/admin/screen_template_templates.html
+++ b/modules/formulize/templates/admin/screen_template_templates.html
@@ -28,7 +28,7 @@
         <div class="form-item">
             <fieldset>
             <legend>Custom code</legend>
-                <textarea id="screens-custom_code" name="screens-custom_code" class="code-textarea" rows="20"/>
+                <textarea id="screens-custom_code" name="screens-custom_code" class="code-textarea canValidate" rows="20"/>
 <{$content.custom_code}></textarea>
 								<br />
                 <{include file=db:admin/variable_template_help.html variables=$content.variabletemplatehelp}>
@@ -37,10 +37,4 @@
 
     </div>
 </form>
-<script>
-jQuery(document).ready(function() {
-    jQuery(".savebutton").click(function() {
-        fz_check_php_code(jQuery("#screens-custom_code").val(), "Template Code", "<{$icms_url}>", <{$icms_userid}>);
-    });
-});
-</script>
+

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -181,15 +181,19 @@ $(document).ready(function() {
 	async function validateCode() {
 		let codeBlocks = [];
 		let error = '';
+		let errorMsg = '';
 		$(".canValidate").each(function() {
 			codeBlocks.push({ code: $(this).val(), title: $(this).prevAll('legend').first().text() });
 		});
 		for (let i = 0; i < codeBlocks.length; i++) {
-			error = await fz_check_php_code(codeBlocks[i].code, codeBlocks[i].title);
-			if(error) { break };
+			error = await fz_check_php_code(codeBlocks[i].code);
+			if(error.valid == false) {
+				errorMsg = "The "+codeBlocks[i].title+" has an error:\n\n"+error.result+".";
+				break;
+			}
 		}
-		if(error) {
-			alert(error);
+		if(errorMsg) {
+			alert(errorMsg);
 			$('.admin-ui').fadeTo(1, 1);
 		} else if(validateRequired()) {
       runSaveEvent();

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -188,7 +188,7 @@ $(document).ready(function() {
 		for (let i = 0; i < codeBlocks.length; i++) {
 			error = await fz_check_php_code(codeBlocks[i].code);
 			if(error.valid === false) {
-				errorMsg = "The "+codeBlocks[i].title+" has an error:\n\n"+error.result+".";
+				errorMsg = `The ${codeBlocks[i].title} has an error:\n\n${error.result}`;
 				break;
 			}
 		}

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -17,7 +17,7 @@ $(document).ready(function() {
 	//Select all anchor tag with rel set to tooltip
 	$('a[rel=tooltip]').mouseover(function(e) {
 		//Grab the title attribute's value and assign it to a variable
-		var tip = $(this).attr('title');		
+		var tip = $(this).attr('title');
 		//Remove the title attribute's to avoid the native tooltip from the browser
 		$(this).attr('title','');
 		//Append the tooltip template and its value
@@ -48,7 +48,7 @@ $(document).ready(function() {
 <script type="text/javascript">
 $(document).ready(function() {
 	var offset = $('#admin_toolbar').offset();
-	
+
 	  $(window).scroll(function () {
 		var scrollTop = $(window).scrollTop();
 		if (offset && offset.top<scrollTop <{$allowFloatingSave}>) {
@@ -59,12 +59,12 @@ $(document).ready(function() {
 		  $('#admin_toolbar').removeClass('ui-corner-all');
 		};
 	  });
-	  
+
 	});
 </script>
 <!-- end jquery -->
 
-<!--[if IE 6]> 
+<!--[if IE 6]>
 	<link rel="stylesheet" type="text/css" href="<{$xoops_url}>/modules/formulize/templates/css/ie6.css" />
 <![endif]-->
 
@@ -113,7 +113,7 @@ $(document).ready(function() {
     <{/foreach}>
 </p>
 <{/if}>
-    
+
 <!-- modified by Freeform Solutions, S.Gray, April 11, 2011 -->
 <{if $adminPage.needsave}>
 <div id="admin_toolbar">
@@ -121,7 +121,7 @@ $(document).ready(function() {
 <{if $adminPage.isSaveLocked}>
 	READ ONLY
 <{else}>
-    <input type="button" class="savebutton" id="save" value="<{$smarty.const._AM_HOME_SAVECHANGES}>"/>    
+    <input type="button" class="savebutton" id="save" value="<{$smarty.const._AM_HOME_SAVECHANGES}>"/>
 <{/if}>
 </div>
 <div id="savewarning" class="ui-corner-all"><{$smarty.const._AM_HOME_WARNING_UNSAVED}></div>
@@ -130,25 +130,27 @@ $(document).ready(function() {
 <{/if}>
 
 <{if $adminPage.template}>
-<{include file=$adminPage.template}>  
+<{include file=$adminPage.template}>
 <{/if}>
 
-<{if $adminPage.tabs}>  
+<{if $adminPage.tabs}>
 <{include file="db:admin/ui-tabs.html" tabs=$adminPage.tabs}>
 <{/if}>
- 
+
 <p class="versionnumber">Version <{$version}></p>
 
 </div><!-- End admin-ui -->
 
 <script type="text/javascript">
 
+	var icms_url = '<{$XOOPS_URL}>';
+	var icms_userid = <{$UID}>;
   var saveCounter = 0;
   var saveTarget = 0;
   var redirect = "";
   var newhandle = "";
   var formdata = new Array();
-  
+
   $("input").change(function() {
     setDisplay('savewarning','block');
     });
@@ -165,12 +167,36 @@ $(document).ready(function() {
     });
 
   $(".savebutton").click(function() {
-    if(validateRequired()) {
+		<{php}>
+		// if user wants it, and server can validate code, validate code blocks, which will then validateRequired, etc
+		global $xoopsModuleConfig;
+		if ($xoopsModuleConfig['validateCode'] AND isEnabled('shell_exec')) {
+			print "\t\t$('.admin-ui').fadeTo(1, 0.5, function() { validateCode(); });\n";
+		} else {
+			print "\t\tif(validateRequired()) { runSaveEvent(); }\n";
+		}
+		<{/php}>
+	});
+
+	async function validateCode() {
+		let codeBlocks = [];
+		let error = '';
+		$(".canValidate").each(function() {
+			codeBlocks.push({ code: $(this).val(), title: $(this).prevAll('legend').first().text() });
+		});
+		for (let i = 0; i < codeBlocks.length; i++) {
+			error = await fz_check_php_code(codeBlocks[i].code, codeBlocks[i].title);
+			if(error) { break };
+		}
+		if(error) {
+			alert(error);
+			$('.admin-ui').fadeTo(1, 1);
+		} else if(validateRequired()) {
       runSaveEvent();
     }
-  });
+	}
 
-  function runSaveEvent() {
+	function runSaveEvent() {
     $(".admin-ui").fadeTo(1,0.5);
     var formulize_formlist = $(".formulize-admin-form");
     saveCounter = 0;
@@ -184,10 +210,10 @@ $(document).ready(function() {
       }
     }
     if(saveTarget > 0) {
-      sendFormData(formdata[0]); // send the first form's data 
+      sendFormData(formdata[0]); // send the first form's data
     }
   }
-  
+
   function sendFormData(thisformdata, ele_id) {
     if(!ele_id) { ele_id = 0 }
     $.post("save.php?ele_id="+ele_id, $(thisformdata).serialize(), function(data) {
@@ -217,14 +243,14 @@ $(document).ready(function() {
       }
     });
   }
-  
+
   function reloadWithScrollPosition(url) {
     if(url) {
       $("[name=scrollposition]").attr('action', url);
     }
     window.document.scrollposition.scrollx.value = $(window).scrollTop();
     var tabs_selected = "";
-    <{if $adminPage.tabs}> 
+    <{if $adminPage.tabs}>
     tabs_selected = $("#tabs").tabs("option","selected");
     window.document.scrollposition.tabs_selected.value = tabs_selected;
     tabs_selected = tabs_selected+1;
@@ -251,7 +277,7 @@ $(document).ready(function() {
   $().ajaxError(function () {
     alert("There was an error when saving your data.  Please try again.");
   });
-  
+
   $(window).load(function () {
     $(window).scrollTop(<{$scrollx}>);
   });
@@ -286,24 +312,24 @@ $(document).ready(function() {
             enterMode: "keep",
             tabMode: "shift",
             lineWrapping: true,
-            onChange: function(instance) { 
+            onChange: function(instance) {
                 setDisplay('savewarning','block');
                 instance.save(); // Call this to update the textarea value for the ajax post
             }
         });
     })
   );
-  
+
     // change the themes, only possible when no changes to screen settings yet. Change theme property of screen and reload page.
     $("[name='screens-theme']").change(function() {
         window.document.scrollposition.themeswitch.value  = $(this).val();
         reloadWithScrollPosition();
     });
-    
+
     // seed the templates, only possible when no custom templates yet exist for a screen.
     $("#seedtemplates").click(function() {
         window.document.scrollposition.seedtemplates.value = 1;
         reloadWithScrollPosition();
     });
-  
+
 </script>

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -178,25 +178,30 @@ $(document).ready(function() {
 		<{/php}>
 	});
 
+	let validBlocks = []
 	async function validateCode() {
-		let codeBlocks = [];
-		let error = '';
-		let errorMsg = '';
+		let codeBlocks = []
+		let error = ''
+		let errorMsg = ''
 		$(".canValidate").each(function() {
-			codeBlocks.push({ code: $(this).val(), title: $(this).prevAll('legend').first().text() });
+			codeBlocks.push({ code: $(this).val(), title: $(this).prevAll('legend').first().text() })
 		});
 		for (let i = 0; i < codeBlocks.length; i++) {
-			error = await fz_check_php_code(codeBlocks[i].code);
-			if(error.valid === false) {
-				errorMsg = `The ${codeBlocks[i].title} has an error:\n\n${error.result}`;
-				break;
+			if(codeBlocks[i].code && (typeof validBlocks[i] === 'undefined' || codeBlocks[i].code != validBlocks[i].code)) {
+				error = await fz_check_php_code(codeBlocks[i].code)
+				if(error.valid === false) {
+					errorMsg = `The ${codeBlocks[i].title} has an error:\n\n${error.result}`
+					break
+				} else {
+					validBlocks[i] = { code: codeBlocks[i].code }
+				}
 			}
 		}
 		if(errorMsg) {
-			alert(errorMsg);
-			$('.admin-ui').fadeTo(1, 1);
+			alert(errorMsg)
+			$('.admin-ui').fadeTo(1, 1)
 		} else if(validateRequired()) {
-      runSaveEvent();
+      runSaveEvent()
     }
 	}
 

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -178,7 +178,7 @@ $(document).ready(function() {
 		<{/php}>
 	});
 
-	let validBlocks = []
+	let checkedBlocks = []
 	async function validateCode() {
 		let codeBlocks = []
 		let error = ''
@@ -187,13 +187,33 @@ $(document).ready(function() {
 			codeBlocks.push({ code: $(this).val(), title: $(this).prevAll('legend').first().text() })
 		});
 		for (let i = 0; i < codeBlocks.length; i++) {
-			if(codeBlocks[i].code && (typeof validBlocks[i] === 'undefined' || codeBlocks[i].code != validBlocks[i].code)) {
-				error = await fz_check_php_code(codeBlocks[i].code)
-				if(error.valid === false) {
-					errorMsg = `The ${codeBlocks[i].title} has an error:\n\n${error.result}`
+			if(codeBlocks[i].code && codeBlocks[i].code.trim() != '<?php') {
+				if(typeof checkedBlocks[i] === 'undefined' || (codeBlocks[i].code != checkedBlocks[i].code)) {
+					error = await fz_check_php_code(codeBlocks[i].code)
+					if(error.valid === false) {
+						errorMsg = `The ${codeBlocks[i].title} has an error:\n\n${error.result}`
+						checkedBlocks[i] = {
+							code: codeBlocks[i].code,
+							valid: false,
+							error: errorMsg
+						}
+						break
+					} else {
+						checkedBlocks[i] = {
+							code: codeBlocks[i].code,
+							valid: true,
+							error: ''
+						}
+					}
+				} else if(checkedBlocks[i].valid === false) {
+					errorMsg = checkedBlocks[i].error
 					break
-				} else {
-					validBlocks[i] = { code: codeBlocks[i].code }
+				}
+			} else {
+				checkedBlocks[i] = {
+					code: codeBlocks[i].code,
+					valid: true,
+					error: ''
 				}
 			}
 		}

--- a/modules/formulize/templates/admin/ui.html
+++ b/modules/formulize/templates/admin/ui.html
@@ -187,7 +187,7 @@ $(document).ready(function() {
 		});
 		for (let i = 0; i < codeBlocks.length; i++) {
 			error = await fz_check_php_code(codeBlocks[i].code);
-			if(error.valid == false) {
+			if(error.valid === false) {
 				errorMsg = "The "+codeBlocks[i].title+" has an error:\n\n"+error.result+".";
 				break;
 			}

--- a/modules/formulize/xoops_version.php
+++ b/modules/formulize/xoops_version.php
@@ -1000,6 +1000,15 @@ $modversion['config'][] = array(
 	'default' => 0,
 );
 
+$modversion['config'][] = array(
+	'name' => 'validateCode',
+	'title' => '_MI_formulize_VALIDATECODE',
+	'description' => '_MI_formulize_VALIDATECODE_DESC',
+	'formtype' => 'yesno',
+	'valuetype' => 'int',
+	'default' => 1,
+);
+
 $modversion['blocks'][1] = array(
 	'file' => "mymenu.php",
 	'name' => _MI_formulizeMENU_BNAME,


### PR DESCRIPTION
This operation can be enabled/disabled through a preference. It takes time to run, and runs with every save operation. This may be inconvenient for some developers/webmasters.

This operation will only take effect if the server has shell_exec enabled for PHP.

This code removes the xDebug reference in the formulize.ini that is used in Docker. This appears to be unnecessary because the dockerfile that controls our PHP instance already includes/enables xDebug? With the declaration in formulize.ini in place, there is an error on PHP start up, and that shows up as an error in every code block. With the declaration removed, this extra start up error is not present, and xDebug functionality in Docker/VSCode still works like normal.

Textarea boxes that have the class canValidate, are catalogued by the JS code, and then sent to the server which does the shell_exec PHP syntax check. Nothing returned (empty string) means there's no problems. If problems are found, then they are sent to the user in a JS alert and the saving operation does not proceed.

The UI fades out as if saving, while the check is taking place. The "You have unsaved changes" warning does not go away if the syntax check fails. Instead the screen just returns to full brightness and the user can continue from there.