### PR TITLE
Handle special chars in rewriteruleAddress properly

### DIFF
--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -8558,7 +8558,7 @@ function updateAlternateURLIdentifierCode($screen, $entry_id) {
 				$dbValue = $dataHandler->getElementValueInEntry($entry_id, $rewriteruleElementObject);
 				$preppedValue = prepvalues($dbValue, $rewriteruleElementObject->getVar('ele_handle'), $entry_id); // will be array sometimes. Ugh!
 				$preppedValue = is_array($preppedValue) ? $preppedValue[0] : $preppedValue;
-				$entryIdentifier = urlencode($preppedValue);
+				$entryIdentifier = urlencode(htmlspecialchars_decode($preppedValue));
 			}
 			$code = "window.history.replaceState(null, '', '".trim(getCurrentURL(), '/')."/".$entryIdentifier."/');";
     }


### PR DESCRIPTION
One tiny change, so that if the rewriteruleAddress contains special chars in the database, then it is cleaned up before being output into the URL.

ie: if the title of a publication is the unique identifier used in the URL, and the title is Strengthening Canada's Resilience Against Disinformation, then the apostrophe will be encoded properly and it will then work in lookups later when the URL is used to access the page.

Note also, PHP 8.1+ required for the special char handling in 7.4+ to work cleanly! (since htmlspecialchar functions in PHP only use ENT_QUOTES as part of the default flags from 8.1 onwards)