### PR TITLE
FEATURE: Adding a trim option to text input

### DIFF
--- a/modules/formulize/class/textElement.php
+++ b/modules/formulize/class/textElement.php
@@ -108,6 +108,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 				$ele_value[6] = isset($formulizeConfig['number_prefix']) ? $formulizeConfig['number_prefix'] : '';
 				$ele_value[7] = isset($formulizeConfig['number_decimalsep']) ? $formulizeConfig['number_decimalsep'] : '.';
 				$ele_value[8] = isset($formulizeConfig['number_sep']) ? $formulizeConfig['number_sep'] : ',';
+				$ele_value[12] = 1; // Default trim option to enabled
 				$dataToSendToTemplate['ele_value'] = $ele_value;
 			}
       return $dataToSendToTemplate;
@@ -230,6 +231,10 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 		// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
     function prepareDataForSaving($value, $element, $entry_id=null) {
 			$ele_value = $element->getVar('ele_value');
+			// Trim the value if the option is set
+			if ($ele_value[12]) {
+				$value = trim($value);
+			}
 			// if $ele_value[3] is 1 (default is 0) then treat this as a numerical field
 			if ($ele_value[3] AND $value != "{ID}" AND $value != "{SEQUENCE}") {
 					$value = preg_replace ('/[^0-9.-]+/', '', $value);

--- a/modules/formulize/class/textElement.php
+++ b/modules/formulize/class/textElement.php
@@ -232,7 +232,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
     function prepareDataForSaving($value, $element, $entry_id=null) {
 			$ele_value = $element->getVar('ele_value');
 			// Trim the value if the option is set
-			if ($ele_value[12]) {
+			if (isset($ele_value[12]) && $ele_value[12]) {
 				$value = trim($value);
 			}
 			// if $ele_value[3] is 1 (default is 0) then treat this as a numerical field

--- a/modules/formulize/language/english/admin.php
+++ b/modules/formulize/language/english/admin.php
@@ -271,6 +271,8 @@ define("_AM_ELE_DERIVED_NUMBER_OPTS","If this formula produces a number ...");
 
 // require unique option for textboxes
 define("_AM_ELE_REQUIREUNIQUE", "Users must enter a unique value into this box (no duplicates allowed)");
+// trim input for textboxes
+define("_AM_ELE_TRIMINPUT", "Remove spaces from before and after the user's text");
 
 // added - start - August 227 2005 - jpc
 define("_AM_ELE_TYPE","What should people type in this box?");

--- a/modules/formulize/templates/admin/element_type_text.html
+++ b/modules/formulize/templates/admin/element_type_text.html
@@ -1,76 +1,84 @@
-
-
-
 <div class="panel-content content">
-    <div class="form-item required">
-	    <label for="elements-ele_value[0]"><{$smarty.const._AM_ELE_SIZE}><em>*</em></label>
-	    <input type="text" id="elements-ele_value[0]" name="elements-ele_value[0]" value="<{$content.ele_value[0]}>" size="3" maxlength="3"/>
-    </div>
-    <div class="form-item required">
-	    <label for="elements-ele_value[1]"><{$smarty.const._AM_ELE_MAX_LENGTH}><em>*</em></label>
-	    <input type="text" id="elements-ele_value[1]" name="elements-ele_value[1]" value="<{$content.ele_value[1]}>" size="3" maxlength="3"/>
-    </div>
-    <div class="form-item">
-	    <label for="elements-ele_value[2]"><{$smarty.const._AM_ELE_DEFAULT}></label>
-	    <textarea id="elements-ele_value[2]" class="code-textarea" name="elements-ele_value[2]" rows="5" cols="35"><{$content.ele_value[2]|htmlspecialchars}></textarea>
-	    <div class="description">
-          <p><{$smarty.const._AM_ELE_TEXT_DESC}><{$smarty.const._AM_ELE_TEXT_DESC2}></p>
-      	</div>
-    </div>
-    <div class="form-item">
-      	<fieldset>
-      	<legend><{$smarty.const._AM_ELE_PLACEHOLDER_DESC}></legend>
-      		<div class="form-radios">
-      			<label for="no-placeholder"><input type="radio" id="no-placeholder" name="elements-ele_value[11]" value="0"<{if $content.ele_value[11] eq 0}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_NO_PLACEHOLDER}></label>
-      		</div>
-      		<div class="form-radios">
-      			<label for="placeholder"><input type="radio" id="placeholder" name="elements-ele_value[11]" value="1"<{if $content.ele_value[11] eq 1}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_PLACEHOLDER_OPTION}></label>
-      		</div>
-      	</fieldset>
-    </div>
-    <div class="form-item">
-	    <fieldset>
-	    <legend><{$smarty.const._AM_ELE_TYPE}></legend>
-		    <div class="form-radios">
-			    <label for="anything"><input type="radio" id="anything" name="elements-ele_value[3]" value="0"<{if $content.ele_value[3] eq 0}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_TYPE_STRING}></label>
-		    </div>
-		    <div class="form-radios">
-			    <label for="numbers"><input type="radio" id="numbers" name="elements-ele_value[3]" value="1"<{if $content.ele_value[3] eq 1}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_TYPE_NUMBER}></label>
-		    </div>
-		    <div class="description">
-			    <p><{$smarty.const._AM_ELE_TYPE_DESC}></p>
-		    </div>
-	    </fieldset>
-    </div>
-    <div class="form-item">
-	    <fieldset>
-		    <legend><{$smarty.const._AM_ELE_NUMBER_OPTS}></legend>
-		    <div class="form-item">
-			    <label for="elements-ele_value[5]"><{$smarty.const._AM_ELE_NUMBER_OPTS_DEC}></label><input type="text" id="elements-ele_value[5]" name="elements-ele_value[5]" value="<{$content.ele_value[5]}>" size="2" maxlength="2"/>
-		    </div>
-		    <div class="form-item">
-			    <label for="elements-ele_value[6]"><{$smarty.const._AM_ELE_NUMBER_OPTS_PREFIX}></label><input type="text" id="elements-ele_value[6]" name="elements-ele_value[6]" value="<{$content.ele_value[6]}>" size="5" maxlength="255"/>
-		    </div>
-		    <div class="form-item">
-			    <label for="elements-ele_value[10]"><{$smarty.const._AM_ELE_NUMBER_OPTS_SUFFIX}></label><input type="text" id="elements-ele_value[10]" name="elements-ele_value[10]" value="<{$content.ele_value[10]}>" size="5" maxlength="255"/>
-		    </div>
-		    <div class="form-item">
-			    <label for="elements-ele_value[7]"><{$smarty.const._AM_ELE_NUMBER_OPTS_DECSEP}></label><input type="text" id="elements-ele_value[7]" name="elements-ele_value[7]" value="<{$content.ele_value[7]}>" size="5" maxlength="255"/>
-		    </div>
-		    <div class="form-item">
-			    <label for="elements-ele_value[8]"><{$smarty.const._AM_ELE_NUMBER_OPTS_SEP}></label><input type="text" id="elements-ele_value[8]" name="elements-ele_value[8]" value="<{$content.ele_value[8]}>" size="5" maxlength="255"/>
-		    </div>
-		    <div class="description">
-			    <{$smarty.const._AM_ELE_NUMBER_OPTS_DESC}>
-		    </div>
-	    </fieldset>
-    </div>
-    <div class="form-item">
-	    <label for="formlink"><{$smarty.const._AM_ELE_FORMLINK_TEXTBOX}></label>
-      <{$content.formlink}>
-	    <div class="description">
-		    <{$smarty.const._AM_ELE_FORMLINK_DESC_TEXTBOX}>
-	    </div>
-    </div>
-		  <input type="checkbox" id="elements-ele_value[9]" name="elements-ele_value[9]"<{if $content.ele_value[9] eq 1}> checked="checked"<{/if}> value="1"/> <{$smarty.const._AM_ELE_REQUIREUNIQUE}>
+	<div class="form-item required">
+		<label for="elements-ele_value[0]"><{$smarty.const._AM_ELE_SIZE}><em>*</em></label>
+		<input type="text" id="elements-ele_value[0]" name="elements-ele_value[0]" value="<{$content.ele_value[0]}>" size="3" maxlength="3"/>
+	</div>
+	<div class="form-item required">
+		<label for="elements-ele_value[1]"><{$smarty.const._AM_ELE_MAX_LENGTH}><em>*</em></label>
+		<input type="text" id="elements-ele_value[1]" name="elements-ele_value[1]" value="<{$content.ele_value[1]}>" size="3" maxlength="3"/>
+	</div>
+	<div class="form-item">
+		<input type="checkbox" id="elements-ele_value[9]" name="elements-ele_value[9]"<{if $content.ele_value[9] eq 1}> checked="checked"<{/if}> value="1"/> <{$smarty.const._AM_ELE_REQUIREUNIQUE}>
+	</div>
+	<div class="form-item">
+		<input type="checkbox" id="elements-ele_value[12]" name="elements-ele_value[12]"<{if $content.ele_value[12] eq 1}> checked="checked"<{/if}> value="1"/> <{$smarty.const._AM_ELE_TRIMINPUT}>
+	</div>
+	<br/>
+	<div class="form-item">
+		<fieldset>
+			<legend><{$smarty.const._AM_ELE_DEFAULT}></legend>
+			<textarea id="elements-ele_value[2]" class="code-textarea" name="elements-ele_value[2]" rows="5" cols="35"><{$content.ele_value[2]|htmlspecialchars}></textarea>
+			<div class="description">
+				<p><{$smarty.const._AM_ELE_TEXT_DESC}><{$smarty.const._AM_ELE_TEXT_DESC2}></p>
+			</div>
+		</fieldset>
+	</div>
+	<div class="form-item">
+			<fieldset>
+			<legend><{$smarty.const._AM_ELE_PLACEHOLDER_DESC}></legend>
+				<div class="form-radios">
+					<label for="no-placeholder"><input type="radio" id="no-placeholder" name="elements-ele_value[11]" value="0"<{if $content.ele_value[11] eq 0}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_NO_PLACEHOLDER}></label>
+				</div>
+				<div class="form-radios">
+					<label for="placeholder"><input type="radio" id="placeholder" name="elements-ele_value[11]" value="1"<{if $content.ele_value[11] eq 1}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_PLACEHOLDER_OPTION}></label>
+				</div>
+			</fieldset>
+	</div>
+	<div class="form-item">
+		<fieldset>
+		<legend><{$smarty.const._AM_ELE_TYPE}></legend>
+			<div class="form-radios">
+				<label for="anything"><input type="radio" id="anything" name="elements-ele_value[3]" value="0"<{if $content.ele_value[3] eq 0}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_TYPE_STRING}></label>
+			</div>
+			<div class="form-radios">
+				<label for="numbers"><input type="radio" id="numbers" name="elements-ele_value[3]" value="1"<{if $content.ele_value[3] eq 1}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_TYPE_NUMBER}></label>
+			</div>
+			<div class="description">
+				<p><{$smarty.const._AM_ELE_TYPE_DESC}></p>
+			</div>
+		</fieldset>
+	</div>
+	<div class="form-item">
+		<fieldset>
+			<legend><{$smarty.const._AM_ELE_NUMBER_OPTS}></legend>
+			<div class="form-item">
+				<label for="elements-ele_value[5]"><{$smarty.const._AM_ELE_NUMBER_OPTS_DEC}></label><input type="text" id="elements-ele_value[5]" name="elements-ele_value[5]" value="<{$content.ele_value[5]}>" size="2" maxlength="2"/>
+			</div>
+			<div class="form-item">
+				<label for="elements-ele_value[6]"><{$smarty.const._AM_ELE_NUMBER_OPTS_PREFIX}></label><input type="text" id="elements-ele_value[6]" name="elements-ele_value[6]" value="<{$content.ele_value[6]}>" size="5" maxlength="255"/>
+			</div>
+			<div class="form-item">
+				<label for="elements-ele_value[10]"><{$smarty.const._AM_ELE_NUMBER_OPTS_SUFFIX}></label><input type="text" id="elements-ele_value[10]" name="elements-ele_value[10]" value="<{$content.ele_value[10]}>" size="5" maxlength="255"/>
+			</div>
+			<div class="form-item">
+				<label for="elements-ele_value[7]"><{$smarty.const._AM_ELE_NUMBER_OPTS_DECSEP}></label><input type="text" id="elements-ele_value[7]" name="elements-ele_value[7]" value="<{$content.ele_value[7]}>" size="5" maxlength="255"/>
+			</div>
+			<div class="form-item">
+				<label for="elements-ele_value[8]"><{$smarty.const._AM_ELE_NUMBER_OPTS_SEP}></label><input type="text" id="elements-ele_value[8]" name="elements-ele_value[8]" value="<{$content.ele_value[8]}>" size="5" maxlength="255"/>
+			</div>
+			<div class="description">
+				<{$smarty.const._AM_ELE_NUMBER_OPTS_DESC}>
+			</div>
+		</fieldset>
+	</div>
+	<div class="form-item">
+		<fieldset>
+			<legend><{$smarty.const._AM_ELE_FORMLINK_TEXTBOX}></legend>
+			<{$content.formlink}>
+			<div class="description">
+				<{$smarty.const._AM_ELE_FORMLINK_DESC_TEXTBOX}>
+			</div>
+		</fieldset>
+	</div>
+	<br/>
 </div>


### PR DESCRIPTION
This feature adds a checkbox on the options page which trims the input values before saving. This option is enabled by default for all new elements but not for existing elements.

Additionally I restructuted the options page a little for clarity. An example of the layout is below.

![Screenshot 2024-11-07 at 15 21 48](https://github.com/user-attachments/assets/adee43a6-2a6b-4b48-91f1-360a21d100e5)
