### PR TITLE
FIX: onetoone and regular conditions work together on the same form

### DIFF
--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -1166,6 +1166,7 @@ function checkForLinks($frid, $fids, $fid, $entries=null, $unified_display=false
         }
     }
 
+    $sub_entries = array();
     foreach ($one_to_many as $many_fid) {
         $sub_fids[] = $many_fid['fid'];
         if (isset($entries[$fid][0])) {
@@ -1174,7 +1175,9 @@ function checkForLinks($frid, $fids, $fid, $entries=null, $unified_display=false
                 $entries_found = findLinkedEntries($fid, $many_fid, $entries[$fid][0]);
                 if (is_array($entries_found)) {
                     foreach ($entries_found as $many_entry) {
-                        $sub_entries[$many_fid['fid']][] = $many_entry;
+                        if(!isset($sub_entries[$many_fid['fid']]) OR !in_array($many_entry, $sub_entries[$many_fid['fid']])) {
+                            $sub_entries[$many_fid['fid']][] = $many_entry;
+                        }
                     }
                 }
             }
@@ -1190,7 +1193,9 @@ function checkForLinks($frid, $fids, $fid, $entries=null, $unified_display=false
             if ($thisent = $entries[$fid][0]) {
                 $entries_found = findLinkedEntries($fid, $manyToOneFid, $entries[$fid][0]);
                 foreach ($entries_found as $many_entry) {
-                    $entries[$manyToOneFid['fid']][] = $many_entry;
+                    if(!isset($entries[$manyToOneFid['fid']]) OR !in_array($many_entry, $entries[$manyToOneFid['fid']])) {
+                        $entries[$manyToOneFid['fid']][] = $many_entry;
+                    }
                 }
             }
         } else {

--- a/modules/formulize/include/js/conditional.js
+++ b/modules/formulize/include/js/conditional.js
@@ -9,6 +9,7 @@ var conditionalCheckInProgress = 0;
 function callCheckCondition(name) {
 	const checks = [];
     const relevantElementSets = [];
+	const relevantElementSetsUseOneToOne = [];
 	var oneToOne;
 	for(key in governedElements[name]) {
 		var markupHandle = governedElements[name][key];
@@ -19,12 +20,13 @@ function callCheckCondition(name) {
 		}
 		elementValuesForURL = getRelevantElementValues(markupHandle, oneToOne);
         if(elementValuesForURL in relevantElementSets == false) {
+			relevantElementSetsUseOneToOne[elementValuesForURL] = oneToOne;
             relevantElementSets[elementValuesForURL] = new Array();
         }
         relevantElementSets[elementValuesForURL].push(markupHandle);
     }
     for(elementValuesForURL in relevantElementSets) {
-        checks.push(checkCondition(relevantElementSets[elementValuesForURL], elementValuesForURL, oneToOne));
+        checks.push(checkCondition(relevantElementSets[elementValuesForURL], elementValuesForURL, relevantElementSetsUseOneToOne[elementValuesForURL]));
     }
     var results = jQuery.when.apply(jQuery, checks);
     results.done(function(){


### PR DESCRIPTION
This PR cleans up the handling of conditional elements, when there is a mix of onetoone elements and regular conditional elements on the same form screen.

Previously, multiple conditional checks were being fired, when we only want the one to one conditions in cases where the one to one governing element was altered.

There are various fixes/refinements to determining the correct entry to use as the context for rendering the element, in various situations.

One to one conditions now have the one to one metadata attached, and we respond to that accordingly. Non-onetoone conditions don't have that metadata and behave normally.