### PR TITLE
Adding option for how many rows to display at once in subform interfaces

### DIFF
--- a/modules/formulize/class/templateScreen.php
+++ b/modules/formulize/class/templateScreen.php
@@ -179,7 +179,7 @@ class formulizeTemplateScreenHandler extends formulizeScreenHandler {
                 print "
                     <script>function xoopsFormValidate_formulize_mainform(leave, myform){return true;}</script>
                     <style> #savingmessage { display: none !important; } </style>".
-                    drawJavascript().
+                    drawJavascript(entryId: $entry_id, screen: $screen).
                     "<div id='formulizeform' style='display: none;'><form id='formulize_mainform' name='formulize_mainform' action='$doneDestination' method='post'>".
                     writeHiddenSettings($settings, null, array($screen->getVar('fid')=>array($entry_id)), array(), $screen).
                     "</form></div>

--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -362,18 +362,43 @@ function renderElement($elementObject, $entryId, $frid, $screenObject) {
 		// figure out what we've got on our hands to render
 		$breakClass = 'head';
 		$entryForDEElements = (is_numeric($entryId) AND $entryId) ? $entryId : 'new';
-		if($elementObject->getVar('ele_type') == "ib") {
+		$renderedElementMarkupName = 'de_'.$elementObject->getVar('id_form').'_'.$entryForDEElements.'_'.$elementObject->getVar('ele_id');
+		$elementType = $elementObject->getVar('ele_type');
+
+		if($elementType == "ib") {
 			$elementContents = "<div class=\"formulize-text-for-display\">" . trans(stripslashes($form_ele[0])) . "</div>";
 			$breakClass = $form_ele[1];
-		} elseif($elementObject->getVar('ele_type') == "grid") {
+
+		} elseif($elementType == "grid") {
 			$elementContents = renderGrid($elementObject, $entryForDEElements); // won't take into account the existing entry's saved values or the screen config when rendering the consituent elements, but probably doesn't matter.
+
+
+		// CONDITIONAL SUBFORMS DON'T WORK WHEN SUBFORM IS SET TO ACCORDIONS! JS won't kick in if element is not visible at initial pageload (because of document ready around the instantiation of the accordion section?
+		} elseif($elementType == "subform") {
+			$elementContents = "";
+			if(elementIsAllowedForUserInEntry($elementObject, $entryId)) {
+				global $xoopsUser;
+				$ele_value = $elementObject->getVar('ele_value');
+				$uid = is_object($xoopsUser) ? $xoopsUser->getVar('uid') : 0;
+				$groups = $xoopsUser ? $xoopsUser->getGroups() : array(0=>XOOPS_GROUP_ANONYMOUS);
+				$owner = getEntryOwner($entryId, $elementObject->getVar('id_form'));
+				$customCaption = $elementObject->getVar('ele_caption');
+				$customElements = $ele_value[1] ? explode(",", $ele_value[1]) : "";
+				$subUICols = drawSubLinks($ele_value[0], array($ele_value[0] => array()), $uid, $groups, $_GET['frid'], getFormulizeModId(), $elementObject->getVar('id_form'), $entryId, $customCaption, $customElements, $ele_value[2], $ele_value[3], $ele_value[4], $ele_value[5], $owner, $ele_value[6], $ele_value[7], $elementObject->getVar('ele_id'), $ele_value[8], $ele_value[9], $elementObject);
+				if(isset($subUICols['single'])) {
+					$elementContents = $subUICols['single'];
+					$breakClass = "even";
+				} else {
+					$elementContents = new XoopsFormLabel($subUICols['c1'], $subUICols['c2'], $renderedElementMarkupName);
+				}
+			}
 		}
 
 		// render the element
 		if(is_object($elementContents)) {
 			$html = $form->_drawElementElementHTML($elementContents);
 		} else {
-			$form->insertBreakFormulize($elementContents, $breakClass, 'de_'.$elementObject->getVar('id_form').'_'.$entryForDEElements.'_'.$elementObject->getVar('ele_id'), $elementObject->getVar("ele_handle"));
+			$form->insertBreakFormulize($elementContents, $breakClass, $renderedElementMarkupName, $elementObject->getVar("ele_handle"));
 			$hidden = '';
 			$html = '';
 			list($html, $hidden) = $form->_drawElements($form->getElements(), $html, $hidden);

--- a/modules/formulize/include/common.php
+++ b/modules/formulize/include/common.php
@@ -65,3 +65,5 @@ if (file_exists(XOOPS_ROOT_PATH . "/modules/formulize/language/".$xoopsConfig['l
 }
 
 formulize_handleHtaccessRewriteRule();
+
+$GLOBALS['formulize_subformInstance'] = 100;

--- a/modules/formulize/include/elementdisplay.php
+++ b/modules/formulize/include/elementdisplay.php
@@ -419,8 +419,7 @@ function checkElementConditions($elementFilterSettings, $form_id, $entry) {
 	}
 
 	// setup evaluation condition as PHP and then eval it so we know if we should include this element or not
-	$evaluationCondition = "\$passedCondition = false;\n";
-	$evaluationCondition .= "if(";
+	$evaluationCondition = "if(";
 
 	$evaluationConditionAND = buildEvaluationCondition("AND",$filterElementsAll,$filterElements,$filterOps,$filterTerms,$entry,$entryData);
 	$evaluationConditionOR = buildEvaluationCondition("OR",$filterElementsOOM,$filterElements,$filterOps,$filterTerms,$entry,$entryData);
@@ -438,6 +437,7 @@ function checkElementConditions($elementFilterSettings, $form_id, $entry) {
 	$evaluationCondition .= "  \$passedCondition = true;\n";
 	$evaluationCondition .= "}\n";
 
+	$passedCondition = false;
 	eval($evaluationCondition);
 
 	$allowed = 1;

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -959,7 +959,7 @@ function displayEntries($formframe, $mainform="", $loadview="", $loadOnlyView=0,
 	 */
 
 	//formulize_benchmark("after generating calcs/before creating pagenav");
-	list($formulize_LOEPageNav, $formulize_LOEEntryCount, $entriesPerPageSelector) = formulize_LOEbuildPageNav($data, $screen, $regeneratePageNumbers);
+	list($formulize_LOEPageNav, $formulize_LOEEntryCount, $entriesPerPageSelector) = formulize_LOEbuildPageNav($screen, $regeneratePageNumbers);
 	//formulize_benchmark("after nav/before interface");
 
 	ob_start();
@@ -4434,11 +4434,7 @@ function formulize_gatherDataSet($settings, $searches, $sort, $order, $frid, $fi
 }
 
 // THIS FUNCTION CALCULATES THE NUMBER OF PAGES AND DRAWS HTML FOR NAVIGATING THEM
-function formulize_LOEbuildPageNav($data, $screen, $regeneratePageNumbers) {
-	if(!is_array($data)) {
-		// $data can now be a flag that says "Limit Reached"
-		$data = array();
-	}
+function formulize_LOEbuildPageNav($screen, $regeneratePageNumbers) {
 
     // setup default navigation - and in Anari theme, put in a hack to extend the height of the scrollbox if necessary -- need to rebuild markup for list so this kind of thing is not necessary!
     $pageNav = "";
@@ -4458,11 +4454,11 @@ function formulize_LOEbuildPageNav($data, $screen, $regeneratePageNumbers) {
     }
 
 	$numberPerPage = is_object($screen) ? $screen->getVar('entriesperpage') : 10;
-    $numberPerPage = (isset($_POST['formulize_entriesPerPage']) AND intval($_POST['formulize_entriesPerPage']) > 0) ? intval($_POST['formulize_entriesPerPage']) : $numberPerPage;
+ 	$numberPerPage = (isset($_POST['formulize_entriesPerPage']) AND intval($_POST['formulize_entriesPerPage']) > 0) ? intval($_POST['formulize_entriesPerPage']) : $numberPerPage;
 
 	// regenerate essentially causes the user to jump back to page 0 because something about the dataset has fundamentally changed (like a new search term or something)
 	$currentPage = (isset($_POST['formulize_LOEPageStart']) AND !$regeneratePageNumbers) ? intval($_POST['formulize_LOEPageStart']) : 0;
-    $userPageNumber = $currentPage > 0 ? ($currentPage / $numberPerPage) + 1 : 1;
+ 	$userPageNumber = $currentPage > 0 ? ($currentPage / $numberPerPage) + 1 : 1;
 
     $lastEntryNumber = $numberPerPage > 0 ? $numberPerPage*($userPageNumber) : $GLOBALS['formulize_countMasterResultsForPageNumbers'];
     $lastEntryNumber = $lastEntryNumber > $GLOBALS['formulize_countMasterResultsForPageNumbers'] ? $GLOBALS['formulize_countMasterResultsForPageNumbers'] : $lastEntryNumber;
@@ -4510,29 +4506,9 @@ function formulize_LOEbuildPageNav($data, $screen, $regeneratePageNumbers) {
             $lastDisplayPage = $pageNumbers;
         }
 
-        $pageNav = "<p></p><div class=\"formulize-page-navigation\"><span class=\"page-navigation-label\">". $entriesPerPageSelector."</span>";
-        if ($currentPage > 1) {
-            $pageNav .= "<a href=\"\" class=\"page-navigation-prev\" onclick=\"javascript:pageJump('".($currentPage - $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_PREVIOUS."</a>";
-        }
-        if($firstDisplayPage > 1) {
-            $pageNav .= "<a href=\"\" onclick=\"javascript:pageJump('0');return false;\">1</a><span class=\"page-navigation-skip\">—</span>";
-        }
-        for($i = $firstDisplayPage; $i <= $lastDisplayPage; $i++) {
-            $thisPageStart = ($i * $numberPerPage) - $numberPerPage;
-            if($thisPageStart == $currentPage) {
-                $pageNav .= "<a href=\"\" class=\"page-navigation-active\" onclick=\"javascript:pageJump('$thisPageStart');return false;\">$i</a>";
-            } else {
-                $pageNav .= "<a href=\"\" onclick=\"javascript:pageJump('$thisPageStart');return false;\">$i</a>";
-            }
-        }
-        if($lastDisplayPage < $pageNumbers) {
-            $lastPageStart = ($pageNumbers * $numberPerPage) - $numberPerPage;
-            $pageNav .= "<span class=\"page-navigation-skip\">—</span><a href=\"\" onclick=\"javascript:pageJump('$lastPageStart');return false;\">" . $pageNumbers . "</a>";
-        }
-        if ($currentPage < ($GLOBALS['formulize_countMasterResultsForPageNumbers'] - $numberPerPage)) {
-            $pageNav .= "<a href=\"\" class=\"page-navigation-next\" onclick=\"javascript:pageJump('".($currentPage + $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_NEXT."</a>";
-        }
-        $pageNav .= "</div>";
+				$jsFunctionName = 'pageJump';
+				$pageNav = formulize_buildPageNavMarkup($jsFunctionName, $numberPerPage, $currentPage, $firstDisplayPage, $lastDisplayPage, $pageNumbers, $entriesPerPageSelector);
+
     }
 
 	return array($pageNav,$entryTotals,$entriesPerPageSelector);

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -1826,14 +1826,13 @@ function drawSubLinks($subform_id, $sub_entries, $uid, $groups, $frid, $mid, $fi
     list($elementq, $element_to_write, $value_to_write, $value_source, $value_source_form, $alt_element_to_write) = formulize_subformSave_determineElementToWrite($frid, $fid, $entry, $target_sub_to_use);
 
     if (0 == strlen($element_to_write)) {
-        error_log("Relationship $frid for subform $subform_id on form $fid is invalid.");
+        error_log("Relationship $frid does not include subform $subform_id, when displaying the main form $fid.");
         $to_return = array("c1"=>"", "c2"=>"", "sigle"=>"");
         if (is_object($xoopsUser) and in_array(XOOPS_GROUP_ADMIN, $xoopsUser->getGroups())) {
             if (0 == $frid) {
                 $to_return['single'] = "This subform cannot be shown because no relationship is active.";
             } else {
-                $to_return['single'] = "This subform cannot be shown because relationship $frid for subform ".
-                    "$subform_id on form $fid is invalid.";
+                $to_return['single'] = "This subform interface cannot be shown because the the form to be displayed (id: $subform_id) is not part of the active relationship (id: $frid). Check if the active screen is using the relationship, or just \"the form only.\", and check whether the relationship includes all the forms it should.";
             }
         }
         return $to_return;

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8734,6 +8734,8 @@ function formulize_buildPageNavMarkup($jsFunctionName, $numberPerPage, $currentP
 	$pageNav .= $entriesPerPageSelector ? "<span class=\"page-navigation-label\">". $entriesPerPageSelector."</span>" : "";
 	if ($currentPageFirstRecord > 1) {
 		$pageNav .= "<a href=\"\" class=\"page-navigation-prev\" onclick=\"javascript:$jsFunctionName('".($currentPageFirstRecord - $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_PREVIOUS."</a>";
+	} else {
+				$pageNav .= "<span>"._AM_FORMULIZE_LOE_PREVIOUS."</span>";
 	}
 	if($firstDisplayPage > 1) {
 		$pageNav .= "<a href=\"\" onclick=\"javascript:$jsFunctionName('0');return false;\">1</a><span class=\"page-navigation-skip\">—</span>";
@@ -8752,6 +8754,8 @@ function formulize_buildPageNavMarkup($jsFunctionName, $numberPerPage, $currentP
 	}
 	if ($currentPageFirstRecord < $lastPageStart) {
 		$pageNav .= "<a href=\"\" class=\"page-navigation-next\" onclick=\"javascript:$jsFunctionName('".($currentPageFirstRecord + $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_NEXT."</a>";
+	} else {
+		$pageNav .= "<span>"._AM_FORMULIZE_LOE_NEXT."</span>";
 	}
 	$pageNav .= "</div>";
 	return $pageNav;

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -6225,8 +6225,8 @@ function _buildConditionsFilterSQL($filterId, &$filterOps, &$filterTerms, $filte
         // so we can build this odd comparison value that repeats the "handle op" part internally, to catch all the cases for checkboxes. Ugh.
         if($multiValueSearchMetadata = mustMatchOneOfMultiplePossibleValuesInElement($filterElementObject, $filterOps[$filterId])) {
             $useAndOr = $multiValueSearchMetadata['andOr'];
-            $filterOps[$filterId] = $multiValueSearchMetadata['operator'];    
-            $conditionsFilterComparisonValue = " \"%*=+*:".formulize_db_escape($filterTerms[$filterId])."*=+*:%\" $useAndOr ".$filterElementObject->getVar('ele_handle')." ".$filterOps[$filterId]." \"%*=+*:".formulize_db_escape($filterTerms[$filterId])."\" ";        
+            $filterOps[$filterId] = $multiValueSearchMetadata['operator'];
+            $conditionsFilterComparisonValue = " \"%*=+*:".formulize_db_escape($filterTerms[$filterId])."*=+*:%\" $useAndOr ".$filterElementObject->getVar('ele_handle')." ".$filterOps[$filterId]." \"%*=+*:".formulize_db_escape($filterTerms[$filterId])."\" ";
         } else {
             $conditionsFilterComparisonValue = $quotes.$likebits.formulize_db_escape($filterTerms[$filterId]).$likebits.$quotes;
         }
@@ -8705,7 +8705,7 @@ function mustMatchOneOfMultiplePossibleValuesInElement($elementIdentifier, $oper
         return $returnValue;
     }
     $allowableOperators = array('=', '!=', '<=>', 'LIKE', 'NOT LIKE');
-    if($element->canHaveMultipleValues 
+    if($element->canHaveMultipleValues
       AND !$element->isLinked
       AND in_array($operator, $allowableOperators)) {
           $returnValue = array(
@@ -8714,4 +8714,46 @@ function mustMatchOneOfMultiplePossibleValuesInElement($elementIdentifier, $oper
       );
     }
     return $returnValue;
+}
+
+/**
+ * Create the markup for the page selector used at the bottom of lists of entries, and on subform elements that page paging
+ * @param string jsFunctionname - the name of the javascript function to trigger when the user clicks on a page number
+ * @param int numberPerPage - the number of entries per page
+ * @param int currentPageFirstRecord - the ordinal number of the first record on the current page, ie: 11 if there are five entries per page and the current page is 3
+ * @param int firstDisplayPage - the first number that is shown in the pager, if the user is deep into a long series of pages, this won't be 1
+ * @param int lastDisplayPage - the last number that is shown in the pager, if the user is in the middle of a long series of pages, this won't be the last page
+ * @param int numberOfPages - the total number of pages, will be equal to the readable number of the last page
+ * @param string entriesPerPageSelector - the markup for the entries per page selector, only used by lists of entries
+ * @return string The markup for the pager
+ */
+
+function formulize_buildPageNavMarkup($jsFunctionName, $numberPerPage, $currentPageFirstRecord, $firstDisplayPage, $lastDisplayPage, $numberOfPages, $entriesPerPageSelector=null) {
+
+	$pageNav = "<div class=\"formulize-page-navigation\">";
+	$pageNav .= $entriesPerPageSelector ? "<span class=\"page-navigation-label\">". $entriesPerPageSelector."</span>" : "";
+	if ($currentPageFirstRecord > 1) {
+		$pageNav .= "<a href=\"\" class=\"page-navigation-prev\" onclick=\"javascript:$jsFunctionName('".($currentPageFirstRecord - $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_PREVIOUS."</a>";
+	}
+	if($firstDisplayPage > 1) {
+		$pageNav .= "<a href=\"\" onclick=\"javascript:$jsFunctionName('0');return false;\">1</a><span class=\"page-navigation-skip\">—</span>";
+	}
+	for($i = $firstDisplayPage; $i <= $lastDisplayPage; $i++) {
+		$thisPageStart = ($i * $numberPerPage) - $numberPerPage;
+		if($thisPageStart == $currentPageFirstRecord) {
+			$pageNav .= "<a href=\"\" class=\"page-navigation-active\" onclick=\"javascript:$jsFunctionName('$thisPageStart');return false;\">$i</a>";
+		} else {
+			$pageNav .= "<a href=\"\" onclick=\"javascript:$jsFunctionName('$thisPageStart');return false;\">$i</a>";
+		}
+	}
+	$lastPageStart = ($numberOfPages * $numberPerPage) - $numberPerPage;
+	if($lastDisplayPage < $numberOfPages) {
+		$pageNav .= "<span class=\"page-navigation-skip\">—</span><a href=\"\" onclick=\"javascript:$jsFunctionName('$lastPageStart');return false;\">" . $numberOfPages . "</a>";
+	}
+	if ($currentPageFirstRecord < $lastPageStart) {
+		$pageNav .= "<a href=\"\" class=\"page-navigation-next\" onclick=\"javascript:$jsFunctionName('".($currentPageFirstRecord + $numberPerPage)."');return false;\">"._AM_FORMULIZE_LOE_NEXT."</a>";
+	}
+	$pageNav .= "</div>";
+	return $pageNav;
+
 }

--- a/modules/formulize/include/js/conditional.js
+++ b/modules/formulize/include/js/conditional.js
@@ -98,23 +98,23 @@ function conditionalHTMLHasChanged(handle, data) {
 }
 
 function checkCondition(relevantElementSet, elementValuesForURL) {
-    var oneToOneAdded = false;
-    var elementIds = '';
-    var elementIdsSep = '';
-    for(k in relevantElementSet) {
-        conditionalCheckInProgress = conditionalCheckInProgress + 1;
-        var markupHandle = relevantElementSet[k];
+	var oneToOneAdded = false;
+	var elementIds = '';
+	var elementIdsSep = '';
+	for(k in relevantElementSet) {
+		conditionalCheckInProgress = conditionalCheckInProgress + 1;
+		var markupHandle = relevantElementSet[k];
 		partsArray = markupHandle.split('_');
-        elementIds = elementIds + elementIdsSep + partsArray[3];
-        entryId = partsArray[2]; // assuming all the same!
-        fid = partsArray[1]; // assuming all the same!
-        if(oneToOneAdded == false && oneToOneElements[markupHandle]['onetoonefrid'] && partsArray[1] != oneToOneElements[markupHandle]['onetoonefid']) {
-            elementValuesForURL = elementValuesForURL + '&onetoonekey=1&onetoonefrid='+oneToOneElements[markupHandle]['onetoonefrid']+'&onetoonefid='+oneToOneElements[markupHandle]['onetoonefid']+'&onetooneentries='+oneToOneElements[markupHandle]['onetooneentries']+'&onetoonefids='+oneToOneElements[markupHandle]['onetoonefids'];
-            oneToOneAdded = true;
-        }
-        elementIdsSep = ',';
-    }
-	return jQuery.post(FORMULIZE.XOOPS_URL+"/modules/formulize/formulize_xhr_responder.php?uid="+FORMULIZE.XOOPS_UID+"&sid="+FORMULIZE.SCREEN_ID+"&op=get_element_row_html&elementId="+elementIds+"&entryId="+entryId+"&fid="+fid+elementValuesForURL);
+		elementIds = elementIds + elementIdsSep + partsArray[3];
+		entryId = partsArray[2]; // assuming all the same!
+		fid = partsArray[1]; // assuming all the same!
+		if(oneToOneAdded == false && oneToOneElements[markupHandle]['onetoonefrid'] && partsArray[1] != oneToOneElements[markupHandle]['onetoonefid']) {
+				elementValuesForURL = elementValuesForURL + '&onetoonekey=1&onetoonefrid='+oneToOneElements[markupHandle]['onetoonefrid']+'&onetoonefid='+oneToOneElements[markupHandle]['onetoonefid']+'&onetooneentries='+oneToOneElements[markupHandle]['onetooneentries']+'&onetoonefids='+oneToOneElements[markupHandle]['onetoonefids'];
+				oneToOneAdded = true;
+		}
+		elementIdsSep = ',';
+	}
+	return jQuery.post(FORMULIZE.XOOPS_URL+"/modules/formulize/formulize_xhr_responder.php?uid="+FORMULIZE.XOOPS_UID+"&sid="+FORMULIZE.SCREEN_ID+"&op=get_element_row_html&elementId="+elementIds+"&entryId="+entryId+"&fid="+fid+"&frid="+FORMULIZE.FRID+elementValuesForURL);
 }
 
 function getRelevantElementValues(elements) {

--- a/modules/formulize/initialize.php
+++ b/modules/formulize/initialize.php
@@ -41,7 +41,7 @@ if (file_exists(XOOPS_ROOT_PATH.'/class/mail/phpmailer/class.phpmailer.php'))
 $GLOBALS['formulize_asynchronousFormDataInDatabaseReadyFormat'] = array();
 $GLOBALS['formulize_asynchronousFormDataInAPIFormat'] = array();
 
-$GLOBALS['formulize_subformInstance'] = 100;
+include_once XOOPS_ROOT_PATH.'/modules/formulize/include/common.php';
 
 $GLOBALS['formulize_displayingMultipageScreen'] = false; // later, will be set to the screen id if we're displaying a multipage screen, or just true if we're displaying a multipage form without a screen specified
 

--- a/modules/formulize/language/english/admin.php
+++ b/modules/formulize/language/english/admin.php
@@ -43,7 +43,7 @@ define("_AM_HOME_CONFIRMLOCKDOWN","Are you sure you want to lockdown this form? 
 define("_AM_HOME_APP_CONFIG","Configure this application and the relationships of its forms");
 define("_AM_HOME_APP_DELETE","Delete this application");
 define("_AM_HOME_APP_DESC","To assign a form to an application, look on the Settings tab when configuring the form.");
-define("_AM_HOME_APP_RELATION","Configure relationships (frameworks) for these forms");
+define("_AM_HOME_APP_RELATION","Configure relationships for these forms");
 define("_AM_HOME_GOBACKTO","Go Back to ");
 define("_AM_HOME_SAVECHANGES","Save your changes");
 define("_AM_HOME_WARNING_UNSAVED","You have unsaved changes!");
@@ -349,9 +349,9 @@ define("_AM_ELE_SUBFORM_FORM", "Which form do you want to include as a subform?"
 define("_AM_ELE_SUBFORM_IFFORM", "Screen for displaying each entry:");
 define("_AM_ELE_SUBFORM_SCREEN", "Which screen should be used to display each entry?");
 define("_AM_ELE_SUBFORM_SCREEN_HELP", "The screen will be used for subform entries displayed as a form, or for displaying the entry in a row when its view button is clicked.");
-define("_AM_ELE_SUBFORM", "Subform (from a form framework)");
-define("_AM_ELE_SUBFORM_DESC", "When you display the current form as part of a framework, the subform interface can be included in the form.  The subform interface allows users to create and modify entries in a related subform without leaving the main form.  The list here shows all the possible subforms from all frameworks that this form is part of.");
-define("_AM_ELE_SUBFORM_NONE", "No subforms available - define a framework first");
+define("_AM_ELE_SUBFORM", "Subform (from a Relationship)");
+define("_AM_ELE_SUBFORM_DESC", "When you display the current form as part of a Relationship, the subform interface can be included in the form.  The subform interface allows users to create and modify entries in a related subform without leaving the main form.  The list here shows all the possible subforms from all Relationships that this form is part of.");
+define("_AM_ELE_SUBFORM_NONE", "No subforms available - define a Relationship first");
 define("_AM_ELE_SUBFORM_ELEMENTS", "Element options");
 define("_AM_ELE_SUBFORM_ELEMENT_LIST", "Choose the elements to show in the row, or to use as the heading if you're showing the full form");
 define("_AM_ELE_SUBFORM_ELEMENTS_DESC", "When displayed in a row, about three or four elements from the subform can be displayed comfortably as part of the main form.  More than four elements starts to make the interface cluttered.  You can choose which elements you want to display by selecting them from this list.  Users can always modify all elements by clicking a button next to each subform entry that it listed in the main form. <b>You do not need to choose the element that joins the subform to the mainform; Formulize will automatically populate that element with the correct values for you.</b>");
@@ -399,7 +399,7 @@ define("_AM_ELE_GRID_START_DESC", "Each table will have a number of elements in 
 // derived columns
 define("_AM_ELE_DERIVED", "Value derived from other elements");
 define("_AM_ELE_DERIVED_CAP", "Formula for generating values in this element");
-define("_AM_ELE_DERIVED_DESC", "Select an element above to add it to your formula.  You can also use element ID numbers or Framework handles in your formula, as long as they are inside double quotes.  The formula can have multiple lines, or steps, and you can use PHP code in the formula.  The last line should be of the format <i>\$value = \$something</i> where \$something is the final number or formula that you want use.<br /><br />Example:<br />\$value = \"Number of hits\" / \"Total shots\" * 100<br /><br />Note: only use double quotes (\") to refer to a field.  If you need to use quotes in a line of PHP code, use single quotes (').");
+define("_AM_ELE_DERIVED_DESC", "Select an element above to add it to your formula.  You can also use element ID numbers or Relationship handles in your formula, as long as they are inside double quotes.  The formula can have multiple lines, or steps, and you can use PHP code in the formula.  The last line should be of the format <i>\$value = \$something</i> where \$something is the final number or formula that you want use.<br /><br />Example:<br />\$value = \"Number of hits\" / \"Total shots\" * 100<br /><br />Note: only use double quotes (\") to refer to a field.  If you need to use quotes in a line of PHP code, use single quotes (').");
 define("_AM_ELE_DERIVED_ADD", "Add to Formula");
 define("_AM_ELE_DERIVED_DONE","Finished updating values!");
 define("_AM_ELE_DERIVED_UPDATE", "Update Derived Values");
@@ -471,7 +471,7 @@ define("_AM_VIEW_FORM", "View this form");
 define("_AM_GOTO_PARAMS", "Edit the form's settings");
 define("_AM_PARAMS_EXTRA", "(Specify what elements appear<br>on the <i>View Entries</i> page)");
 define("_AM_GOTO_MAIN", "Return to main page");
-define("_AM_GOTO_MODFRAME", "Back to first<br>Frameworks page");
+define("_AM_GOTO_MODFRAME", "Back to first<br>Relationships page");
 
 define("_AM_CLEAR_DEFAULT", "Clear Default");
 
@@ -567,8 +567,8 @@ define("_AM_FORMULIZE_SCREENTYPE_LISTOFENTRIES", "List of Entries in this Form")
 define("_AM_FORMULIZE_ADD_SCREEN_NOW", "Add it Now!");
 define("_AM_FORMULIZE_SCREEN_FORM", "Create or Modify a Screen");
 define("_AM_FORMULIZE_SCREEN_TITLE", "Title of this screen");
-define("_AM_FORMULIZE_USE_NO_FRAMEWORK", "Use this form only, no Framework");
-define("_AM_FORMULIZE_SELECT_FRAMEWORK", "Framework to use on this screen, if any");
+define("_AM_FORMULIZE_USE_NO_FRAMEWORK", "Use this form only, no Relationship");
+define("_AM_FORMULIZE_SELECT_FRAMEWORK", "Relationship to use on this screen, if any");
 define("_AM_FORMULIZE_SCREEN_SECURITY", "Use the XOOPS security token on this screen?");
 define("_AM_FORMULIZE_SCREEN_SECURITY_DESC", "The XOOPS security token is a defense against cross-site scripting attacks.  However, it can cause problems if you are using an advanced Ajax-based UI in a List of Entries screen, and possibly other screen types.");
 
@@ -646,8 +646,8 @@ define("_AM_FORMULIZE_SCREEN_LOE_DESC_DEFAULTVIEW", "If you are customizing the 
 define("_AM_FORMULIZE_SCREEN_LOE_LIMITVIEWS", "If the 'Current View' list is in use, include these views:");
 define("_AM_FORMULIZE_SCREEN_LOE_DESC_LIMITVIEWS", "If you include the basic views (\"Entries by...\"), then the selected view will switch to a basic view when the user makes a change, such as a sort or Quicksearch.");
 define("_AM_FORMULIZE_SCREEN_LOE_DEFAULTVIEWLIMIT", "Include all views");
-define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_IN_FRAME", "only avail. in framework: ");
-define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_NO_FRAME", "only avail. with no framework");
+define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_IN_FRAME", "only avail. in Relationship: ");
+define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_NO_FRAME", "only avail. with no Relationship");
 define("_AM_FORMULIZE_SCREEN_LOE_DESC_LEAVEBLANK", "Leave blank to turn this button off");
 define("_AM_FORMULIZE_SCREEN_LOE_DESC_LEAVEBLANK_LIST", "Leave blank to turn off the list");
 define("_AM_FORMULIZE_SCREEN_LOE_NOPUBDVIEWS", "There are no published views for this form");
@@ -755,7 +755,7 @@ define("_AM_FORMULIZE_SCREEN_LOE_DESC_SEEDTEMPLATES3", "Customize the Templates"
 define("_AM_FORMULIZE_SCREEN_LOE_BOTTOMTEMPLATE", "Template for the bottom portion of the page, below the list:");
 define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE", "Template for each entry in the list portion of the page:");
 define("_AM_FORMULIZE_SCREEN_LOE_DESC_LISTTEMPLATE", "If you specify a List Item Template, certain buttons and configuration options mentioned above may be unavailable.");
-define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FRAMEWORK", "Below is a list of handles for all the form elements in this Framework.  Use them with the <i>display</i> function.<br><br>Use \"<i>\$entry_id</i>\" to refer to the main form's entry id number.<br><br>Use \"<i>\$form_id</i>\" to refer to the id number of the main form.");
+define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FRAMEWORK", "Below is a list of handles for all the form elements in this Relationship.  Use them with the <i>display</i> function.<br><br>Use \"<i>\$entry_id</i>\" to refer to the main form's entry id number.<br><br>Use \"<i>\$form_id</i>\" to refer to the id number of the main form.");
 define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FORM", "Below is a list of element data handles for all the elements in this form. Use them with the <i>display</i> function.<br><br>Use \"<i>\$entry_id</i>\" to refer to the entry id number.<br><br>Use \"<i>\$form_id</i>\" to refer to the form id number.");
 
 define("_AM_FORMULIZE_SCREEN_LOE_DISPLAY_ONLY_COLUMNS", "Display only these columns");

--- a/modules/formulize/language/french/admin.php
+++ b/modules/formulize/language/french/admin.php
@@ -38,7 +38,7 @@ define("_AM_HOME_CONFIRMLOCKDOWN","Etes vous sur de vouloir verrouiller ce formu
 define("_AM_HOME_APP_CONFIG","Configurer ce regroupement ainsi que les inter relations entre les formulaires y figurant");
 define("_AM_HOME_APP_DELETE","Effacer ce regroupement");
 define("_AM_HOME_APP_DESC","Pour mettre un formulaire dans un regroupement, regardez dans les réglages du formulaire.");
-define("_AM_HOME_APP_RELATION","Configurer les inter-relations (frameworks) pour ces formulaires");
+define("_AM_HOME_APP_RELATION","Configurer les inter-relations pour ces formulaires");
 define("_AM_HOME_GOBACKTO","Retourner sur ");
 define("_AM_HOME_SAVECHANGES","Sauver modifications");
 define("_AM_HOME_WARNING_UNSAVED","Vous avez des changements non sauvegardés!");
@@ -220,7 +220,7 @@ define("_AM_FORMULIZE_SCREEN_SECURITY_DESC", "La sécurité XOOPS est une défen
 define("_AM_ELE_DERIVED", "Valeur dérivée venant d'autres éléments (calculs...)");
 define("_AM_ELE_DERIVED_ADD", "Ajouter à la formule");
 define("_AM_ELE_DERIVED_CAP", "Formule pour générer des valeurs dans cet élément");
-define("_AM_ELE_DERIVED_DESC", "Sélectionner un element ci dessous pour l'ajouter à votre formule.  Vous pouvez aussi utiliser le numéro ID d'un élément ouh d'un Framework dans votre code, tant qu'il est entre les doubles guillemets.  Vous pouvez utiliser un code PHP, avec de multiples lignes.  Format de la dernière ligne obligatoire: <i>\$value = \$something</i> où \$something est le nombre final ou le code que vous souhaitez utiliser.<br /><br />Exemple:<br />\$value = \"Number of hits\" / \"Total shots\" * 100");
+define("_AM_ELE_DERIVED_DESC", "Sélectionner un element ci dessous pour l'ajouter à votre formule.  Vous pouvez aussi utiliser le numéro ID d'un élément ouh d'un inter-relation dans votre code, tant qu'il est entre les doubles guillemets.  Vous pouvez utiliser un code PHP, avec de multiples lignes.  Format de la dernière ligne obligatoire: <i>\$value = \$something</i> où \$something est le nombre final ou le code que vous souhaitez utiliser.<br /><br />Exemple:<br />\$value = \"Number of hits\" / \"Total shots\" * 100");
 define("_AM_ELE_DERIVED_NUMBER_OPTS","Si cette formule produit un nombre ...");
 define("_AM_ELE_DESC","texte descriptif");
 define("_AM_ELE_DESC_HELP","quoique vous tapiez ici, cela apparaitra comme cette ligne de texte le fait.");
@@ -300,9 +300,9 @@ define("_AM_ELE_SEP","Ligne de séparation");
 define("_AM_ELE_SIZE","Taille");
 define("_AM_ELE_SOUL","Souligné");
 // subforms
-define("_AM_ELE_SUBFORM", "Sous formulaire (venant d'un framework de formulaires)");
+define("_AM_ELE_SUBFORM", "Sous formulaire (venant d'un inter-relation de formulaires)");
 define("_AM_ELE_SUBFORM_BLANKS", "How many blank spaces should be shown for this subform when the page first loads?");
-define("_AM_ELE_SUBFORM_DESC", "When you display the current form as part of a framework, the subform interface can be included in the form.  The subform interface allows users to create and modify entries in a related subform without leaving the main form.  The list here shows all the possible subforms from all frameworks that this form is part of.");
+define("_AM_ELE_SUBFORM_DESC", "When you display the current form as part of a Relationship, the subform interface can be included in the form.  The subform interface allows users to create and modify entries in a related subform without leaving the main form.  The list here shows all the possible subforms from all Relationships that this form is part of.");
 define("_AM_ELE_SUBFORM_ELEMENTS", "Which elements should be displayed as part of the subform interface?");
 define("_AM_ELE_SUBFORM_ELEMENTS_DESC", "About three or four elements from the subform can be displayed comfortably as part of the main form.  More than four elements starts to make the interface cluttered.  You can choose which elements you want to display by selecting them from this list.  Users can always modify all elements by clicking a button next to each subform entry that it listed in the main form.<br><br>You do not need to choose the element that joins the subform to the mainform; Formulize will automatically populate that element with the correct values for you.");
 define("_AM_ELE_SUBFORM_FORM", "Quel formulaire voulez vous inclure en tant que sous formulaire?");
@@ -312,7 +312,7 @@ define("_AM_ELE_SUBFORM_HEADINGSORCAPTIONS_HEADINGS", "En-têtes de colonnes (le
 define("_AM_ELE_SUBFORM_IFFORM", "Screen for displaying each entry:");
 define("_AM_ELE_SUBFORM_SCREEN", "Which screen should be used to display each entry?");
 define("_AM_ELE_SUBFORM_SCREEN_HELP", "The screen will be used for subform entries displayed as a form, or for displaying the entry in a row when its view button is clicked.");
-define("_AM_ELE_SUBFORM_NONE", "Pas de sous formulaires valides - définissez d'abord un Framework");
+define("_AM_ELE_SUBFORM_NONE", "Pas de sous formulaires valides - définissez d'abord un inter-relation");
 define("_AM_ELE_SUBFORM_REFRESH", "Refresh elements list to match selected form");
 define("_AM_ELE_SUBFORM_VIEW", "Montrer les boutons<i>Voir</i> a coté de chaque entrée du sous formulaire?");
 define("_AM_ELE_SUBFORM_VIEW_DESC", "The <i>View</i> buttons let users click through to the complete entry in the subform.  This may be useful when only some elements in the subform are visible in the main interface.");
@@ -429,7 +429,7 @@ define("_AM_FORMULIZE_SCREEN_LOE_HIDDENCOLUMNS", "Sélectionnez toutes les colon
 define("_AM_FORMULIZE_SCREEN_LOE_LIMITVIEWS", "If the 'Current View' list is in use, include these views:");
 define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE", "Template for each entry in the list portion of the page:");
 define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FORM", "Below is a list of element IDs for all the elements in this form. Use them with the <i>display</i> function.");
-define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FRAMEWORK", "Below is a list of handles for all the form elements in this Framework.  Use them with the <i>display</i> function.");
+define("_AM_FORMULIZE_SCREEN_LOE_LISTTEMPLATE_HELPINTRO_FRAMEWORK", "Below is a list of handles for all the form elements in this Relationship.  Use them with the <i>display</i> function.");
 define("_AM_FORMULIZE_SCREEN_LOE_NOPUBDVIEWS", "Il n'y a pas de vue publiée pour ce formulaire");
 define("_AM_FORMULIZE_SCREEN_LOE_NOVIEWSAVAIL", "Il n'y a aucune vue disponible");
 define("_AM_FORMULIZE_SCREEN_LOE_REPEATHEADERS", "Si vous utilisez des en-têtes, au bout de combien de lignes doivent-ils se répéter?");
@@ -513,7 +513,7 @@ define("_AM_FORMULIZE_SCREEN_LOE_TEMPLATEINTRO2", "<span style=\"font-weight: no
 </td>
 </tr>
 </table>
-<p>For Quicksearch boxes, use \"\$quickSearch<i>Column</i>\" where <i>Column</i> is either the element ID number, or the element handle if using a Framework.</p>\n<p>For Custom Buttons, use \"\$handle\" where <i>handle</i> is the handle you specified for that button.  You can use \"\$messageText\" to control where the clicked button's message will appear on the screen.  By default, the message appears centred at the top.</p>\n<p>If the current view list is available, you can determine which view was last selected from the list, by checking whether <i>\$The_view_name</i> is true or not.  You can also check <i>\$viewX</i> where X is a number corresponding to the position of the view in the list, 1 through n.  You can use this to put if..else clauses into your template, so it changes depending what view is selected.</p>\n<p><b>List Item Template</b></p>\n<p>If you specify any PHP code for the List Item Template, it will be used to draw in each row of the list.</p>\n<p>You do not need to create a foreach loop or any other loop structure in this template.  The PHP code you specify will be executed inside a loop that runs once for each entry.</p>\n<p>You have full access to XOOPS and Formulize objects, functions, variables and constants in this template, including <i>\$fid</i> for the form ID.  Use \$entry to refer to the current entry in the list.  For example:</p>\n<p style=\"font-family: courier\">&nbsp;&nbsp;&nbsp;display(\$entry, \"phonenumber\");</p>\n<p>That code will display the phone number recorded in that entry (assuming \"phonenumber\" is a valid element handle).</p><p>You can use \"\$selectionCheckbox\" to display the special checkbox used to select an entry.</p><p>You can use a special function called \"viewEntryLink\" to create a link to the entry so users can edit it.  This function takes one parameter, which is the text that will be clickable.  Examples:</p><p style=\"font-family: courier\">&nbsp;&nbsp;&nbsp;print viewEntryLink(\"Click to view this entry\");<br>&nbsp;&nbsp;&nbsp;print viewEntryLink(display(\$entry, \"taskname\"));<br>&nbsp;&nbsp;&nbsp;print viewEntryLink(\"&lt;img src='\" . XOOPS_ROOT_PATH . \"/images/button.jpg'&gt;\");</p></span>\n");
+<p>For Quicksearch boxes, use \"\$quickSearch<i>Column</i>\" where <i>Column</i> is either the element ID number, or the element handle if using a Relationship.</p>\n<p>For Custom Buttons, use \"\$handle\" where <i>handle</i> is the handle you specified for that button.  You can use \"\$messageText\" to control where the clicked button's message will appear on the screen.  By default, the message appears centred at the top.</p>\n<p>If the current view list is available, you can determine which view was last selected from the list, by checking whether <i>\$The_view_name</i> is true or not.  You can also check <i>\$viewX</i> where X is a number corresponding to the position of the view in the list, 1 through n.  You can use this to put if..else clauses into your template, so it changes depending what view is selected.</p>\n<p><b>List Item Template</b></p>\n<p>If you specify any PHP code for the List Item Template, it will be used to draw in each row of the list.</p>\n<p>You do not need to create a foreach loop or any other loop structure in this template.  The PHP code you specify will be executed inside a loop that runs once for each entry.</p>\n<p>You have full access to XOOPS and Formulize objects, functions, variables and constants in this template, including <i>\$fid</i> for the form ID.  Use \$entry to refer to the current entry in the list.  For example:</p>\n<p style=\"font-family: courier\">&nbsp;&nbsp;&nbsp;display(\$entry, \"phonenumber\");</p>\n<p>That code will display the phone number recorded in that entry (assuming \"phonenumber\" is a valid element handle).</p><p>You can use \"\$selectionCheckbox\" to display the special checkbox used to select an entry.</p><p>You can use a special function called \"viewEntryLink\" to create a link to the entry so users can edit it.  This function takes one parameter, which is the text that will be clickable.  Examples:</p><p style=\"font-family: courier\">&nbsp;&nbsp;&nbsp;print viewEntryLink(\"Click to view this entry\");<br>&nbsp;&nbsp;&nbsp;print viewEntryLink(display(\$entry, \"taskname\"));<br>&nbsp;&nbsp;&nbsp;print viewEntryLink(\"&lt;img src='\" . XOOPS_ROOT_PATH . \"/images/button.jpg'&gt;\");</p></span>\n");
 define("_AM_ELE_CAPTION","Affichage");
 define("_AM_FORMULIZE_SCREENTYPE_LISTOFENTRIES", "Liste des entrées dans ce formulaire");
 define("_AM_FORMULIZE_SCREENTYPE_MULTIPAGE", "Version multi pages du formulaire");
@@ -537,8 +537,8 @@ define("_AM_FORMULIZE_SCREEN_LOE_USEWORKING", "Est ce que le message 'Working' d
 define("_AM_FORMULIZE_SCREEN_LOE_VIEWENTRYPAGEWORKS", "Page des pageworks");
 define("_AM_FORMULIZE_SCREEN_LOE_VIEWENTRYSCREEN", "Quel écran par défaut doit être montré aux utilisateurs lorsqu'ils souhaitent rentrer une nouvelle entrée?");
 define("_AM_FORMULIZE_SCREEN_LOE_VIEWENTRYSCREEN_DEFAULT", "Utilise la version par défault de ce formulaire");
-define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_IN_FRAME", "dispo. seulement dans un framework: ");
-define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_NO_FRAME", "dispo. seulement sans framework");
+define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_IN_FRAME", "dispo. seulement dans un inter-relation: ");
+define("_AM_FORMULIZE_SCREEN_LOE_VIEW_ONLY_NO_FRAME", "dispo. seulement sans inter-relation");
 define("_AM_FORMULIZE_SCREEN_PAGETITLE", "Titre pour le numéro de page");
 define("_AM_FORMULIZE_SCREEN_PARAENTRYFORM", "Est ce que les réponses d'une entrée précédente doivent être montrée comme partie du formulaire?  Si c'est le cas choisissez le formulaire.");
 define("_AM_FORMULIZE_SCREEN_PARAENTRYFORM_FALSE", "Non, ne pas montrer les réponses précédentes.");
@@ -553,11 +553,11 @@ define("_AM_FORMULIZE_SCREEN_SAVED", "Les détails pour cet écran ont été sau
 define("_AM_FORMULIZE_SCREEN_THANKS", "Texte de remerciement pour la dernière page de ce formulaire");
 define("_AM_FORMULIZE_SCREEN_TITLE", "Titre de cet écran");
 define("_AM_FORMULIZE_SCREEN_TYPE", "Type: ");
-define("_AM_FORMULIZE_SELECT_FRAMEWORK", "Framework utilisé sur cet écran, s'il y en a un");
-define("_AM_FORMULIZE_USE_NO_FRAMEWORK", "Utilisez ce formulaire seulement, pas de Framework");
+define("_AM_FORMULIZE_SELECT_FRAMEWORK", "Inter-relation utilisé sur cet écran, s'il y en a un");
+define("_AM_FORMULIZE_USE_NO_FRAMEWORK", "Utilisez ce formulaire seulement, pas de inter-relation");
 define("_AM_FUNCTION","Fonction");
 define("_AM_GOTO_MAIN", "Retourner au menu");
-define("_AM_GOTO_MODFRAME", "Retourner à la première page<br> du Frameworks");
+define("_AM_GOTO_MODFRAME", "Retourner à la première page<br> du inter-relations");
 define("_AM_GOTO_PARAMS", "Editer les paramètres du formulaire");
 define("_AM_ID","NÂ°");
 define("_AM_INACTIVE","inactif");

--- a/modules/formulize/templates/admin/element_type_subform.html
+++ b/modules/formulize/templates/admin/element_type_subform.html
@@ -22,23 +22,29 @@
 		 <div class="form-radios">
 		     <label for="elements-ele_value[8]-form"><input type="radio" id="elements-ele_value[8]-form" name="elements-ele_value[8]" value="form"<{if $content.ele_value[8] eq 'form'}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_SUBFORM_UITYPE_FORM}></label>
 		 </div>
-         <div class="form-radios">
+     <div class="form-radios">
 		     <label for="elements-ele_value[8]-flatform"><input type="radio" id="elements-ele_value[8]-flatform" name="elements-ele_value[8]" value="flatform"<{if $content.ele_value[8] eq 'flatform'}> checked="checked"<{/if}>/>Display each subform entry using the full form, NOT inside a collapsable area</label>
 		 </div>
+		</div>
+		<div class="form-item" id="rowsPerPage" <{if $content.ele_value[8] neq 'row' AND $content.ele_value[8] neq ''}>style='display: none;'<{/if}>>
+			<p>When shown as rows, subform listings can be split into multiple pages. How many rows should appear on each page? <input name="elements-ele_value[numberOfEntriesPerPage]" size="2" value="<{$content.ele_value.numberOfEntriesPerPage}>"></p>
+			<div class="description">
+				Enter 0 for all entries on one page.
+			</div>
 		</div>
 
         <div class="form-item">
             <p>Show the button to add entries?</p>
-            <div class="description">The "Add x Entries" button lets users create additional entries in the subform.</div>
             <div class="form-radios">
                 <label for="elements-ele_value[6]-subform"><input type="radio" id="elements-ele_value[6]-subform" name="elements-ele_value[6]" value="subform"<{if $content.ele_value[6] eq 'subform' OR $content.ele_value[6] eq '1'}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_SUBFORM_ADD_SUBFORM}></label>
             </div>
             <div class="form-radios">
                 <label for="elements-ele_value[6]-parent"><input type="radio" id="elements-ele_value[6]-parent" name="elements-ele_value[6]" value="parent"<{if $content.ele_value[6] eq 'parent'}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_SUBFORM_ADD_PARENT}></label>
             </div>
-	    <div class="form-radios">
+	    			<div class="form-radios">
                 <label for="elements-ele_value[6]-no"><input type="radio" id="elements-ele_value[6]-no" name="elements-ele_value[6]" value="hideaddentries"<{if $content.ele_value[6] eq 'hideaddentries' OR $content.ele_value[6] eq ''}> checked="checked"<{/if}>/><{$smarty.const._AM_ELE_SUBFORM_ADD_NONE}></label>
             </div>
+						<div class="description">The "Add x Entries" button lets users create additional entries in the subform.</div>
         </div>
 
         <div class="form-item">
@@ -277,6 +283,14 @@
         }
         removeNonDisplayedElementsFromDisabledList();
     });
+
+		$("input[name=elements-ele_value\\[8\\]]").change(function() {
+			if($(this).val() == 'row') {
+				$("#rowsPerPage").show(200);
+			} else {
+				$("#rowsPerPage").hide(200);
+			}
+		});
 
     removeNonDisplayedElementsFromDisabledList()
 

--- a/modules/formulize/templates/admin/screen_display.html
+++ b/modules/formulize/templates/admin/screen_display.html
@@ -61,7 +61,7 @@
 					</td>
 				</tr>
 			</table>
-			<p>For Quicksearch boxes, use "$quickSearchColumn" where Column is either the element's data handle, or the Framework's element handle if using a Framework. Note:  you must turn off the quicksearch boxes at the top of the columns before you can use them in a top template.</p>
+			<p>For Quicksearch boxes, use "$quickSearchColumn" where Column is the element's data handle. Note:  you must turn off the quicksearch boxes at the top of the columns before you can use them in a top template.</p>
 			<p>You can also add a global quick search box, which searches all columns, with "$globalQuickSearch".</p>
 			<p>You can also make Quickfilter dropdown boxes, by using "$quickFilterColumn". This only works for selectboxes, radio buttons and checkboxes.</p>
 			<p>For Custom Buttons, use "$handle" where handle is the handle you specified for that button. You can use "$messageText" to control where the clicked button's message will appear on the screen. By default, the message appears centred at the top.</p>

--- a/modules/formulize/templates/css/formulize.css
+++ b/modules/formulize/templates/css/formulize.css
@@ -203,7 +203,8 @@
 .page-navigation-label {
   margin-right: 1em; }
 
-.formulize-page-navigation a {
+.formulize-page-navigation a,
+.formulize-page-navigation span {
   margin: 0 0.1em;
   padding: 0.4em 0.5em;
   font-weight: normal; }


### PR DESCRIPTION
- Added admin UI for number of rows (0 or blank for show all rows)
- Made subform elements work with live conditional display JS and formulize_xhr_responder
- Compartmentalized the generation of the pager UI, so subform elements and lists of entries can use it
- Trigger similar process to conditional display when user clicks a page number, to regenerate and redisplay the subform interface
- Add a limit clause to the SQL statement that handles ordering the subform entries, so that we only show the correct ones for the page the user is looking at