### PR TITLE
BUGFIX: Config-as-code decimal values weren't applied correctly

### DIFF
--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -109,7 +109,7 @@ class formulizeElement extends FormulizeObject {
 			$defaultTypeSize = '';
 		}
 		//define array and return type and size
-		return array("dataType" => $defaultType, "dataTypeSize" => $defaultTypeSize, "dataTypeString" => $defaultTypeComplete);
+		return array("dataType" => $defaultType, "dataTypeSize" => $defaultTypeSize, "dataTypeCompleteString" => $defaultTypeComplete);
 
 	}
 

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -109,7 +109,7 @@ class formulizeElement extends FormulizeObject {
 			$defaultTypeSize = '';
 		}
 		//define array and return type and size
-		return array("dataType" => $defaultType, "dataTypeSize" => $defaultTypeSize);
+		return array("dataType" => $defaultType, "dataTypeSize" => $defaultTypeSize, "dataTypeString" => $defaultTypeComplete);
 
 	}
 

--- a/modules/formulize/include/formulizeConfigSync.php
+++ b/modules/formulize/include/formulizeConfigSync.php
@@ -223,8 +223,7 @@ class FormulizeConfigSync
 			$preparedElement = $this->prepareElementForDb($element, $eleOrder);
 			$configMetadata = [
 				'form_handle' => $formHandle,
-				'data_type' => $element['metadata']['data_type'],
-				'data_type_size' => $element['metadata']['data_type_size'] ?? "",
+				'data_type' => $element['metadata']['data_type']
 			];
 
 			if (!$dbElement) {
@@ -237,8 +236,7 @@ class FormulizeConfigSync
 
 			$dbMetadata = [
 				'form_handle' => $formHandle,
-				'data_type' => $formulizeDbElementDataType['dataType'],
-				'data_type_size' => $formulizeDbElementDataType['dataTypeSize'],
+				'data_type' => $formulizeDbElementDataType['dataTypeString']
 			];
 
 			// Compare the element fields
@@ -342,12 +340,6 @@ class FormulizeConfigSync
 			$differences['data_type'] = [
 				'config_value' => $configMetadata['data_type'],
 				'db_value' => $dbMetadata['data_type']
-			];
-		}
-		if ($dbMetadata['data_type_size'] !== $configMetadata['data_type_size']) {
-			$differences['data_type_size'] = [
-				'config_value' => $configMetadata['data_type_size'],
-				'db_value' => $dbMetadata['data_type_size']
 			];
 		}
 
@@ -518,7 +510,7 @@ class FormulizeConfigSync
 	{
 		$table = $this->getTableForType($change['type']);
 		$primaryKey = $this->getPrimaryKeyForType($change['type']);
-		$dataType = $this->generateDataTypeString($change['metadata']['data_type'], $change['metadata']['data_type_size']);
+		$dataType = $change['metadata']['data_type'];
 
 		switch ($change['operation']) {
 			case 'create':
@@ -760,8 +752,7 @@ class FormulizeConfigSync
 		}
 		// Add element Metadata
 		$preparedElement['metadata'] = [
-			'data_type' => $elementDataType['dataType'],
-			'data_type_size' => $elementDataType['dataTypeSize']
+			'data_type' => $elementDataType['dataTypeString']
 		];
 		// Remove not needed fields
 		unset($preparedElement['id_form']);

--- a/modules/formulize/include/formulizeConfigSync.php
+++ b/modules/formulize/include/formulizeConfigSync.php
@@ -518,7 +518,7 @@ class FormulizeConfigSync
 	{
 		$table = $this->getTableForType($change['type']);
 		$primaryKey = $this->getPrimaryKeyForType($change['type']);
-		$dataType = $change['metadata']['data_type_size'] ? "{$change['metadata']['data_type']}({$change['metadata']['data_type_size']})" : $change['metadata']['data_type'];
+		$dataType = $this->generateDataTypeString($change['metadata']['data_type'], $change['metadata']['data_type_size']);
 
 		switch ($change['operation']) {
 			case 'create':
@@ -841,5 +841,22 @@ class FormulizeConfigSync
 			default:
 				throw new \Exception("Unknown configuration type: {$type}");
 		}
+	}
+
+	/**
+	 * Generate a data type string
+	 * @param string $dataType
+	 * @param string $dataTypeSize
+	 * @return string
+	 */
+	private function generateDataTypeString($dataType, $dataTypeSize = ""): string
+	{
+		if (!$dataTypeSize) {
+			return $dataType;
+		}
+		if ($dataType == 'decimal') {
+			return "{$dataType}(11,$dataTypeSize)";
+		}
+		return "{$dataType}({$dataTypeSize})";
 	}
 }

--- a/modules/formulize/include/formulizeConfigSync.php
+++ b/modules/formulize/include/formulizeConfigSync.php
@@ -236,7 +236,7 @@ class FormulizeConfigSync
 
 			$dbMetadata = [
 				'form_handle' => $formHandle,
-				'data_type' => $formulizeDbElementDataType['dataTypeString']
+				'data_type' => $formulizeDbElementDataType['dataTypeCompleteString']
 			];
 
 			// Compare the element fields
@@ -752,7 +752,7 @@ class FormulizeConfigSync
 		}
 		// Add element Metadata
 		$preparedElement['metadata'] = [
-			'data_type' => $elementDataType['dataTypeString']
+			'data_type' => $elementDataType['dataTypeCompleteString']
 		];
 		// Remove not needed fields
 		unset($preparedElement['id_form']);

--- a/modules/formulize/include/formulizeConfigSync.php
+++ b/modules/formulize/include/formulizeConfigSync.php
@@ -833,21 +833,4 @@ class FormulizeConfigSync
 				throw new \Exception("Unknown configuration type: {$type}");
 		}
 	}
-
-	/**
-	 * Generate a data type string
-	 * @param string $dataType
-	 * @param string $dataTypeSize
-	 * @return string
-	 */
-	private function generateDataTypeString($dataType, $dataTypeSize = ""): string
-	{
-		if (!$dataTypeSize) {
-			return $dataType;
-		}
-		if ($dataType == 'decimal') {
-			return "{$dataType}(11,$dataTypeSize)";
-		}
-		return "{$dataType}({$dataTypeSize})";
-	}
 }


### PR DESCRIPTION
When an element type is `decimal` the result of `$elementObject->getDataTypeInformation()` will only return the decimal portion of the full configuration type (e.g. `decimal(11,2)` will return `decimal` and `2` as values. As a result when we send the dataType for applying configuration changes that included decimal values  we weren't sending the correct information.

The `getDataTypeInformation` has now been updated to include the raw string value as an additional key in the return array so we can use it directly with our configuration management.