### PR TITLE
Pref for Revisions History always on

### DIFF
--- a/modules/formulize/admin/form.php
+++ b/modules/formulize/admin/form.php
@@ -529,6 +529,7 @@ $settings['menutext'] = $menutext;
 $settings['form_handle'] = $form_handle;
 $settings['send_digests'] = $send_digests;
 $settings['store_revisions'] = $store_revisions;
+$settings['revisionsDisabled'] = formulizeRevisionsForAllFormsIsOn() ? 'disabled="disabled"' : '';
 $settings['istableform'] = ($tableform OR $newtableform) ? true : false;
 if (isset($groupsCanEditOptions)) {
     $settings['groupsCanEditOptions'] = $groupsCanEditOptions;

--- a/modules/formulize/admin/save/form_settings_save.php
+++ b/modules/formulize/admin/save/form_settings_save.php
@@ -206,7 +206,7 @@ if(isset($_POST['forms-tableform'])) {
 
 // if the revision history flag was on, then create the revisions history table, if it doesn't exist already
 if(isset($_POST['forms-store_revisions']) AND $_POST['forms-store_revisions'] AND !$form_handler->revisionsTableExists($formObject)) {
-  if(!$form_handler->createDataTable($fid, 0, array(), true)) { // 0 is the id of a form we're cloning, array() is the map of old elements to new elements when cloning so n/a here, true is the flag for making a revisions table
+  if(!$form_handler->createDataTable($fid, revisionsTable: true)) { // 0 is the id of a form we're cloning, array() is the map of old elements to new elements when cloning so n/a here, true is the flag for making a revisions table
     print "Error: could not create the revision history table for the form";
   }
 }

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -137,7 +137,7 @@ class formulizeForm extends FormulizeObject {
 		$this->initVar("defaultlist", XOBJ_DTYPE_INT, $defaultlist, true);
 		$this->initVar("menutext", XOBJ_DTYPE_TXTBOX, $formq[0]['menutext'], false, 255);
 		$this->initVar("form_handle", XOBJ_DTYPE_TXTBOX, $formq[0]['form_handle'], false, 255);
-		$this->initVar("store_revisions", XOBJ_DTYPE_INT, $formq[0]['store_revisions'], true);
+		$this->initVar("store_revisions", XOBJ_DTYPE_INT, (formulizeRevisionsForAllFormsIsOn() ? 1 : $formq[0]['store_revisions']), true); // override based on module preference
 		$this->initVar("on_before_save", XOBJ_DTYPE_TXTAREA, $this->getVar('on_before_save'));
 		$this->initVar("on_after_save", XOBJ_DTYPE_TXTAREA, $this->getVar('on_after_save'));
 		$this->initVar("on_delete", XOBJ_DTYPE_TXTAREA, $this->getVar('on_delete'));

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8634,3 +8634,15 @@ function stripEntryFromDoneDestination($done_dest) {
 function convertStringToUseSpecialCharsToMatchDB($string) {
 	return str_replace('&amp;', '&', htmlspecialchars($string));
 }
+
+/**
+ * Check if the 'revision history on for all forms' preference is set
+ * @return bool Returns true if it is on, and false if it is not
+ */
+function formulizeRevisionsForAllFormsIsOn() {
+	$module_handler = xoops_gethandler('module');
+	$config_handler = xoops_gethandler('config');
+	$formulizeModule = $module_handler->getByDirname("formulize");
+	$formulizeConfig = $config_handler->getConfigsByCat(0, $formulizeModule->getVar('mid'));
+	return $formulizeConfig['formulizeRevisionsForAllForms'] ? true : false;
+}

--- a/modules/formulize/language/english/modinfo.php
+++ b/modules/formulize/language/english/modinfo.php
@@ -152,6 +152,10 @@ if(isset($GLOBALS['config'])) {
 define("_MI_formulize_PUBLICAPIENABLED", "Enable the Public API".$publicAPIInstructions);
 define("_MI_formulize_PUBLICAPIENABLED_DESC", "When this is enabled, you can use the Public API documented at https://formulize.org/developers/public-api/");
 
+define("_MI_formulize_REVISIONSFORALLFORMS", "Turn on revision history for all forms");
+define("_MI_formulize_REVISIONSFORALLFORMS_DESC", "Normally, you can turn on revision history for each form as you see fit. If you want to turn it on for all forms always, turn this preference on, and the option will be disabled in each form's settings.");
+
+
 // The name of this module
 define("_MI_formulizeMENU_NAME","MyMenu");
 

--- a/modules/formulize/language/french/modinfo.php
+++ b/modules/formulize/language/french/modinfo.php
@@ -115,6 +115,9 @@ if(isset($GLOBALS['config'])) {
 define("_MI_formulize_PUBLICAPIENABLED", "Enable the Public API".$publicAPIInstructions);
 define("_MI_formulize_PUBLICAPIENABLED_DESC", "When this is enabled, you can use the Public API documented at https://formulize.org/developers/public-api/");
 
+define("_MI_formulize_REVISIONSFORALLFORMS", "Turn on revision history for all forms");
+define("_MI_formulize_REVISIONSFORALLFORMS_DESC", "Normally, you can turn on revision history for each form as you see fit. If you want to turn it on for all forms always, turn this preference on, and the option will be disabled in each form's settings.");
+
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY', "Show empty form elements when displaying forms in read-only mode");
 define('_MI_formulize_SHOW_EMPTY_ELEMENTS_WHEN_READ_ONLY_DESC', "When form elements are rendered in read-only mode, and there is no value to display, the element is skipped by default and not shown. If you want to show all elements even empty ones when users cannot edit the entry, turn this setting on.");
 

--- a/modules/formulize/templates/admin/form_settings.html
+++ b/modules/formulize/templates/admin/form_settings.html
@@ -18,7 +18,7 @@
         	<fieldset>
                 <legend><label for="forms-title" class="question"><{$smarty.const._AM_SETTINGS_FORM_TITLE_QUESTION}></label></legend>
                 <p><{$smarty.const._AM_SETTINGS_FORM_TITLE}><input type="text" id="forms-title" name="forms-title" class="required_formulize_element" value="<{$content.name}>" onkeyup="fillHandle()" /></p>
-            
+
             </fieldset>
 		</div>
 	</div>
@@ -65,13 +65,13 @@
 		</div>
 		<div style="clear: both;"></div>
 		<{/if}>
-	
+
 		<{if $content.istableform == false}>
 		<div class="accordion-box">
 			<div class="form-item">
         	<fieldset>
 				<legend><label class="question"><{$smarty.const._AM_SETTINGS_FORM_ENTRIES_ALLOWED}></label></legend>
-				
+
 				<div class="form-radios">
 					<label for="group"><input type="radio" id="group" name="forms-single" value="group" /><{$smarty.const._AM_SETTINGS_FORM_ENTRIES_ONEPERGROUP}></label>
 				</div>
@@ -85,7 +85,7 @@
 		</div>
 	</div>
 	<div style="clear: both;"></div>
-	
+
 		<{if $content.fid == "new"}>
 			<div class="accordion-box">
 			<div class="form-item">
@@ -99,7 +99,7 @@
 			</div>
 			<div style="clear: both;"></div>
 		<{/if}>
-	
+
 		<{if $content.fid != "new" AND $content.elementheadings|is_array AND $content.elementheadings|@count}>
 		<div class="accordion-box">
 			<div class="form-item">
@@ -120,18 +120,18 @@
 				<fieldset>
 					<legend><label class="question">Do you want to keep a revision history of all the changes people make to entries in this form?</label></legend>
 					<div class="form-radios">
-						<label for="store_revisions-0"><input type="radio" id="store_revisions-0" name="forms-store_revisions" value="0" />No</label>
+						<label for="store_revisions-0"><input type="radio" <{$content.revisionsDisabled}> id="store_revisions-0" name="forms-store_revisions" value="0" />No</label>
 					</div>
 					<div class="form-radios">
-						<label for="store_revisions-1"><input type="radio" id="store_revisions-1" name="forms-store_revisions" value="1" />Yes, store revision history for this form</label>
+						<label for="store_revisions-1"><input type="radio" <{$content.revisionsDisabled}> id="store_revisions-1" name="forms-store_revisions" value="1" />Yes, store revision history for this form</label>
 					</div>
 					<div class="description">
-						<p>This can increase the size of your database <b>a lot</b> if you turn on revisions for a form where entries are updated very often!</p>
+						<p>This can increase the size of your database <b>a lot</b> if you turn on revisions for a form where entries are updated very often!</p><p>You can turn this on for all forms at once, through the <a href="../../system/admin.php?fct=preferences&op=showmod&mod=<{$adminPage.formulizeModId}>">Formulize preferences</a>. If you do that, then you cannot alter it here. This option becomes disabled.</p>
 					</div>
 				</fieldset>
 			</div>
 		</div>
-					
+
         <div class="accordion-box">
 			<div class="form-item">
 				<fieldset>
@@ -148,10 +148,10 @@
 				</fieldset>
 			</div>
 		</div>
-    
-    
+
+
 	<{/if}>
-	
+
 	<{if $content.applications|is_array AND $content.applications|@count > 0}>
 	<div class="accordion-box">
 		<div class="form-item">
@@ -183,18 +183,18 @@
 							</div>
             </fieldset>
 		</div>
-	</div> 
+	</div>
 
 </form>
 <script type="text/javascript">
   $("#<{$content.singleentry}>").attr('checked', true);
   $("#store_revisions-<{$content.store_revisions}>").attr('checked', true);
   $("#send_digests-<{$content.send_digests}>").attr('checked', true);
-	
+
 	$("#forms-title").keydown(function () {
 		window.document.getElementById('reload_settings').value = 1;
 	});
-	
+
 	$('input:radio[name=new_app_yes_no]').change(function(){
 		if($('input:radio[name=new_app_yes_no]:checked').val() == 'yes') {
 			window.document.getElementById("new-application-box").style.display = 'block';
@@ -202,7 +202,7 @@
 			window.document.getElementById("new-application-box").style.display = 'none';
 		}
 		});
-	
+
 	$(".savebutton").click(function() {
 		if($("[name=forms-title]").val() == "") {
 			alert("Forms must have a name!");
@@ -211,7 +211,7 @@
 		if ($("[name=forms-form_handle]").val() == "") {
 			fillHandle();
 		}
-		
+
 	});
 	function fillHandle(){
 		//this function will be called when they are typing title to update handle
@@ -231,7 +231,7 @@
 				alert(response);
 			}
 		});
-	});	
+	});
 </script>
 <div style="clear: both"></div>
 </div> <!--// end content -->

--- a/modules/formulize/xoops_version.php
+++ b/modules/formulize/xoops_version.php
@@ -1023,6 +1023,15 @@ $modversion['config'][] = array(
 	'default' => 0,
 );
 
+$modversion['config'][] = array(
+	'name' => 'formulizeRevisionsForAllForms',
+	'title' => '_MI_formulize_REVISIONSFORALLFORMS',
+	'description' => '_MI_formulize_REVISIONSFORALLFORMS_DESC',
+	'formtype' => 'yesno',
+	'valuetype' => 'int',
+	'default' => 0,
+);
+
 $modversion['blocks'][1] = array(
 	'file' => "mymenu.php",
 	'name' => _MI_formulizeMENU_BNAME,


### PR DESCRIPTION
Added a module preference in Formulize for whether revisions history is always on for all form. If so, setting on admin side is disabled and always on.

If preference is on, form objects always have store_revisions set to 1.

Interactions with revisions tables are always wrapped in checks for if the revision table exists. If the preference is on, then the revision table is created as part of this check, if it doesn't already exist.