### PR TITLE
Fix "random" session loss

### DIFF
--- a/modules/formulize/class/fileUploadElement.php
+++ b/modules/formulize/class/fileUploadElement.php
@@ -117,9 +117,10 @@ class formulizeFileUploadElementHandler extends formulizeElementsHandler {
     // $caption is the prepared caption for the element
     // $markupName is what we have to call the rendered element in HTML
     // $isDisabled flags whether the element is disabled or not so we know how to render it
-    // $element is the element object
+		// $element is the element object
     // $entry_id is the ID number of the entry where this particular element comes from
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id) {
+    // $screen is the screen object that is in effect, if any (may be null)
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
         // ele_value[3] is the fileName or error message
         // ele_value[4] is the displayName version of the fileName (only going to be diff from fileName if there is no direct linking to files allowed)
         // ele_value[5] is the flag for whether there's a file or not

--- a/modules/formulize/class/provinceListElement.php
+++ b/modules/formulize/class/provinceListElement.php
@@ -117,7 +117,8 @@ class formulizeProvinceListElementHandler extends formulizeElementsHandler {
     // $isDisabled flags whether the element is disabled or not so we know how to render it
     // $element is the element object
     // $entry_id is the ID number of the entry where this particular element comes from
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id) {
+    // $screen is the screen object that is in effect, if any (may be null)
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
 		$provinceList = $this->getProvinceList();
 
 		if($isDisabled) {

--- a/modules/formulize/class/sliderElement.php
+++ b/modules/formulize/class/sliderElement.php
@@ -114,9 +114,10 @@ class formulizeSliderElementHandler extends formulizeElementsHandler {
     // $caption is the prepared caption for the element
     // $markupName name of rendered element in the HTML
     // $isDisabled flags whether the element should be rendered or not
-    // $element is the element object
-    // $entry_id is the ID of the entry for the element
-    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id) {
+		// $element is the element object
+    // $entry_id is the ID number of the entry where this particular element comes from
+    // $screen is the screen object that is in effect, if any (may be null)
+    function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen, $owner) {
         $slider_html = "<input type=\"range\" ";
         $slider_html .= "name=\"{$markupName}\"";
         $slider_html .= "id=\"{$markupName}\"";

--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -209,11 +209,16 @@ switch($op) {
       }
     }
 		$screenObject = null;
-		if($sid) {
+		$groups = $xoopsUser ? $xoopsUser->getGroups() : array(0=>XOOPS_GROUP_ANONYMOUS);
+		$gperm_handler = xoops_gethandler('groupperm');
+		if($sid AND $viewFormPermission = $gperm_handler->checkRight("view_form", $fid, $groups, getFormulizeModId())) {
 			$screen_handler = xoops_getmodulehandler('screen', 'formulize');
 			if($screenObject = $screen_handler->get($sid)) {
 				$screen_handler = xoops_getmodulehandler($screenObject->getVar('type').'Screen', 'formulize');
 				$screenObject = $screen_handler->get($sid);
+				if($screenObject->getVar('fid') != $fid) {
+					$screenObject = null;
+				}
 			}
 		}
 		// Normally, the entryId we're rendering is the one displayed in the form at load time, elements are dependent on conditions, but always rendered as in that entry.

--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -213,11 +213,10 @@ switch($op) {
 		$gperm_handler = xoops_gethandler('groupperm');
 		if($sid AND $viewFormPermission = $gperm_handler->checkRight("view_form", $fid, $groups, getFormulizeModId())) {
 			$screen_handler = xoops_getmodulehandler('screen', 'formulize');
-			if($screenObject = $screen_handler->get($sid)) {
-				$screen_handler = xoops_getmodulehandler($screenObject->getVar('type').'Screen', 'formulize');
-				$screenObject = $screen_handler->get($sid);
-				if($screenObject->getVar('fid') != $fid) {
-					$screenObject = null;
+			if($candidateScreenObject = $screen_handler->get($sid)) {
+				if($candidateScreenObject->getVar('fid') == $fid) {
+					$screen_handler = xoops_getmodulehandler($candidateScreenObject->getVar('type').'Screen', 'formulize');
+					$screenObject = $screen_handler->get($sid);
 				}
 			}
 		}

--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -345,7 +345,7 @@ switch($op) {
 function renderElement($elementObject, $entryId, $frid, $screenObject) {
 
 	$GLOBALS['formulize_asynchronousRendering'][$elementObject->getVar('ele_handle')] = true;
-	$deReturnValue = displayElement("", $elementObject, $entryId, false, $screenObject, null, false); // false, null, null, false means it's not a noSave element, no screen, no prevEntry data passed in, and do not render the element on screen
+	$deReturnValue = displayElement("", $elementObject, $entryId, false, $screenObject, null, false); // false, means it's not a noSave element, null, false means no prevEntry data passed in, and do not render the element on screen
 	unset($GLOBALS['formulize_asynchronousRendering']);
 
 	// element is allowed, so prep some stuff for rendering...

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -118,15 +118,8 @@ class formulize_themeForm extends XoopsThemeForm {
         $template = '';
 				global $xoopsUser;
 				$uid = $xoopsUser ? $xoopsUser->getVar('uid') : 0;
-        if($this->getTitle() != 'formulizeAsynchElementRender' AND is_object($this->screen)) {
-            $template = getTemplateToRender($type, $this->screen);
-        } elseif(isset($_SESSION['formulizeScreenId'][$uid]) AND $sid = $_SESSION['formulizeScreenId'][$uid]) {
-            // retrieve the cached screen id from when the form was first rendered, if we're rendering a disembodied element now as part of an asynchronous conditional call -- screen object is not available in this case because we are only working with the individual element
-            $screen_handler = xoops_getmodulehandler('screen', 'formulize');
-            $screen = $screen_handler->get($sid);
-            $screenType = $screen->getVar('type');
-            $screen_handler = xoops_getmodulehandler($screenType.'Screen', 'formulize');
-            $template = getTemplateToRender($type, $screen_handler->get($sid));
+        if(is_object($this->screen)) {
+          $template = getTemplateToRender($type, $this->screen);
         }
         if(!$template) {
             $template = getTemplateToRender($type, 'multiPage');
@@ -192,7 +185,7 @@ class formulize_themeForm extends XoopsThemeForm {
             }
         }
 
-        if($this->getTitle() != 'formulizeAsynchElementRender' AND is_object($this->screen)) {
+        if(is_object($this->screen)) {
             $modifyScreenLink = $this->modifyScreenLink;
         }
 
@@ -241,8 +234,8 @@ class formulize_themeForm extends XoopsThemeForm {
 		return $js;
 	}
 
-    function _getColumns($ele) {
-			if($this->getTitle() != 'formulizeAsynchElementRender' AND is_object($this->screen)) {
+    function _getColumns() {
+			if(is_object($this->screen)) {
 					$columns = $this->screen->getVar('displaycolumns') == 1 ? 1 : 2;
 					if($this->screen->getVar('column1width')) {
 							$column1width = $this->screen->getVar('column1width');
@@ -265,7 +258,7 @@ class formulize_themeForm extends XoopsThemeForm {
 
 		foreach ( $elements as $ele ) {
 
-			$columnData = $this->_getColumns($ele);
+			$columnData = $this->_getColumns();
 			$columns = $columnData[0];
 			$column1Width = str_replace(';','',$columnData[1]);
 			$column2Width = str_replace(';','',$columnData[2]);
@@ -409,7 +402,7 @@ class formulize_themeForm extends XoopsThemeForm {
 
 		static $show_element_edit_link = null;
 		global $formulize_drawnElements;
-        $columnData = $this->_getColumns($ele);
+    $columnData = $this->_getColumns();
 		// initialize things first time through...
 		if($show_element_edit_link === null) {
 			$formulize_drawnElements = array();
@@ -537,7 +530,7 @@ class formulize_themeForm extends XoopsThemeForm {
                         }
                     }
                     $js .= ")==false) {\n".$validationJs."\n}";
-                    $columnData = $this->_getColumns($ele);
+                    $columnData = $this->_getColumns();
                     $columns = $columnData[0];
                     if(strstr($this->getTemplate('elementcontainero'), "\$elementContainerId") OR strstr($this->getTemplate('elementtemplate'.$columns), "\$elementContainerId")) {
                         $checkConditionalRow = true;

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -241,85 +241,35 @@ class formulize_themeForm extends XoopsThemeForm {
 		return $js;
 	}
 
-    // reset will cause the cached copy of columns to be bypassed - this is done when a form is rendered, so that we don't reuse the setting for an element when it appeared on a different screen in the past in this same session
-    function _getColumns($ele, $reset = false) {
-        global $xoopsUser, $xoopsConfig;
-        $uid = $xoopsUser ? $xoopsUser->getVar('uid') : 0;
-        // cache in the session the column setting we used for a given element last time it was rendered
-        // should be unnecessary to segregate by uid in the session superglobal, but can't hurt
-        // This caching is necessary so that conditional calls for rendering the element work as expected!
-
-        // cache also the screen id since we need to lookup the template according to the screen object settings
-
-        // if a numeric value is passed as ele, that is an element id, sent specifically so we can seed the right column value based on the screen setting
-        if(is_numeric($ele)) {
-            $eleKey = $ele;
-        } elseif(is_object($ele) AND isset($ele->formulize_element)) {
-            $eleKey = $ele->formulize_element->getVar('ele_id');
-        } elseif(is_object($ele)) {
-			$eleKey = md5(serialize($ele));
-        } elseif(strstr($ele, "<<||>>")) {
-            $ele = explode("<<||>>", $ele);
-            $parts = explode('_', $ele[1]);
-            $ele_id = $parts[3];
-            $eleKey = $ele_id;
-        } else {
-            $eleKey = md5($ele);
-        }
-
-        if(isset($_SESSION['columns'][$uid][$eleKey]) AND !$reset) {
-            $columns = $_SESSION['columns'][$uid][$eleKey];
-        } elseif($this->getTitle() != 'formulizeAsynchElementRender' AND is_object($this->screen)) {
-            $_SESSION['formulizeScreenId'][$uid] = $this->screen->getVar('sid');
-            $columns = $this->screen->getVar('displaycolumns') == 1 ? 1 : 2;
-            if($this->screen->getVar('column1width')) {
-                $column1width = $this->screen->getVar('column1width');
-            } elseif($columns == 2) {
-                $column1width = '20%';
-            } else {
-                $column1width = 'auto';
-            }
-            $column2width = $this->screen->getVar('column2width') ? $this->screen->getVar('column2width') : 'auto';
-            $columns = array($columns, $column1width, $column2width);
-        } elseif($_SERVER['SCRIPT_NAME'] == '/modules/formulize/admin/fakeform.php') {
-						$columns = array(2, '20%', 'auto');
-        } else {
-            $columns = array(1, 'auto', 'auto');
-        }
-        $_SESSION['columns'][$uid][$eleKey] = $columns;
-        return $columns;
+    function _getColumns($ele) {
+			if($this->getTitle() != 'formulizeAsynchElementRender' AND is_object($this->screen)) {
+					$columns = $this->screen->getVar('displaycolumns') == 1 ? 1 : 2;
+					if($this->screen->getVar('column1width')) {
+							$column1width = $this->screen->getVar('column1width');
+					} elseif($columns == 2) {
+							$column1width = '20%';
+					} else {
+							$column1width = 'auto';
+					}
+					$column2width = $this->screen->getVar('column2width') ? $this->screen->getVar('column2width') : 'auto';
+					$columns = array($columns, $column1width, $column2width);
+			} elseif($_SERVER['SCRIPT_NAME'] == '/modules/formulize/admin/fakeform.php') {
+					$columns = array(2, '20%', 'auto');
+			} else {
+					$columns = array(1, 'auto', 'auto');
+			}
+			return $columns;
     }
 
 	function _drawElements($elements, $ret, $hidden) {
 
 		foreach ( $elements as $ele ) {
 
-            if(is_string($ele) AND isset($GLOBALS['formulize_renderedElementHasConditions'])) {
-                // check if this is a placeholder row for an element that has conditions, and if so, deduce the element ID from the key in the global array of rendered elements that had conditions
-                foreach($GLOBALS['formulize_renderedElementHasConditions'] as $deKey=>$conditions) {
-                    if(strstr($ele, $deKey)) {
-                        $deParts = explode('_', $deKey);
-                        $eleToSetForColumns = $deParts[3];
-                        break;
-                    }
-                }
-            } else {
-                $eleToSetForColumns = $ele;
-            }
-
-            // set the column value for all elements, regardless of if they're being rendered or not, so we can pick up the value from session if a conditional element is activated later asynchronously
-            // but only do this when rendering the screen that the element is natively part of! -- conditionally hidden elements could otherwise end up with a different screen's settings as their cached-in-session settings
-            $eleToCheckForReset = is_numeric($eleToSetForColumns) ? $eleToSetForColumns : $ele->formulize_element;
-            if(($this->screen AND $this->screen->elementIsPartOfScreen($eleToCheckForReset))
-               OR (is_object($ele) AND ($ele->getName() == 'button-controls' OR $ele->getName() == 'proxyuser' OR substr($ele->getName(), 0, 12) == 'updateowner_'))) {
-                $columnData = $this->_getColumns($eleToSetForColumns, 'reset');
-            } else {
-                $columnData = $this->_getColumns($ele);
-            }
-            $columns = $columnData[0];
-            $column1Width = str_replace(';','',$columnData[1]);
-            $column2Width = str_replace(';','',$columnData[2]);
-            $startHidden = false;
+			$columnData = $this->_getColumns($ele);
+			$columns = $columnData[0];
+			$column1Width = str_replace(';','',$columnData[1]);
+			$column2Width = str_replace(';','',$columnData[2]);
+			$startHidden = false;
 
 			$containerOpen = '';
 			$containerContents = '';
@@ -3281,6 +3231,7 @@ var formulize_xhr_returned_check_for_unique_value = new Array();
 var FORMULIZE = {
 	XOOPS_URL : \"".XOOPS_URL."\",
 	XOOPS_UID : ".($xoopsUser ? $xoopsUser->getVar('uid') : 0).",
+	SCREEN_ID : ".($screen ? $screen->getVar('sid') : 0).",
 }
 ";
 $split = random_int(8, strlen(getCurrentURL())-2);

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -6319,7 +6319,7 @@ function formulize_xhr_send(op,params) {
 // provides the token that is associated witht he entry locking/unlocking for this page load
 function getEntryLockSecurityToken() {
     static $token;
-    $token = $token ? $token : $GLOBALS['xoopsSecurity']->createToken(0, 'formulize_entry_lock_token');
+    $token = $token ? $token : hash('sha256',(uniqid(rand(), true).$_SERVER['HTTP_USER_AGENT'].XOOPS_DB_PREFIX.$_SERVER['REMOTE_ADDR']));
     return $token;
 }
 

--- a/modules/formulize/include/js/conditional.js
+++ b/modules/formulize/include/js/conditional.js
@@ -114,7 +114,7 @@ function checkCondition(relevantElementSet, elementValuesForURL) {
         }
         elementIdsSep = ',';
     }
-	return jQuery.post(FORMULIZE.XOOPS_URL+"/modules/formulize/formulize_xhr_responder.php?uid="+FORMULIZE.XOOPS_UID+"&op=get_element_row_html&elementId="+elementIds+"&entryId="+entryId+"&fid="+fid+elementValuesForURL);
+	return jQuery.post(FORMULIZE.XOOPS_URL+"/modules/formulize/formulize_xhr_responder.php?uid="+FORMULIZE.XOOPS_UID+"&sid="+FORMULIZE.SCREEN_ID+"&op=get_element_row_html&elementId="+elementIds+"&entryId="+entryId+"&fid="+fid+elementValuesForURL);
 }
 
 function getRelevantElementValues(elements) {


### PR DESCRIPTION
Previously, we were storing a bunch of things in the user session, that we didn't need to. If too much stuff built up in the session, which is stored in the database, then the session could no longer be decoded by PHP after retrieving the session record from the database.

To resolve this, we are no longer storing stuff in the session that we don't need to have there. The main thing is the column settings for every rendered element, which was being stored there just in case the element was conditional and we needed to render it some time in the future. This was originally thought necessary because we don't have the screen settings at the time the conditional elements are rendered, so we cached the column settings for all elements when the screen was first rendered, so when asynch requests came in later we would know the column settings to use. Now we pass the screen id with the asynch request and we use that to determine the column settings based on the screen. Duh.

We also used the old token system to generate unique, personalized tokens related to entry locking. We then stored data about which entries were locked, in a file based on the token name, so we could look up the data later when a "delete entry lock" request came in. The old token system stores every token it creates in the session, because it presumes you are validating against the session in the future. We validate entry locks against the files we write (we used to do it all in session, I think, which is maybe why it made sense originally -- but as soon as we weren't validating against data in session, then we don't need to store tokens in session any longer). So now we just generate a unique token per page load that is used to handle entry locks, and nothing is stored in the session related to this at all. Files written to disk related to entry locking, are unaffected by this change and continue to work normally.

End result is that sessions do not have unnecessary things filling them up which can lead to the session being lost when it is no longer readable. The core tokens that are used for their original anti CSRF purpose, are still stored in session. We could/should evolve this to get rid of them sooner, or store them elsewhere, due to the 64KB size limit on data stored in TEXT fields in the database, because if someone exceeded that size on a particularly long session with intensive form loading, they would lose their session still. This is only an issue if users load many tabs/windows, and do not save data in the form. Tokens are issued for every form, and cleared when validated, but tokens that are never validated hang around because many that form will be submitted later.

*I have tested this locally and entry locking still works, and columns are used correctly in asynch rendering.*
