### PR TITLE
Live derived value updates

### DIFF
--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -227,6 +227,14 @@ switch($op) {
     $json = '{ "elements" : [';
     foreach(explode(',',$elementId) as $thisElementId) {
       $elementObject = $element_handler->get($thisElementId);
+			if($elementObject->getVar('ele_type') == "derived") {
+				// if it's a derived value, we need to do an update of the derived values based on this changed value... but not save it!!
+				// When the global formulize_asynchronousFormDataInAPIFormat has values in it, the derived value computation will put
+				// the values into asynch space to later be picked up when rendered. Does not write values to the database.
+				// However, if derived value code is specifically writing anything anywhere because someone wrote it that way, those writing operations may happen now!
+				// People should not be using derived values for that kind of thing. They should be using on_before_save and on_after_save.
+				formulize_updateDerivedValues($entryId, $fid, $frid);
+			}
 			$html = "";
       $json .= $jsonSep.'{ "handle" : '.json_encode('de_'.$_GET['fid'].'_'.$_GET['entryId'].'_'.$thisElementId);
       if(security_check($fid, $entryId)) {

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -2920,7 +2920,11 @@ function loadValue($prevEntry, $element, $ele_value, $owner_groups, $entry_id) {
 			switch ($type)
 			{
 				case "derived":
-					$ele_value[5] = $value;	// there is not a number 5 position in ele_value for derived values...we add the value to print in this position so we don't mess up any other information that might need to be carried around
+					if(isset($GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entry_id][$element->getVar('ele_handle')])) {
+						$ele_value[5] = $GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entry_id][$element->getVar('ele_handle')];
+					} else {
+						$ele_value[5] = $value;	// there is not a number 5 position in ele_value for derived values...we add the value to print in this position so we don't mess up any other information that might need to be carried around
+					}
 					break;
 
 


### PR DESCRIPTION
If a derived value has a display conditional based on another element(s), and that element(s) are referenced in the derived value formula, then when the derived value is conditionally displayed/redisplayed, it will show a value based on the live value presently in the form on screen.

Such values are not saved to the database, they are only displayed. The computation is repeated when the entry is saved, and the values at that time are used to compute the derived value.

If a derived value formula is doing odd things and interacting with other data, those operations will proceed when the conditional display happens, same as if there is a save operation. This could be problematic, and people should only use conditional derived values when appropriate, and perform other operations affecting other data in on_before_save and on_after_save events, for example.

This feature could be made easier to use if we add some awareness/metadata to derived values to declare which elements they are referencing in code, and then we could automatically make them conditional based on those elements. Right now, the webmaster has to specifically add a display condition to the derived value for the live updates to take place. Typical display conditions would be "element-we-depend-on IS NOT {BLANK}"