### PR TITLE
FEATURE: Adding support for database options in trust config

### DIFF
--- a/install/templates/mainfile.dist.php
+++ b/install/templates/mainfile.dist.php
@@ -26,13 +26,13 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
 	// This constant also causes errors to still be logged (but not displayed) when the Developer Dashboard setting is off.
 	// Comment out this constant if you don't want any of this behaviour
 	define("ICMS_ERROR_LOG_SEVERITY", E_WARNING);
-	
+
 	// ADDED BY FREEFORM SOLUTIONS
 	// Set the default timezone to UTC if there is no other timezone specifically set already
 	if ("UTC" == @date_default_timezone_get()) {
 		date_default_timezone_set("UTC");
 	}
-		
+
 	// XOOPS Physical Path
 	// Physical path to your main XOOPS directory WITHOUT trailing slash
 	// Example: define('XOOPS_ROOT_PATH', '/path/to/xoops/directory');
@@ -127,9 +127,9 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
 	    // Set the database charset if applicable
     if (defined('XOOPS_DB_CHARSET')) die();
     define('XOOPS_DB_CHARSET', '');
-	
+
 	$xoopsDBCharset = XOOPS_DB_CHARSET ? XOOPS_DB_CHARSET : 'utf8mb4';
-	define('XOOPS_DB_DSN', 'host='.SDATA_DB_HOST.';dbname='.SDATA_DB_NAME.';charset='.$xoopsDBCharset); 
+	define('XOOPS_DB_DSN', 'host='.SDATA_DB_HOST.';dbname='.SDATA_DB_NAME.';charset='.$xoopsDBCharset);
 
 	// Table Prefix
 	// This prefix will be added to all new tables created to avoid name conflict in the database. If you are unsure, just use the default 'icms'.
@@ -155,7 +155,14 @@ if (!defined("XOOPS_MAINFILE_INCLUDED")) {
 	// This salt will be appended to passwords in the icms_encryptPass() function.
 	// Do NOT change this once your site is Live, doing so will invalidate everyones Password.
 	define('XOOPS_DB_SALT', '');
-	
+
+	// Additional database options
+	if (defined('SDATA_DB_OPTIONS') && is_array(SDATA_DB_OPTIONS) && !empty(SDATA_DB_OPTIONS)) {
+		define ('XOOPS_DB_OPTIONS', SDATA_DB_OPTIONS);
+	} else {
+		define ('XOOPS_DB_OPTIONS', NULL);
+	}
+
 	// Use persistent connection? (Yes=1 No=0)
 	// Default is 'Yes'. Choose 'Yes' if you are unsure.
 	define('XOOPS_DB_PCONNECT', 0);

--- a/install/templates/sdata.dist.php
+++ b/install/templates/sdata.dist.php
@@ -39,3 +39,8 @@ define('SDATA_DB_PREFIX', '');
 // This salt will be appended to passwords in the icms_encryptPass() function.
 // Do NOT change this once your site is Live, doing so will invalidate everyones Password.
 define('SDATA_DB_SALT', '');
+
+// Additional database options
+// If you need to specify additional options for the database connection, you can do so here.
+// For example, to specify the charset to be used, you can set the PDO::MYSQL_ATTR_INIT_COMMAND option to "SET NAMES utf8"
+define('SDATA_DB_OPTIONS', []);

--- a/install/templates/sdata.dist.php
+++ b/install/templates/sdata.dist.php
@@ -42,5 +42,5 @@ define('SDATA_DB_SALT', '');
 
 // Additional database options
 // If you need to specify additional options for the database connection, you can do so here.
-// For example, to specify the charset to be used, you can set the PDO::MYSQL_ATTR_INIT_COMMAND option to "SET NAMES utf8"
+// For example, to specify the charset to be used, you can set the PDO::ATTR_ERRMODE option to "PDO::ERRMODE_EXCEPTION"
 define('SDATA_DB_OPTIONS', []);

--- a/libraries/icms/db/Factory.php
+++ b/libraries/icms/db/Factory.php
@@ -29,12 +29,7 @@ abstract class icms_db_Factory {
 		if (!class_exists($class)) {
 			$class = "icms_db_Connection";
 		}
-		$test = XOOPS_DB_OPTIONS;
-		self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS, XOOPS_DB_OPTIONS);
-		$currentErrMode = self::$pdoInstance->getAttribute(PDO::ATTR_ERRMODE);
-
-		return self::pdoInstance();
-		// return self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS, XOOPS_DB_OPTIONS);
+		return self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS, XOOPS_DB_OPTIONS);
 	}
 	/**
 	 * Get a reference to the only instance of database class and connects to DB

--- a/libraries/icms/db/Factory.php
+++ b/libraries/icms/db/Factory.php
@@ -29,7 +29,12 @@ abstract class icms_db_Factory {
 		if (!class_exists($class)) {
 			$class = "icms_db_Connection";
 		}
-		return self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS);
+		$test = XOOPS_DB_OPTIONS;
+		self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS, XOOPS_DB_OPTIONS);
+		$currentErrMode = self::$pdoInstance->getAttribute(PDO::ATTR_ERRMODE);
+
+		return self::pdoInstance();
+		// return self::$pdoInstance = new $class($dsn, XOOPS_DB_USER, XOOPS_DB_PASS, XOOPS_DB_OPTIONS);
 	}
 	/**
 	 * Get a reference to the only instance of database class and connects to DB


### PR DESCRIPTION
Provides an SDATA_DB_OPTIONS constant in your trust file which can be used to add PDO options. If the constant is missing or is an empty array the default of `null` will be passed to PDO.