### PR TITLE
Redirecting from invalid entries more cleanly

### DIFF
--- a/libraries/icms/core/Session.php
+++ b/libraries/icms/core/Session.php
@@ -226,7 +226,7 @@ class icms_core_Session {
       $instance->update_cookie();
     }
 
-		include_once XOOPS_ROOT_PATH.'/modules/formulize/include/common.php';
+		include_once XOOPS_ROOT_PATH.'/modules/formulize/include/writeToFormulizeLog.php';
 		writeToFormulizeLog(array(
 			'formulize_event'=>'session-loaded-for-user',
 			'user_id'=>intval($_SESSION['xoopsUserId'])

--- a/modules/formulize/class/templateScreen.php
+++ b/modules/formulize/class/templateScreen.php
@@ -133,8 +133,17 @@ class formulizeTemplateScreenHandler extends formulizeScreenHandler {
     function render($screen, $entry_id, $settings = "") {
 
         if(!security_check($screen->getVar('fid'), $entry_id)) {
-            print "<p>You do not have permission to view this entry in the form</p>";
-            return;
+					if(!$done_dest = $screen->getVar('donedest')) {
+						$done_dest = determineDoneDestinationFromURL($screen);
+					}
+					$done_dest = stripEntryFromDoneDestination($done_dest);
+					$done_dest = substr($done_dest,0,4) == "http" ? $done_dest : "http://".$done_dest;
+					icms::$logger->disableLogger();
+					while(ob_get_level()) {
+							ob_end_clean();
+					}
+					print "<script>window.location = \"$done_dest\";</script>";
+					exit();
         }
 
         $previouslyRenderingScreen = (isset($GLOBALS['formulize_screenCurrentlyRendering']) AND $GLOBALS['formulize_screenCurrentlyRendering']) ? $GLOBALS['formulize_screenCurrentlyRendering'] : null;

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -3215,6 +3215,11 @@ $output
 function interfaceJavascript($fid, $frid, $currentview, $useWorking, $useXhr, $lockedColumns) {
 
 	print "<script type='text/javascript' src='".XOOPS_URL."/modules/formulize/include/js/autocomplete.js'></script>";
+
+	global $formulizeRemoveEntryIdentifier;
+	if($formulizeRemoveEntryIdentifier) {
+		print "<script>$formulizeRemoveEntryIdentifier</script>";
+	}
 ?>
 <script type='text/javascript'>
 

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -3207,7 +3207,7 @@ function writeHiddenSettings($settings, $form = null, $entries = array(), $sub_e
 // $nosave indicates that the user cannot save this entry, so we shouldn't check for formulizechanged
 function drawJavascript($nosave=false, $entryId=null, $screen=null) {
 
-global $xoopsUser, $xoopsConfig, $actionFunctionName;
+global $xoopsUser, $xoopsConfig, $actionFunctionName, $formulizeRemoveEntryIdentifier;
 
 static $drawnJavascript = false;
 if($drawnJavascript) {
@@ -3248,9 +3248,9 @@ print "
 	    };
 	  });
 	})(jQuery);
-";
 
-print "
+$formulizeRemoveEntryIdentifier
+
 initialize_formulize_xhr();
 var formulizechanged=0;
 var formulize_javascriptFileIncluded = new Array();

--- a/modules/formulize/include/formdisplaypages.php
+++ b/modules/formulize/include/formdisplaypages.php
@@ -258,53 +258,15 @@ function displayFormPages($formframe, $entry, $mainform, $pages, $conditions="",
 
 	$nextPage = $currentPage+1;
 
-		global $formulizeCanonicalURI;
-    if(!$done_dest) {
-        // check for a dd in get and use that as a screen id
-        if(isset($_GET['dd']) AND is_numeric($_GET['dd'])) {
-            $done_dest = XOOPS_URL.'/modules/formulize/index.php?sid='.$_GET['dd'];
-        } else {
-            $done_dest = getCurrentURL();
-            // check if the done destination is for this specific form screen that we're rendering, if so, switch done destination to the default list for the form if any
-						$alternateURLForSid = $screen->getVar('rewriteruleAddress');
-						$doneDestHasSid = strstr($done_dest, 'sid='.$screen->getVar('sid'));
-						$doneDestHasSid = $doneDestHasSid ? $doneDestHasSid : ($alternateURLForSid AND strstr($done_dest, $alternateURLForSid));
-            if($screen AND $doneDestHasSid) {
-                $form_handler = xoops_getmodulehandler('forms', 'formulize');
-                $formObject = $form_handler->get($screen->getVar('fid'));
-                if($defaultListScreenId = $formObject->getVar('defaultlist')) {
-										$screen_handler = xoops_getmodulehandler('screen', 'formulize');
-										if($defaultListScreenObject = $screen_handler->get($defaultListScreenId)) {
-											if($rewriteruleAddress = $defaultListScreenObject->getVar('rewriteruleAddress')) {
-												$done_dest = XOOPS_URL.'/'.$rewriteruleAddress;
-											} else {
-                    		$done_dest = XOOPS_URL.'/modules/formulize/index.php?sid='.$defaultListScreenId;
-											}
-										}
-                }
-            }
-        }
-    }
-
-		// strip out any ve portion of a done destination, so we don't end up forcing the user back to this entry after they're done
-		$veTarget = strstr($done_dest, '&ve=') ? '&ve=' : '?ve=';
-		if($done_dest AND $vepos = strpos($done_dest, $veTarget)) {
-				if(is_numeric(substr($done_dest, $vepos+4))) {
-						$done_dest = substr($done_dest, 0, $vepos);
-				}
-		}
-		// if there was an alternate URL used to access the page, and a ve was specified, scale back to remove the ve from the done_dest
-		global $formulizeCanonicalURI;
-		if($done_dest AND $formulizeCanonicalURI AND $_GET['ve']) {
-			$trimmedDoneDest = trim($done_dest, '/'); // take off last slash if any
-			$trailingSlash = $trimmedDoneDest === $done_dest ? '' : '/'; // if there was a slash on the end, remember this for later
-			$doneDestParts = explode('/', $trimmedDoneDest); // split on slashes
-			if(intval($doneDestParts[count($doneDestParts)-1]) === intval($_GET['ve'])) { // make sure this is the ve we're talking about
-				unset($doneDestParts[count($doneDestParts)-1]); // remove the last value, which will be the ve number
-				$done_dest = implode('/', $doneDestParts).$trailingSlash; // put back together, with trailing slash if necessary
+	if(!$done_dest) {
+			// check for a dd in get and use that as a screen id
+			if(isset($_GET['dd']) AND is_numeric($_GET['dd'])) {
+					$done_dest = XOOPS_URL.'/modules/formulize/index.php?sid='.$_GET['dd'];
+			} else {
+					$done_dest = determineDoneDestinationFromURL($screen);
 			}
-		}
-
+	}
+	$done_dest = stripEntryFromDoneDestination($done_dest);
 	$done_dest = substr($done_dest,0,4) == "http" ? $done_dest : "http://".$done_dest;
 
 	// display a form if that's what this page is...

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -62,6 +62,7 @@ if (typeof jQuery.ui == 'undefined') {
 ";
 
 include_once XOOPS_ROOT_PATH . "/modules/formulize/include/common.php";
+include_once XOOPS_ROOT_PATH.'/modules/formulize/include/writeToFormulizeLog.php';
 
 function getFormFramework($formframe, $mainform=0) {
     static $cachedToReturn = array();
@@ -8277,82 +8278,6 @@ function generateSelfReferenceExclusionSQL($entry_id, $fid, $sourceFid, $ele_val
 		$selfReferenceExclusion = " AND ($tableAlias.entry_id != $entry_id) ";
 	}
 	return $selfReferenceExclusion;
-}
-
-/**
- * Record information in a log file. One log file per day. Log file location is a Formulize preference. Log file storage duration is a Formulize preference.
- *
- * @param array $data Key-Value pairs that should be written to the log entry
- * @return int|boolean Returns the number of bytes written to the file, or false on failure
- */
-function writeToFormulizeLog($data) {
-
-	// initialize the configuration settings
-	static $formulizeConfig = false;
-	static $formulizeLoggingOnOff = false;
-	static $formulizeLogFileLocation = XOOPS_ROOT_PATH.'/logs';
-	static $formulizeLogFileStorageDurationHours = 168;
-	static $logFilesCleanedUp = false;
-	static $phpUniqueId = '';
-	static $todayLogFileExists = null;
-	$phpUniqueId = $phpUniqueId ? $phpUniqueId : uniqid('', true);
-	if(!$formulizeConfig) {
-		$config_handler = xoops_gethandler('config');
-		$formulizeConfig = $config_handler->getConfigsByCat(0, getFormulizeModId());
-		$formulizeLoggingOnOff = $formulizeConfig['formulizeLoggingOnOff'];
-		$formulizeLogFileLocation = $formulizeConfig['formulizeLogFileLocation'];
-		$formulizeLogFileStorageDurationHours = $formulizeConfig['formulizeLogFileStorageDurationHours'];
-	}
-
-	// check if logging is on and log file location is valid
-	if(!$formulizeLoggingOnOff OR !$formulizeLogFileLocation OR !is_dir($formulizeLogFileLocation)) { return false; }
-
-	// cleanup old log files (last param requires seconds) -- only once per page load
-	if(!$logFilesCleanedUp) {
-		formulize_scandirAndClean($formulizeLogFileLocation, 'formulize_log_', $formulizeLogFileStorageDurationHours * 60 * 60);
-		$logFilesCleanedUp = true;
-	}
-
-	// UNIQUE ID is only available if the server has mod_unique_id turned on
-	// All log lines have standard format, but values are dependent on the event that wrote to the log
-	$data = array(
-		'microtime' => microtime(true),
-		'request_id' => (isset($_SERVER['UNIQUE_ID']) ? $_SERVER['UNIQUE_ID'] : $phpUniqueId),
-		'session_id' => session_id(),
-		'formulize_event' => (isset($data['formulize_event']) ? $data['formulize_event'] : ''),
-		'user_id' => (isset($data['user_id']) ? $data['user_id'] : ''),
-		'form_id' => (isset($data['form_id']) ? $data['form_id'] : ''),
-		'screen_id' => (isset($data['screen_id']) ? $data['screen_id'] : ''),
-		'entry_id' => (isset($data['entry_id']) ? $data['entry_id'] : ''),
-		'form_screen_page_number' => (isset($data['form_screen_page_number']) ? $data['form_screen_page_number'] : ''),
-		'searches' => (isset($data['searches']) ? $data['searches'] : ''),
-		'sort' => (isset($data['sort']) ? $data['sort'] : ''),
-		'order' => (isset($data['order']) ? $data['order'] : ''),
-		'scope' => (isset($data['scope']) ? $data['scope'] : ''),
-		'limit_start' => (isset($data['limit_start']) ? $data['limit_start'] : ''),
-		'page_size' => (isset($data['page_size']) ? $data['page_size'] : ''),
-		'uids_to_notify' => (isset($data['uids_to_notify']) ? $data['uids_to_notify'] : ''),
-		'formulize_notification_emails_if_uid_is_zero' => (isset($data['formulize_notification_emails_if_uid_is_zero']) ? $data['formulize_notification_emails_if_uid_is_zero'] : ''),
-		'subject' => (isset($data['subject']) ? $data['subject'] : ''),
-		'template' => (isset($data['template']) ? $data['template'] : ''),
-		'tags' => (isset($data['tags']) ? $data['tags'] : ''),
-		'PHP_error_number' => (isset($data['PHP_error_number']) ? $data['PHP_error_number'] : ''),
-		'PHP_error_string' => (isset($data['PHP_error_string']) ? $data['PHP_error_string'] : ''),
-		'PHP_error_file' => (isset($data['PHP_error_file']) ? $data['PHP_error_file'] : ''),
-		'PHP_error_errline' => (isset($data['PHP_error_errline']) ? $data['PHP_error_errline'] : '')
-	);
-
-	// write the new log entry (to a new file if necessary, active file has generic name, archived files are named with the current date based on server timezone)
-	// write operation is self contained in file_put_contents and closes the file, so it's available for other concurrent requests to write to after
-	$todayLogFile = $formulizeLogFileLocation.'/'.'formulize_log_'.date('Y-m-d').'.log';
-	$yesterdayLogFile = $formulizeLogFileLocation.'/'.'formulize_log_'.date('Y-m-d', strtotime('-1 day')).'.log';
-	$activeLogFile = $formulizeLogFileLocation.'/'.'formulize_log_active.log';
-	$todayLogFileExists = $todayLogFileExists === null ? file_exists($todayLogFile) : $todayLogFileExists;
-	if(!$todayLogFileExists) {
-		file_put_contents($todayLogFile, '', LOCK_EX);
-		rename($activeLogFile, $yesterdayLogFile);
-	}
-	return file_put_contents($activeLogFile, json_encode($data, JSON_NUMERIC_CHECK)."\n", FILE_APPEND | LOCK_EX);
 }
 
 /**

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8399,7 +8399,7 @@ function formulize_handleHtaccessRewriteRule() {
 				} else {
 					// when we get to JS later, we'll need to alter the URL to remove the invalid identifier
 					$formulizeRemoveEntryIdentifier = "window.history.replaceState(null, '', '".XOOPS_URL."/$address/');";
-					// see the current URL with the correct address
+					// seed the current URL with the correct address
 					getCurrentURL($address);
 				}
 			}

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8438,12 +8438,17 @@ function formulize_getSidFromRewriteAddress($address="") {
 			exit();
 		}
 
-		$sql = 'SELECT sid FROM '.$xoopsDB->prefix('formulize_screen').' WHERE MATCH(`rewriteruleAddress`) AGAINST("'.formulize_db_escape($address).'") AND `rewriteruleAddress` = "'.formulize_db_escape($address).'" LIMIT 0,1';
+		$sql = 'SELECT sid, type FROM '.$xoopsDB->prefix('formulize_screen').' WHERE MATCH(`rewriteruleAddress`) AGAINST("'.formulize_db_escape($address).'") AND `rewriteruleAddress` = "'.formulize_db_escape($address).'"';
 		if($res = $xoopsDB->query($sql)) {
-			if($row = $xoopsDB->fetchRow($res)) {
-				if($row[0]) {
-					return $row[0];
+			$candidateScreen = 0;
+			while($record = $xoopsDB->fetchArray($res)) {
+				if($record['sid']) {
+					// take the first one we've found, or if more than one and a later one is a list-ish screen, let's do that instead
+					$candidateScreen = (!$candidateScreen OR $record['type'] == 'listOfEntries' OR $record['type'] == 'calendar') ? $record['sid'] : $candidateScreen;
 				}
+			}
+			if($candidateScreen) {
+				return $candidateScreen;
 			}
 		}
 	}

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8308,8 +8308,8 @@ function formulize_handleHtaccessRewriteRule() {
 				}
 				if($ve AND (!$screenObject OR security_check($screenObject->getVar('fid'), $ve))) {
 					$queryString = "sid=$sid&ve=$ve";
-						$_GET['ve'] = $ve;
-						$_REQUEST['ve'] = $ve;
+					$_GET['ve'] = $ve;
+					$_REQUEST['ve'] = $ve;
 				} else {
 					// when we get to JS later, we'll need to alter the URL to remove the invalid identifier
 					$formulizeRemoveEntryIdentifier = "window.history.replaceState(null, '', '".XOOPS_URL."/$address/');";
@@ -8399,8 +8399,8 @@ function formulize_getSidFromRewriteAddress($address="", $entryIdentifier="") {
 			if($rowsFound == 1 AND $record = $xoopsDB->fetchArray($res)) {
 				$candidateScreen = $record['sid'] ? $record['sid'] : $candidateScreen;
 			} elseif($rowsFound > 1) {
-			while($record = $xoopsDB->fetchArray($res)) {
-				if($record['sid']) {
+				while($record = $xoopsDB->fetchArray($res)) {
+					if($record['sid']) {
 						$candidateScreen = $record['sid'];
 						// stop looking if we've found the right type based on whether an entry is being displayed
 						if((!$entryIdentifier AND ($record['type'] == 'listOfEntries' OR $record['type'] == 'calendar' OR $record['type'] == 'graph'))
@@ -8446,17 +8446,17 @@ function updateAlternateURLIdentifierCode($screen, $entry_id) {
     $code = '';
 		$entry_id = intval($entry_id);
     if($screen AND $entry_id AND $rewriteruleAddress = $screen->getVar('rewriteruleAddress') AND strpos(trim(str_replace(XOOPS_URL, '', getCurrentURL()), '/'), '/') === false) {
-        $entryIdentifier = $entry_id;
-        if($rewriteruleElement = $screen->getVar('rewriteruleElement')) {
-            $element_handler = xoops_getmodulehandler('elements', 'formulize');
-            $rewriteruleElementObject = $element_handler->get($rewriteruleElement);
-            $dataHandler = new formulizeDataHandler($screen->getVar('fid'));
-            $dbValue = $dataHandler->getElementValueInEntry($entry_id, $rewriteruleElementObject);
-            $preppedValue = prepvalues($dbValue, $rewriteruleElementObject->getVar('ele_handle'), $entry_id); // will be array sometimes. Ugh!
-            $preppedValue = is_array($preppedValue) ? $preppedValue[0] : $preppedValue;
-            $entryIdentifier = urlencode($preppedValue);
-        }
-        $code = "window.history.replaceState(null, '', '".trim(getCurrentURL(), '/')."/".$entryIdentifier."/');";
+			$entryIdentifier = $entry_id;
+			if($rewriteruleElement = $screen->getVar('rewriteruleElement')) {
+				$element_handler = xoops_getmodulehandler('elements', 'formulize');
+				$rewriteruleElementObject = $element_handler->get($rewriteruleElement);
+				$dataHandler = new formulizeDataHandler($screen->getVar('fid'));
+				$dbValue = $dataHandler->getElementValueInEntry($entry_id, $rewriteruleElementObject);
+				$preppedValue = prepvalues($dbValue, $rewriteruleElementObject->getVar('ele_handle'), $entry_id); // will be array sometimes. Ugh!
+				$preppedValue = is_array($preppedValue) ? $preppedValue[0] : $preppedValue;
+				$entryIdentifier = urlencode($preppedValue);
+			}
+			$code = "window.history.replaceState(null, '', '".trim(getCurrentURL(), '/')."/".$entryIdentifier."/');";
     }
     return $code;
 }
@@ -8495,14 +8495,21 @@ function determineDoneDestinationFromURL($screen = false) {
 	$doneDestHasSid = $screen ? strstr($done_dest, 'sid='.$screen->getVar('sid')) : false;
 	$doneDestHasSid = $doneDestHasSid ? $doneDestHasSid : ($alternateURLForSid AND strstr($done_dest, $alternateURLForSid));
 	if($screen AND $doneDestHasSid) {
-		$form_handler = xoops_getmodulehandler('forms', 'formulize');
-		$formObject = $form_handler->get($screen->getVar('fid'));
-		if($defaultListScreenId = $formObject->getVar('defaultlist')) {
-			if($defaultListScreenObject = $screen_handler->get($defaultListScreenId)) {
-				if($rewriteruleAddress = $defaultListScreenObject->getVar('rewriteruleAddress')) {
-					$done_dest = XOOPS_URL.'/'.$rewriteruleAddress;
-				} else {
-					$done_dest = XOOPS_URL.'/modules/formulize/index.php?sid='.$defaultListScreenId;
+		// if this rewrite address is associated with another screen, go there... (will prefer lists when no entry identifier passed to this function, so almost certainly an alternate screen id will be of a list screen)
+		$doneScreenId = formulize_getSidFromRewriteAddress($alternateURLForSid);
+		if($doneScreenId AND $screen->getVar('sid') != $doneScreenId) {
+			$done_dest = XOOPS_URL.'/'.$alternateURLForSid;
+		} else {
+			$form_handler = xoops_getmodulehandler('forms', 'formulize');
+			if($formObject = $form_handler->get($screen->getVar('fid'))) {
+				if($defaultListScreenId = $formObject->getVar('defaultlist')) {
+					if($defaultListScreenObject = $screen_handler->get($defaultListScreenId)) {
+						if($rewriteruleAddress = $defaultListScreenObject->getVar('rewriteruleAddress')) {
+							$done_dest = XOOPS_URL.'/'.$rewriteruleAddress;
+						} else {
+							$done_dest = XOOPS_URL.'/modules/formulize/index.php?sid='.$defaultListScreenId;
+						}
+					}
 				}
 			}
 		}

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8434,6 +8434,7 @@ function extractOperatorFromString($string) {
  */
 function updateAlternateURLIdentifierCode($screen, $entry_id) {
     $code = '';
+		$entry_id = intval($entry_id);
     if($screen AND $entry_id AND $rewriteruleAddress = $screen->getVar('rewriteruleAddress') AND strpos(trim(str_replace(XOOPS_URL, '', getCurrentURL()), '/'), '/') === false) {
         $entryIdentifier = $entry_id;
         if($rewriteruleElement = $screen->getVar('rewriteruleElement')) {

--- a/modules/formulize/include/writeToFormulizeLog.php
+++ b/modules/formulize/include/writeToFormulizeLog.php
@@ -1,0 +1,113 @@
+<?php
+
+###############################################################################
+##     Formulize - ad hoc form creation and reporting module for XOOPS       ##
+##                    Copyright (c) Formulize Project												 ##
+###############################################################################
+##                    XOOPS - PHP Content Management System                  ##
+##                       Copyright (c) 2000 XOOPS.org                        ##
+##                          <http://www.xoops.org/>                          ##
+###############################################################################
+##  This program is free software; you can redistribute it and/or modify     ##
+##  it under the terms of the GNU General Public License as published by     ##
+##  the Free Software Foundation; either version 2 of the License, or        ##
+##  (at your option) any later version.                                      ##
+##                                                                           ##
+##  You may not change or alter any portion of this comment or credits       ##
+##  of supporting developers from this source code or any supporting         ##
+##  source code which is considered copyrighted (c) material of the          ##
+##  original comment or credit authors.                                      ##
+##                                                                           ##
+##  This program is distributed in the hope that it will be useful,          ##
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of           ##
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            ##
+##  GNU General Public License for more details.                             ##
+##                                                                           ##
+##  You should have received a copy of the GNU General Public License        ##
+##  along with this program; if not, write to the Free Software              ##
+##  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA ##
+###############################################################################
+##  Author of this file: Formulize Project  					     									 ##
+##  Project: Formulize                                                       ##
+###############################################################################
+
+/**
+ * Record information in a log file. One log file per day. Log file location is a Formulize preference. Log file storage duration is a Formulize preference.
+ *
+ * @param array $data Key-Value pairs that should be written to the log entry
+ * @return int|boolean Returns the number of bytes written to the file, or false on failure
+ */
+function writeToFormulizeLog($data) {
+
+	// initialize the configuration settings
+	static $formulizeConfig = false;
+	static $formulizeLoggingOnOff = false;
+	static $formulizeLogFileLocation = XOOPS_ROOT_PATH.'/logs';
+	static $formulizeLogFileStorageDurationHours = 168;
+	static $logFilesCleanedUp = false;
+	static $phpUniqueId = '';
+	static $todayLogFileExists = null;
+	$phpUniqueId = $phpUniqueId ? $phpUniqueId : uniqid('', true);
+	if(!$formulizeConfig) {
+		global $xoopsDB;
+		$config_handler = xoops_gethandler('config');
+		if($res = $xoopsDB->query("SELECT mid FROM ".$xoopsDB->prefix("modules")." WHERE dirname='formulize'")) {
+			$row = $xoopsDB->fetchRow($res);
+      $mid = $row[0];
+		}
+		$formulizeConfig = $config_handler->getConfigsByCat(0, $mid);
+		$formulizeLoggingOnOff = $formulizeConfig['formulizeLoggingOnOff'];
+		$formulizeLogFileLocation = $formulizeConfig['formulizeLogFileLocation'];
+		$formulizeLogFileStorageDurationHours = $formulizeConfig['formulizeLogFileStorageDurationHours'];
+	}
+
+	// check if logging is on and log file location is valid
+	if(!$formulizeLoggingOnOff OR !$formulizeLogFileLocation OR !is_dir($formulizeLogFileLocation)) { return false; }
+
+	// cleanup old log files (last param requires seconds) -- only once per page load
+	if(!$logFilesCleanedUp) {
+		formulize_scandirAndClean($formulizeLogFileLocation, 'formulize_log_', $formulizeLogFileStorageDurationHours * 60 * 60);
+		$logFilesCleanedUp = true;
+	}
+
+	// UNIQUE ID is only available if the server has mod_unique_id turned on
+	// All log lines have standard format, but values are dependent on the event that wrote to the log
+	$data = array(
+		'microtime' => microtime(true),
+		'request_id' => (isset($_SERVER['UNIQUE_ID']) ? $_SERVER['UNIQUE_ID'] : $phpUniqueId),
+		'session_id' => session_id(),
+		'formulize_event' => (isset($data['formulize_event']) ? $data['formulize_event'] : ''),
+		'user_id' => (isset($data['user_id']) ? $data['user_id'] : ''),
+		'form_id' => (isset($data['form_id']) ? $data['form_id'] : ''),
+		'screen_id' => (isset($data['screen_id']) ? $data['screen_id'] : ''),
+		'entry_id' => (isset($data['entry_id']) ? $data['entry_id'] : ''),
+		'form_screen_page_number' => (isset($data['form_screen_page_number']) ? $data['form_screen_page_number'] : ''),
+		'searches' => (isset($data['searches']) ? $data['searches'] : ''),
+		'sort' => (isset($data['sort']) ? $data['sort'] : ''),
+		'order' => (isset($data['order']) ? $data['order'] : ''),
+		'scope' => (isset($data['scope']) ? $data['scope'] : ''),
+		'limit_start' => (isset($data['limit_start']) ? $data['limit_start'] : ''),
+		'page_size' => (isset($data['page_size']) ? $data['page_size'] : ''),
+		'uids_to_notify' => (isset($data['uids_to_notify']) ? $data['uids_to_notify'] : ''),
+		'formulize_notification_emails_if_uid_is_zero' => (isset($data['formulize_notification_emails_if_uid_is_zero']) ? $data['formulize_notification_emails_if_uid_is_zero'] : ''),
+		'subject' => (isset($data['subject']) ? $data['subject'] : ''),
+		'template' => (isset($data['template']) ? $data['template'] : ''),
+		'tags' => (isset($data['tags']) ? $data['tags'] : ''),
+		'PHP_error_number' => (isset($data['PHP_error_number']) ? $data['PHP_error_number'] : ''),
+		'PHP_error_string' => (isset($data['PHP_error_string']) ? $data['PHP_error_string'] : ''),
+		'PHP_error_file' => (isset($data['PHP_error_file']) ? $data['PHP_error_file'] : ''),
+		'PHP_error_errline' => (isset($data['PHP_error_errline']) ? $data['PHP_error_errline'] : '')
+	);
+
+	// write the new log entry (to a new file if necessary, active file has generic name, archived files are named with the current date based on server timezone)
+	// write operation is self contained in file_put_contents and closes the file, so it's available for other concurrent requests to write to after
+	$todayLogFile = $formulizeLogFileLocation.'/'.'formulize_log_'.date('Y-m-d').'.log';
+	$yesterdayLogFile = $formulizeLogFileLocation.'/'.'formulize_log_'.date('Y-m-d', strtotime('-1 day')).'.log';
+	$activeLogFile = $formulizeLogFileLocation.'/'.'formulize_log_active.log';
+	$todayLogFileExists = $todayLogFileExists === null ? file_exists($todayLogFile) : $todayLogFileExists;
+	if(!$todayLogFileExists) {
+		file_put_contents($todayLogFile, '', LOCK_EX);
+		rename($activeLogFile, $yesterdayLogFile);
+	}
+	return file_put_contents($activeLogFile, json_encode($data, JSON_NUMERIC_CHECK)."\n", FILE_APPEND | LOCK_EX);
+}


### PR DESCRIPTION
When users enter a URL for a specific entry, and the entry is not valid, because it doesn't exist or because they don't have permission, we should shunt them to the parent page if possible.

This happens slightly differently if there is an rewriteAddress in effect. In that case, we just send them to the list-ish screen associated with the base rewriteAddress, if the address is shared between screens. Otherwise, default list screen.

If there is no rewriteAddress, then we will use the done destination, or if none specified then deduce the done destination from the current URL.

Also, remove the entry identifier from the URL if it was invalid.