### PR TITLE
First pass at converting handle storage to id storage

### DIFF
--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -1215,12 +1215,13 @@ class formulizeFormsHandler {
 			return "";
 		}
 
+		$element_handler = xoops_getmodulehandler('elements', 'formulize');
+
 		global $xoopsUser;
 		$uid = $xoopsUser ? $xoopsUser->getVar('uid') : 0;
 		if(!is_array($groupids)) {
 			$groupids = $xoopsUser ? $xoopsUser->getGroups() : array(0=>XOOPS_GROUP_ANONYMOUS);
 		}
-
 
 		if($formAlias) {
 			$formAlias .= "."; // add a period at the end of the alias so it will work with the field names in the query
@@ -1246,6 +1247,13 @@ class formulizeFormsHandler {
 			$filterAll = array();
 			$filterOOM = array();
 			for($i=0;$i<count((array) $filterSettings[3]);$i++) {
+				// ensure filterSettings[0] is an array of element handles! (will be stored as IDs but we need the handles for lower code to work)
+				if($elementObject = $element_handler->get($filterSettings[0][$i])) {
+					$filterSettings[0][$i] = $elementObject->getVar('ele_handle');
+				} else {
+					print "Formulize Error: a per-group permission filter on form $fid is referencing an element that does not exist. Was it renamed or deleted?<br>";
+					return "";
+				}
 				if($filterSettings[3][$i] == "all") {
 					$filterAll[] = $i;
 				} else {

--- a/modules/formulize/class/multiPageScreen.php
+++ b/modules/formulize/class/multiPageScreen.php
@@ -415,6 +415,7 @@ function pageMeetsConditions($conditions, $currentPage, $entry_id, $fid, $frid) 
     $element_handler = xoops_getmodulehandler('elements', 'formulize');
             foreach($elements as $i=>$thisElement) {
         if($elementObject = $element_handler->get($thisElement)) {
+					$elements[$i] = $elementObject->getVar('ele_handle'); // safety net for when the elements array is a set of element ids! Code is designed and filter conditions below designed, to work with element handles
         $searchTerm = formulize_swapDBText(trans($terms[$i]),$elementObject->getVar('ele_uitext'));
         if($ops[$i] == "NOT") { $ops[$i] = "!="; }
         if($terms[$i] == "{BLANK}") { // NOTE...USE OF BLANKS WON'T WORK CLEANLY IN ALL CASES DEPENDING WHAT OTHER TERMS HAVE BEEN SPECIFIED!!

--- a/modules/formulize/include/elementdisplay.php
+++ b/modules/formulize/include/elementdisplay.php
@@ -456,18 +456,27 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
     // convert the internal database representation to the displayed value, if this element has uitext that we're supposed to use
     // translate yes/no choices for yes/no elements if French is active language
     global $xoopsConfig;
-        foreach ($filterElements as $key => $element) {
-        $element_metadata = formulize_getElementMetaData($element, true);
-        if($element_metadata['ele_uitextshow'] AND isset($element_metadata['ele_uitext'])) {
-            $filterTerms[$key] = formulize_swapUIText($filterTerms[$key], unserialize($element_metadata['ele_uitext']));
-        }
-        if($element_metadata['ele_type'] == 'yn' AND ($filterTerms[$key] == 'Yes' OR $filterTerms[$key] == 'No') AND $xoopsConfig['language'] == 'french') {
-            $filterTerms[$key] = $filterTerms[$key] == 'Yes' ? 'Oui' : $filterTerms[$key];
-            $filterTerms[$key] = $filterTerms[$key] == 'No' ? 'Non' : $filterTerms[$key];
-    }
+		$element_handler = xoops_getmodulehandler('elements', 'formulize');
+
+    foreach ($filterElements as $key => $element) {
+			// make sure that the filterElements array is using handles, as originally designed and required by code below
+			if($filterElementObject = $element_handler->get($element)) {
+				$filterElements[$key] = $filterElementObject->getVar('ele_handle');
+			} else {
+				print "Formulize Error: a display or disabled condition for a form element, is referencing a non existent element in another form. Probably the element was deleted?<br>";
+				return false;
+			}
+			$element_metadata = formulize_getElementMetaData($element, !is_numeric($element));
+			if($element_metadata['ele_uitextshow'] AND isset($element_metadata['ele_uitext'])) {
+				$filterTerms[$key] = formulize_swapUIText($filterTerms[$key], unserialize($element_metadata['ele_uitext']));
+			}
+			if($element_metadata['ele_type'] == 'yn' AND ($filterTerms[$key] == 'Yes' OR $filterTerms[$key] == 'No') AND $xoopsConfig['language'] == 'french') {
+				$filterTerms[$key] = $filterTerms[$key] == 'Yes' ? 'Oui' : $filterTerms[$key];
+				$filterTerms[$key] = $filterTerms[$key] == 'No' ? 'Non' : $filterTerms[$key];
+    	}
     }
 
-    $element_handler = xoops_getmodulehandler('elements', 'formulize');
+
 	for($io=0;$io<count((array) $indexes);$io++) {
 		$i = $indexes[$io];
 		if(!($evaluationCondition == "")) {


### PR DESCRIPTION
Everywhere there's a filter UI, it now saves element IDs instead of handles.

If the saved data in the database is based on handles, it will be read OK, and the admin UI will use IDs when next saving.

All features running off filter UI settings, can function with handles or IDs so historical data is OK, and it will be updated when next saved to be storing IDs instead of handles.

The only gotcha for users remains that if they change the handle on an element that is used in a filter setting, before they re-save the filter settings, then the older filter settings with the handle reference will be broken. All new elements, and any elements saved to the DB after this fix, will not have that problem and handles can be changed at will without breaking any filters.