### PR TITLE
Form pages can be PHP code, references to other screens, or standard sets of elements

### DIFF
--- a/modules/formulize/admin/multipageScreenGeneratePageItemDescription.php
+++ b/modules/formulize/admin/multipageScreenGeneratePageItemDescription.php
@@ -1,0 +1,85 @@
+<?php
+
+
+###############################################################################
+##     Formulize - ad hoc form creation and reporting module for XOOPS       ##
+##                    Copyright (c) Formulize Project                        ##
+###############################################################################
+##                    XOOPS - PHP Content Management System                  ##
+##                       Copyright (c) 2000 XOOPS.org                        ##
+##                          <http://www.xoops.org/>                          ##
+###############################################################################
+##  This program is free software; you can redistribute it and/or modify     ##
+##  it under the terms of the GNU General Public License as published by     ##
+##  the Free Software Foundation; either version 2 of the License, or        ##
+##  (at your option) any later version.                                      ##
+##                                                                           ##
+##  You may not change or alter any portion of this comment or credits       ##
+##  of supporting developers from this source code or any supporting         ##
+##  source code which is considered copyrighted (c) material of the          ##
+##  original comment or credit authors.                                      ##
+##                                                                           ##
+##  This program is distributed in the hope that it will be useful,          ##
+##  but WITHOUT ANY WARRANTY; without even the implied warranty of           ##
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            ##
+##  GNU General Public License for more details.                             ##
+##                                                                           ##
+##  You should have received a copy of the GNU General Public License        ##
+##  along with this program; if not, write to the Free Software              ##
+##  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA ##
+###############################################################################
+##  Author of this file: Formulize Project                                   ##
+##  Project: Formulize                                                       ##
+###############################################################################
+
+// end point for async update when altering the contents of a multipage screen's page
+
+include "../../../mainfile.php";
+icms::$logger->disableLogger();
+while(ob_get_level()) {
+    ob_end_clean();
+}
+
+$sid = intval($_GET['sid']);
+$pageNumber = intval($_GET['page']);
+$screen_handler = xoops_getmodulehandler('multiPageScreen', 'formulize');
+if($screen = $screen_handler->get($sid)) {
+    setupXoopsTpl();
+    global $xoopsTpl;
+    $fid = $screen->getVar('fid');
+    $frid = $screen->getVar('frid');
+    $elements = $screen->getVar("pages");
+    list($title, $elements) = generateElementInfoForScreenPage($elements[$pageNumber], $fid, $frid);
+    $xoopsTpl->assign('sectionContent', array(
+        'index' => $pageNumber,
+        'pageItemTypeTitle' => $title,
+        'elements' => $elements
+    ));
+    $xoopsTpl->display("db:admin/screen_multipage_pages_sections.html");
+}
+
+function setupXoopsTpl() {
+    global $xoopsOption, $xoopsConfig, $xoopsModule;
+
+    $xoopsOption['theme_use_smarty'] = 1;
+
+    // include Smarty template engine and initialize it
+    require_once XOOPS_ROOT_PATH . '/class/template.php';
+    require_once XOOPS_ROOT_PATH . '/class/theme.php';
+    require_once XOOPS_ROOT_PATH . '/class/theme_blocks.php';
+
+    if ( @$xoopsOption['template_main'] ) {
+        if ( false === strpos( $xoopsOption['template_main'], ':' ) ) {
+            $xoopsOption['template_main'] = 'db:' . $xoopsOption['template_main'];
+        }
+    }
+    $xoopsThemeFactory = new xos_opal_ThemeFactory();
+    $xoopsThemeFactory->allowedThemes = $xoopsConfig['theme_set_allowed'];
+    $xoopsThemeFactory->defaultTheme = $xoopsConfig['theme_set'];
+
+    $xoTheme =& $xoopsThemeFactory->createInstance(array(
+        'contentTemplate' => @$xoopsOption['template_main'],
+    ));
+    global $xoopsTpl;
+    $xoopsTpl =& $xoTheme->template;
+}

--- a/modules/formulize/admin/save/screen_multipage_pages_save.php
+++ b/modules/formulize/admin/save/screen_multipage_pages_save.php
@@ -112,16 +112,6 @@ if($pagesHaveBeenReordered) {
 
 }
 
-
-// handle "deleting" conditions...
-/*foreach($conditions as $pagenum=>$datapiece) {
-   if(isset($datapiece['pagecons']) AND $datapiece['pagecons'] == "none") {
-        $conditions[$pagenum]['details']['elements'] = array();
-        $conditions[$pagenum]['details']['ops'] = array();
-        $conditions[$pagenum]['details']['terms'] = array();
-    }
-}*/
-
 // alter the information based on a user add or delete
 switch ($op) {
 	case "addpage":

--- a/modules/formulize/admin/screen.php
+++ b/modules/formulize/admin/screen.php
@@ -329,7 +329,7 @@ if ($screen_id != "new" && $settings['type'] == 'multiPage') {
     // setup all the elements in this form for use in the listboxes
     include_once XOOPS_ROOT_PATH . "/modules/formulize/class/forms.php";
 		$frid = $screen->getVar("frid");
-    $options = multiPageScreen_addToOptionsList($form_id, $frid);
+    
 
     // get page titles
     $pageTitles = $screen->getVar("pagetitles");
@@ -339,28 +339,11 @@ if ($screen_id != "new" && $settings['type'] == 'multiPage') {
     // get details of each page
     $pages = array();
     for($i=0;$i<(count((array) $pageTitles)+$pageCounterOffset);$i++) {
-				$pages[$i]['name'] = $pageTitles[$i];
-				$pages[$i]['content']['index'] = $i;
-				$pages[$i]['content']['number'] = $i+1;
-				$pages[$i]['content']['title'] = $pageTitles[$i];
-				$pages[$i]['content']['pageItemTypeTitle'] = "Elements displayed on this page:"; // default, historically the only option
-        foreach($elements[$i] as $thisPageItem) {
-						// default is for the elements that make up the page to be a series of element ids
-						if(is_numeric($thisPageItem)) {
-            	$pages[$i]['content']['elements'][] = $options[$thisPageItem];
-						// alternatively, it could be a string of PHP code
-						} elseif($thisPageItem[0] == "PHP") {
-							$pages[$i]['content']['pageItemTypeTitle'] = "This page uses custom code to display content.";
-							$pages[$i]['content']['elements'] = array();
-						// alternatively, it's a series of screen ids, prefixed by "sid:" which must be removed
-						} else {
-							$pages[$i]['content']['pageItemTypeTitle'] = "Screen displayed on this page:";
-							$pageScreenId = substr($thisPageItem, 4);
-							$pageScreenObject = $screen_handler->get($pageScreenId);
-							$pageFormObject = $form_handler->get($pageScreenObject->getVar('id_form'));
-							$pages[$i]['content']['elements'][] = printSmart($pageFormObject->getVar('title').": ".$pageScreenObject->getVar('title'), 200);
-						}
-        }
+        $pages[$i]['name'] = $pageTitles[$i];
+        $pages[$i]['content']['index'] = $i;
+        $pages[$i]['content']['number'] = $i+1;
+        $pages[$i]['content']['title'] = $pageTitles[$i];
+        list($pages[$i]['content']['pageItemTypeTitle'], $pages[$i]['content']['elements']) = generateElementInfoForScreenPage($elements[$i], $form_id, $frid);       
     }
 
     // options data

--- a/modules/formulize/admin/screen_multipage_pages_settings.php
+++ b/modules/formulize/admin/screen_multipage_pages_settings.php
@@ -61,7 +61,8 @@ if (!is_object($screen)) {
 include_once XOOPS_ROOT_PATH . "/modules/formulize/class/forms.php";
 $frid = $screen->getVar("frid");
 $fid = $screen->getVar('fid');
-$options = multiPageScreen_addToOptionsList($fid, $frid);
+$elementOptions = multiPageScreen_addToOptionsList($fid, $frid);
+$screenOptions = multiPageScreenMakeScreenOptionsList($fid, $frid, $sid);
 
 // get page titles
 $pageTitles = $screen->getVar("pagetitles");
@@ -71,6 +72,9 @@ $conditions = $screen->getVar("conditions");
 $pageTitle = $pageTitles[$pageIndex];
 $pageNumber = $pageIndex+1;
 $pageElements = $elements[$pageIndex];
+
+$pit = $screen->determinePageItemType($pageElements);
+
 $filterSettingsToSend = (is_array($conditions) AND isset($conditions[$pageIndex]) AND count($conditions[$pageIndex]) > 0) ? $conditions[$pageIndex] : "";
 if (isset($filterSettingsToSend['details'])) { // if this is in the old format (pre-version 4, these conditions used a non-standard syntax), convert it!
     $newFilterSettingsToSend = array();
@@ -90,7 +94,9 @@ $xoopsTpl->assign("pageNumber",$pageNumber);
 $xoopsTpl->assign("pageIndex",$pageIndex);
 $xoopsTpl->assign("pageElements",$pageElements);
 $xoopsTpl->assign("pageConditions",$pageConditions);
-$xoopsTpl->assign("options",$options);
+$xoopsTpl->assign("pit", $pit);
+$xoopsTpl->assign("elementOptions",$elementOptions);
+$xoopsTpl->assign("screenOptions",$screenOptions);
 $xoopsTpl->assign("sid",$sid);
 $xoopsTpl->display("db:admin/screen_multipage_pages_settings.html");
 

--- a/modules/formulize/admin/screen_multipage_pages_settings.php
+++ b/modules/formulize/admin/screen_multipage_pages_settings.php
@@ -30,6 +30,11 @@
 // this file gets all the data about a particular page of a screen, so it can be edited
 
 require_once "../../../mainfile.php";
+icms::$logger->disableLogger();
+while(ob_get_level()) {
+    ob_end_clean();
+}
+
 include_once("admin_header.php");
 
 include_once XOOPS_ROOT_PATH."/modules/formulize/include/functions.php";

--- a/modules/formulize/class/multiPageScreen.php
+++ b/modules/formulize/class/multiPageScreen.php
@@ -613,7 +613,10 @@ function pageMeetsConditions($conditions, $currentPage, $entry_id, $fid, $frid) 
 
 /**
  * Gather the page description info that should show up on the admin UI for a given page
- *
+ * @param array itemsForPage - an array of the items that make up the contents of the page
+ * @param int fid - the form id
+ * @param int frid - the form relationship id, if any
+ * @return array An array with two items, the descriptor for this type of page, and the items that make up the page
  */
 function generateElementInfoForScreenPage($itemsForPage, $fid, $frid) {
     $options = multiPageScreen_addToOptionsList($fid, $frid);

--- a/modules/formulize/class/multiPageScreen.php
+++ b/modules/formulize/class/multiPageScreen.php
@@ -428,7 +428,7 @@ function multiPageScreenScreenOptionsList_append($fid, $excludedSid=0, $screens=
 	array_multisort(array_column($multiPageScreens, 'title'), $multiPageScreens);
 	foreach($multiPageScreens as $screenMetaData) {
 		if($excludedSid != $screenMetaData['sid']) {
-			$screens['sid:'.$screenMetaData['sid']] = printSmart($formObject->getVar('title').": ".$screenMetaData['title'], 100);
+			$screens['sid:'.$screenMetaData['sid']] = printSmart(trans(strip_tags($formObject->getVar('title'))), 25).": ".printSmart(trans(strip_tags($screenMetaData['title'])), 25);
 		}
 	}
 	return $screens;
@@ -477,7 +477,7 @@ function multiPageScreen_addToOptionsListByFid($fid, $frid=0, $options=array()) 
 		$elementColheads = $formObject->getVar('elementColheads');
 		foreach($elementCaptions as $key=>$elementCaption) {
 			$elementLabel = $elementColheads[$key] ? $elementColheads[$key] : $elementCaption;
-			$options[$elements[$key]] = $frid ? printSmart(trans(strip_tags($formObject->title.': '.$elementLabel)), 125) : printSmart(trans(strip_tags($elementLabel)), 40); // need to pull out potential HTML tags from the caption/colhead
+			$options[$elements[$key]] = $frid ? printSmart(trans(strip_tags($formObject->title)), 25).': '.printSmart(trans(strip_tags($elementLabel)), 25) : printSmart(trans(strip_tags($elementLabel)), 40); // need to pull out potential HTML tags from the caption/colhead
 		}
 	}
 	return $options;

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -2563,11 +2563,23 @@ function addOwnershipList($form, $groups, $member_handler, $gperm_handler, $fid,
 			return $form;
 }
 
+/**
+ * Make a xoops form label element based on the string, and add it to the passed in form object
+ *
+ */
+function addLabelElementWithStringToForm($string, $form) {
+
+}
+
 
 //this function takes a formid and compiles all the elements for that form
 //elements_allowed is NOT based off the display values.  It is based off of the elements that are specifically designated for the current displayForm function (used to display parts of forms at once)
 // $title is the title of a grid that is being displayed
 function compileElements($fid, $form, $prevEntry, $entry_id, $groups, $elements_allowed, $frid, $sub_entries, $sub_fids, $screen=null, $printViewPages=array(), $printViewPageTitles="") {
+
+	if(is_array($elements_allowed AND count($elements_allowed) == 1 AND is_string($elements_allowed[0])) {
+		return addLabelElementWithStringToForm($elements_allowed[0], $form);
+	}
 
 	global $xoopsDB, $xoopsUser;
 	$entry_id = is_numeric($entry_id) ? $entry_id : "new"; // if there is no entry, ie: a new entry, then $entry_id is "" so when writing the entry value into decue_ and other elements that go out to the HTML form, we need to use the keyword "new"

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -1391,11 +1391,6 @@ function displayForm($formframe, $entry="", $mainform="", $done_dest="", $button
 				$form->insertBreakFormulize("<table><th>$title</th></table>","head");
 			}
 
-			// if this form has a parent, then determine the $parentLinks
-			if($go_back['form'] AND !$parentLinks[$this_fid]) {
-				$parentLinks[$this_fid] = getParentLinks($this_fid, $frid);
-			}
-
 			formulize_benchmark("Before Compile Elements.");
 			$form = compileElements($this_fid, $form, $prevEntry, $entries[$this_fid][0], $groups, $elements_allowed, $frid, $sub_entries, $sub_fids, $screen, $printViewPages, $printViewPageTitles);
 			formulize_benchmark("After Compile Elements.");
@@ -2565,19 +2560,27 @@ function addOwnershipList($form, $groups, $member_handler, $gperm_handler, $fid,
 
 /**
  * Make a xoops form label element based on the string, and add it to the passed in form object
- *
+ * Only add a given string once
+ * @param string string - the markup to add to the form
+ * @param object form - the xoopsForm object to which all the elements are being added
+ * @return object The xoopsForm object updated with the string added to it
  */
 function addLabelElementWithStringToForm($string, $form) {
-
+    static $cachedStrings = array();
+    if(!in_array($string, $cachedStrings)) {
+        $form->insertBreakFormulize($string, 'even', 'custom-content', 'custom-content');
+        $cachedStrings[] = $string;
+    }
+    return $form;
 }
 
-
-//this function takes a formid and compiles all the elements for that form
-//elements_allowed is NOT based off the display values.  It is based off of the elements that are specifically designated for the current displayForm function (used to display parts of forms at once)
+// this function takes a formid and compiles all the elements for that form
+// elements_allowed is NOT based off the display values.  It is based off of the elements that are specifically designated for the current displayForm function (used to display parts of forms at once)
 // $title is the title of a grid that is being displayed
+// called once per form included on the page
 function compileElements($fid, $form, $prevEntry, $entry_id, $groups, $elements_allowed, $frid, $sub_entries, $sub_fids, $screen=null, $printViewPages=array(), $printViewPageTitles="") {
 
-	if(is_array($elements_allowed AND count($elements_allowed) == 1 AND is_string($elements_allowed[0])) {
+	if(is_array($elements_allowed) AND count($elements_allowed) == 1 AND !is_numeric($elements_allowed[0]) AND is_string($elements_allowed[0])) {
 		return addLabelElementWithStringToForm($elements_allowed[0], $form);
 	}
 

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -555,7 +555,7 @@ function q($query, $keyfield="", $keyfieldOnly = false) {
 }
 
 // this function truncates a string to a certain number of characters
-function printSmart($value, $chars="35") {
+function printSmart($value, $chars=35) {
     if($chars AND !strstr(getCurrentURL(), 'master.php?')) {
         if (!is_numeric($value) AND $value == "") {
             $value = "&nbsp;";

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -5160,9 +5160,9 @@ function formulize_createFilterUI($filterSettings, $filterName, $formWithSourceE
             foreach ($vs as $row=>$values) {
 								$thisFidObj = $form_handler->get($fid);
                 if ($values['ele_colhead'] != "") {
-                    $options[$values['ele_id']] = $frid ? printSmart(trans(strip_tags($thisFidObj->title.': '.$values['ele_colhead'])), 125) : printSmart(trans(strip_tags($values['ele_colhead'])), 40);
+                    $options[$values['ele_id']] = $frid ? printSmart(trans(strip_tags($thisFidObj->title)), 25).': '.printSmart(trans(strip_tags($values['ele_colhead'])), 25) : printSmart(trans(strip_tags($values['ele_colhead'])), 40);
                 } else {
-                    $options[$values['ele_id']] = $frid ? printSmart(trans(strip_tags($thisFidObj->title.': '.$values['ele_caption'])), 125) : printSmart(trans(strip_tags($values['ele_caption'])), 40);
+                    $options[$values['ele_id']] = $frid ? printSmart(trans(strip_tags($thisFidObj->title)), 25).': '.printSmart(trans(strip_tags($values['ele_caption'])), 25) : printSmart(trans(strip_tags($values['ele_caption'])), 40);
                 }
             }
         }

--- a/modules/formulize/include/multipage_boilerplate.php
+++ b/modules/formulize/include/multipage_boilerplate.php
@@ -143,35 +143,3 @@ if($currentPage == $thanksPage) {
         }
 
 }
-
-// display an HTML or PHP page if that's what this page is...
-if($currentPage != $thanksPage AND ($pages[$currentPage][0] === "HTML" OR $pages[$currentPage][0] === "PHP")) {
-    // PHP
-    if($pages[$currentPage][0] === "PHP") {
-        eval($pages[$currentPage][1]);
-    // HTML
-    } else {
-        print undoAllHTMLChars($pages[$currentPage][1]);
-    }
-
-    // put in the form that passes the entry, page we're going to and page we were on
-    include_once XOOPS_ROOT_PATH . "/modules/formulize/include/functions.php";
-    ?>
-
-
-    <form name=formulize id=formulize_mainform action=<?php print getCurrentURL(); ?> method=post>
-    <input type=hidden name=entry<?php print $fid; ?> id=entry<?php print $fid; ?> value=<?php print $entry ?>>
-    <input type=hidden name=formulize_currentPage id=formulize_currentPage value="">
-    <input type=hidden name=formulize_prevPage id=formulize_prevPage value="">
-    writeHiddenSettings($settings, null, array(), array(), $screen);
-    </form>
-
-    <script type="text/javascript">
-        function validateAndSubmit() {
-            window.document.formulize_mainform.submit();
-        }
-    </script>
-
-    <?php
-
-}

--- a/modules/formulize/templates/admin/element_display.html
+++ b/modules/formulize/templates/admin/element_display.html
@@ -97,11 +97,11 @@ $(document).ready(function() {
 			<{assign var=formscreenpages value=$form_screen.pages}>
 			<li><input type="checkbox" name="multi_page_screens[]" value=all><label><{$form_screen.title}></label>
 			<{foreach from=$formscreenpages key=k item=screen_page}>
-				<{if in_array($content.ele_id, $screen_page)}>
+				<{if !strstr($screen_page.0, 'sid:') AND $screen_page.0 != 'PHP' AND in_array($content.ele_id, $screen_page)}>
 				 <ul>
 	                <li><input type="checkbox" name="multi_page_screens[]" id="<{$formscreenid|cat:'-'|cat:$k}>" value="<{$formscreenid|cat:'-'|cat:$k}>" checked><label for="<{$formscreenid|cat:'-'|cat:$k}>"><{$form_screen.pagetitles[$k]}></label>
 	            </ul>
-	            <{else}>
+	            <{elseif !strstr($screen_page.0, 'sid:') AND $screen_page.0 != 'PHP'}>
 	            <ul>
 	                <li><input type="checkbox" name="multi_page_screens[]" id="<{$formscreenid|cat:'-'|cat:$k}>" value="<{$formscreenid|cat:'-'|cat:$k}>"><label for="<{$formscreenid|cat:'-'|cat:$k}>"><{$form_screen.pagetitles[$k]}></label>
 	            </ul>

--- a/modules/formulize/templates/admin/screen_multipage_pages.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages.html
@@ -67,12 +67,12 @@
   });
   
   
-	$("[name=editpage]").click(function () {
+	$("[name=editpage]").live('click', function () {
 		editPageSettings($(this).attr('target'));
 		return false;
 	});
 	
-	$("[name=delpage]").click(function () {
+	$("[name=delpage]").live('click', function () {
 			var answer = confirm('Are you sure you want to delete this page?');
 			if (answer)	{
 		    $("[name=formulize_admin_op]").val('delpage');

--- a/modules/formulize/templates/admin/screen_multipage_pages_sections.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_sections.html
@@ -1,10 +1,9 @@
-
-    <p><a name="delpage" href="" target="<{$sectionContent.index}>"><img src="../images/editdelete.gif"> Delete this page</a></p>
 		<p><a name="editpage" href="" target="<{$sectionContent.index}>"><img src="../images/kedit.png"> Edit this page</a></p>
-		<p>Form Elements on this page:</p>
+		<p><{$sectionContent.pageItemTypeTitle}></p>
 		<ul>
 			<{foreach from=$sectionContent.elements item=thiselement}>
-			<li><{$thiselement}></li>	
+			<li><{$thiselement}></li>
 			<{/foreach}>
 		</ul>
 
+    <p><a name="delpage" href="" target="<{$sectionContent.index}>"><img src="../images/editdelete.gif"> Delete this page</a></p>

--- a/modules/formulize/templates/admin/screen_multipage_pages_sections.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_sections.html
@@ -1,9 +1,9 @@
-		<p><a name="editpage" href="" target="<{$sectionContent.index}>"><img src="../images/kedit.png"> Edit this page</a></p>
-		<p><{$sectionContent.pageItemTypeTitle}></p>
-		<ul>
-			<{foreach from=$sectionContent.elements item=thiselement}>
-			<li><{$thiselement}></li>
-			<{/foreach}>
-		</ul>
+<p><a name="editpage" href="" target="<{$sectionContent.index}>"><img src="../images/kedit.png"> Edit this page</a></p>
+<p><{$sectionContent.pageItemTypeTitle}></p>
+<ul>
+	<{foreach from=$sectionContent.elements item=thiselement}>
+	<li><{$thiselement}></li>
+	<{/foreach}>
+</ul>
 
-    <p><a name="delpage" href="" target="<{$sectionContent.index}>"><img src="../images/editdelete.gif"> Delete this page</a></p>
+<p><a name="delpage" href="" target="<{$sectionContent.index}>"><img src="../images/editdelete.gif"> Delete this page</a></p>

--- a/modules/formulize/templates/admin/screen_multipage_pages_settings.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_settings.html
@@ -150,7 +150,58 @@ $(".conditionsdelete").click(function () {
 });
 
 	$(".savebuttonpopup").click(function() {
-    if(validateRequired()) { // code validation not happening yet for custom code in multipage screen pages!
+		<{php}>
+		// if user wants it, and server can validate code, validate code blocks, which will then validateRequired, etc
+		global $xoopsModuleConfig;
+		if ($xoopsModuleConfig['validateCode'] AND isEnabled('shell_exec')) {
+			print "\t\tvalidateMultiPageScreenPageCode();\n";
+		} else {
+			print "\t\trunMultiPageScreenPageSettingsSaveEvent();\n";
+		}
+		<{/php}>
+	});
+
+	async function validateMultiPageScreenPageCode() {
+		let error = ''
+		let errorMsg = ''
+		let code = $("#pit-custom-textarea").val();
+		let codePitSelected = $("input[id=pit-custom]:checked").length;
+		if(codePitSelected && code && code.trim() != '<?php') {
+			if(typeof checkedBlocks[99] === 'undefined' || (code != checkedBlocks[99].code)) {
+				error = await fz_check_php_code(code);
+				if(error.valid === false) {
+					errorMsg = `The custom code has an error:\n\n${error.result}`
+					checkedBlocks[99] = {
+						code: code,
+						valid: false,
+						error: errorMsg
+					}
+				} else {
+					checkedBlocks[99] = {
+						code: code,
+						valid: true,
+						error: ''
+					}
+				}
+			} else if(checkedBlocks[99].valid === false) {
+				errorMsg = checkedBlocks[99].error;
+			}
+		} else if(codePitSelected) {
+			checkedBlocks[99] = {
+				code: code,
+				valid: true,
+				error: ''
+			}
+		}
+		if(errorMsg) {
+			alert(errorMsg)
+		} else {
+			runMultiPageScreenPageSettingsSaveEvent();
+		}
+	}
+
+	function runMultiPageScreenPageSettingsSaveEvent() {
+    if(validateRequired()) {
 			var pagedata = window.document.getElementsByName("popupform");
 			$.post("save.php?popupsave=1", $(pagedata).serialize(), function(data) {
 				if(data) {
@@ -163,13 +214,13 @@ $(".conditionsdelete").click(function () {
 				$('div#drawer-5-<{$pageIndex}> span.accordion-name').text($('input#screens-pagetitle_<{$pageIndex}>').val());
 				$.get('<{$smarty.const.XOOPS_URL}>/modules/formulize/admin/multipageScreenGeneratePageItemDescription.php?sid=<{$sid}>&page=<{$pageIndex}>', function(data) {
 					$('div#drawer-5-<{$pageIndex}> div.accordion-content').empty();
-					$('div#drawer-5-<{$pageIndex}> div.accordion-content').append(data);	
+					$('div#drawer-5-<{$pageIndex}> div.accordion-content').append(data);
 				});
 				window.document.getElementById('popupsavewarning').style.display = 'none';
 			});
     }
     $(".savebuttonpopup").blur();
-  });
+  }
 
 	function reloadPopup() {
 		$("#dialog-page-settings-content").load('<{$smarty.const.XOOPS_URL}>/modules/formulize/admin/screen_multipage_pages_settings.php?page=<{$pageIndex}>&sid=<{$sid}>');

--- a/modules/formulize/templates/admin/screen_multipage_pages_settings.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_settings.html
@@ -42,7 +42,8 @@
 
 			<div class="form-item pit-contents" id="pit-custom-contents">
 				<input type="hidden" name="screensx-page<{$pageIndex}>[0]" value="PHP">
-				<textarea id="pit-custom-textarea" name="screensx-page<{$pageIndex}>[1]" class="code-textarea canValidate"><{$pageElements[1]}></textarea>
+				<textarea id="pit-custom-textarea" name="screensx-page<{$pageIndex}>[1]" class="code-textarea canValidate"><{if $pageElements[1] AND $pageElements[1]|is_numeric == false}><{$pageElements[1]}><{else}><?php
+<{/if}></textarea>
 			</div>
 		</div>
 
@@ -160,6 +161,10 @@ $(".conditionsdelete").click(function () {
 					}
 				}
 				$('div#drawer-5-<{$pageIndex}> span.accordion-name').text($('input#screens-pagetitle_<{$pageIndex}>').val());
+				$.get('<{$smarty.const.XOOPS_URL}>/modules/formulize/admin/multipageScreenGeneratePageItemDescription.php?sid=<{$sid}>&page=<{$pageIndex}>', function(data) {
+					$('div#drawer-5-<{$pageIndex}> div.accordion-content').empty();
+					$('div#drawer-5-<{$pageIndex}> div.accordion-content').append(data);	
+				});
 				window.document.getElementById('popupsavewarning').style.display = 'none';
 			});
     }

--- a/modules/formulize/templates/admin/screen_multipage_pages_settings.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_settings.html
@@ -164,9 +164,8 @@ $(".conditionsdelete").click(function () {
 	async function validateMultiPageScreenPageCode() {
 		let error = ''
 		let errorMsg = ''
-		let code = $("#pit-custom-textarea").val();
-		let codePitSelected = $("input[id=pit-custom]:checked").length;
-		if(codePitSelected && code && code.trim() != '<?php') {
+		let code = $("input[id=pit-custom]:checked").length ? $("#pit-custom-textarea").val() : '';
+		if(code && code.trim() != '<?php') {
 			if(typeof checkedBlocks[99] === 'undefined' || (code != checkedBlocks[99].code)) {
 				error = await fz_check_php_code(code);
 				if(error.valid === false) {
@@ -186,7 +185,7 @@ $(".conditionsdelete").click(function () {
 			} else if(checkedBlocks[99].valid === false) {
 				errorMsg = checkedBlocks[99].error;
 			}
-		} else if(codePitSelected) {
+		} else {
 			checkedBlocks[99] = {
 				code: code,
 				valid: true,

--- a/modules/formulize/templates/admin/screen_multipage_pages_settings.html
+++ b/modules/formulize/templates/admin/screen_multipage_pages_settings.html
@@ -6,34 +6,60 @@
 	<input type="hidden" name="conditionsdelete" value="">
 	<input type="hidden" name="piforjquery" value=<{$pageIndex}>>
 	<div id=popupsavebutton><input type="button" class="savebuttonpopup" id="savebuttonpopup" value="Save your changes"/></div>
-	<div id="popupsavewarning">You have unsaved changes!</div>
+	<div id="popupsavewarning">&nbsp;&nbsp;You have unsaved changes!</div>
 	<div style="clear: both"></div>
-	<div class="accordion-box">
-	  <div class="form-item required">
-		  <label for="screens-pagetitle_<{$pageIndex}>">Title for page number <{$pageNumber}></label>
-      <input type="text" class="required_formulize_element" id="screens-pagetitle_<{$pageIndex}>" name="screens-pagetitle_<{$pageIndex}>" value="<{$pageTitle}>" size="30" maxlength="255"/>
-		  <div class="description"></div>
-	  </div>
-	  <div class="form-item">
-		  <label for="screens-page<{$pageIndex}>">Form elements to display on page <{$pageNumber}></label><br>
-	    <select id="screens-page<{$pageIndex}>" name="screens-page<{$pageIndex}>[]" size="10" multiple>
-        <{html_options options=$options selected=$pageElements}>
-	    </select>
-		  <div class="description"></div>
-	  </div>
-	</div>
+	<div class="flex-box">
+		<div>
+			<div class="form-item required">
+				<label for="screens-pagetitle_<{$pageIndex}>">Title for page number <{$pageNumber}></label>
+				<input type="text" class="required_formulize_element" id="screens-pagetitle_<{$pageIndex}>" name="screens-pagetitle_<{$pageIndex}>" value="<{$pageTitle}>" size="30" maxlength="255"/>
+			</div>
 
-	<div class="accordion-box">
-				<p>What conditions are there on the display of this page?</p>
-				<{$pageConditions}>
-				<div class="description"><p>If you don't specify any conditions, the page will always be included in the form.</p></div>
-	</div>
+			<div class="form-item">
+				<br>
+				<label for="pit-elements"><input id="pit-elements" type="radio" name="pageItemType" value="0"> This page displays form elements</label><br>
+				<{if $screenOptions}><label for="pit-screen"><input id="pit-screen" type="radio" name="pageItemType" value="1"> This page displays a specific screen</label><br><{/if}>
+				<label for="pit-custom"><input id="pit-custom" type="radio" name="pageItemType" value="2"> This page displays custom code</label><br>
+				<br>
+			</div>
 
+			<div class="form-item pit-contents" id="pit-elements-contents">
+				<label for="screens-page<{$pageIndex}>">Form elements to display on page <{$pageNumber}>:</label><br>
+				<select id="screens-page<{$pageIndex}>" name="screensx-page<{$pageIndex}>[]" size="10" multiple>
+					<{html_options options=$elementOptions selected=$pageElements}>
+				</select>
+			</div>
+
+			<{if $screenOptions}>
+			<div class="form-item pit-contents" id="pit-screen-contents">
+				<label for="screens-page<{$pageIndex}>">Screen to display on page <{$pageNumber}>:</label><br>
+				<select id="screens-page<{$pageIndex}>" name="screensx-page<{$pageIndex}>[]" size="1">
+					<{html_options options=$screenOptions selected=$pageElements}>
+				</select>
+				<div class="description">All pages of the selected screen will be included as pages in this screen.</div>
+			</div>
+			<{/if}>
+
+			<div class="form-item pit-contents" id="pit-custom-contents">
+				<input type="hidden" name="screensx-page<{$pageIndex}>[0]" value="PHP">
+				<textarea id="pit-custom-textarea" name="screensx-page<{$pageIndex}>[1]" class="code-textarea canValidate"><{$pageElements[1]}></textarea>
+			</div>
+		</div>
+
+		<div>
+			<p>What conditions are there on the display of this page?</p>
+			<{$pageConditions}>
+			<div class="description"><p>If you don't specify any conditions, the page will always be included in the form.</p></div>
+		</div>
+
+	</div>
 
 </form>
 </div>
 
 <script type="text/javascript">
+
+	var multipagePopupTextareaInitialized = false;
 
 	// If saveLock is turned on, do not display save button to user, instead display "READ ONLY"
 	$( document ).ready(function() {
@@ -41,8 +67,44 @@
 			document.getElementById('savebuttonpopup').style.visibility = 'hidden';
 			document.getElementById('popupsavebutton').innerHTML = "READ ONLY";
 		<{/if}>
+		$('div.pit-contents').hide();
+		$('div#<{$pit}>-contents').show();
+		enablePitContents('<{$pit}>');
+		$('input#<{$pit}>').attr('checked', true);
+		<{if $pit == 'pit-custom'}>
+		initializeMultipagePopupTextarea()
+		<{/if}>
 
 	});
+
+	function enablePitContents(pit) {
+		$('div.pit-contents [name^=screens-page]').each(function() {
+			$(this).attr('name', $(this).attr('name').replace('screens-', 'screensx-'));
+		});
+		$('div#'+pit+'-contents [name^=screensx-page').each(function() {
+			$(this).attr('name', $(this).attr('name').replace('screensx-', 'screens-'));
+		})
+	}
+
+	function initializeMultipagePopupTextarea() {
+		if(!multipagePopupTextareaInitialized) {
+			CodeMirror.fromTextArea($('textarea#pit-custom-textarea')[0], {
+				lineNumbers: true,
+				matchBrackets: true,
+				mode: "application/x-httpd-php",
+				indentUnit: 4,
+				indentWithTabs: true,
+				enterMode: "keep",
+				tabMode: "shift",
+				lineWrapping: true,
+				onChange: function(instance) {
+					setDisplay('popupsavewarning','block');
+					instance.save(); // Call this to update the textarea value for the ajax post
+				}
+			});
+		}
+		multipagePopupTextareaInitialized = true;
+	}
 
   $("input").change(function() {
     window.document.getElementById('popupsavewarning').style.display = 'block';
@@ -55,8 +117,16 @@
     });
   $("textarea").keydown(function() {
     window.document.getElementById('popupsavewarning').style.display = 'block';
-    });
+  });
 
+$('input[name=pageItemType]').click(function() {
+	$('div.pit-contents').hide();
+	$('div#'+$(this).attr('id')+'-contents').show();
+	enablePitContents($(this).attr('id'));
+	if($(this).attr('id')=='pit-custom') {
+		initializeMultipagePopupTextarea();
+	}
+});
 
 $(".savebuttonpopup").click(function() {
   $(".required_formulize_element").each(function() {
@@ -79,7 +149,7 @@ $(".conditionsdelete").click(function () {
 });
 
 	$(".savebuttonpopup").click(function() {
-    if(validateRequired()) {
+    if(validateRequired()) { // code validation not happening yet for custom code in multipage screen pages!
 			var pagedata = window.document.getElementsByName("popupform");
 			$.post("save.php?popupsave=1", $(pagedata).serialize(), function(data) {
 				if(data) {
@@ -89,8 +159,8 @@ $(".conditionsdelete").click(function () {
 						alert(data);
 					}
 				}
+				$('div#drawer-5-<{$pageIndex}> span.accordion-name').text($('input#screens-pagetitle_<{$pageIndex}>').val());
 				window.document.getElementById('popupsavewarning').style.display = 'none';
-
 			});
     }
     $(".savebuttonpopup").blur();

--- a/modules/formulize/templates/css/formulize-admin.css
+++ b/modules/formulize/templates/css/formulize-admin.css
@@ -1483,7 +1483,7 @@ div.save-view-access {
   border: solid 1px #9F6000; }
 
 #popupsavewarning {
-  padding-top: 1.75em;
+  padding-top: 0.2em;
   display: none;
   color: red; }
 
@@ -1758,4 +1758,11 @@ div#element-mgmt-ui .ui-accordion {
 form.formulize-admin-form input[type=text] {
 	margin-bottom: 0;
 	margin-top: 0;
+}
+
+div.flex-box {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	gap: 2em;
 }

--- a/modules/formulize/templates/css/formulize-admin.css
+++ b/modules/formulize/templates/css/formulize-admin.css
@@ -1766,3 +1766,7 @@ div.flex-box {
 	justify-content: space-between;
 	gap: 2em;
 }
+
+.pit-contents {
+	width: 440px;
+}


### PR DESCRIPTION
A few to dos here... 

- [x] Make the references to screens recursive
- [x] Remove non-element pages from the assignment options for elements on the Display tab
- [x] Code validation for custom code in pages