### PR TITLE
Make getData aware of creation_uid joins!

### DIFF
--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -2064,11 +2064,14 @@ function formulize_getJoinHandles($elementArrays)
 	foreach ($elementArrays as $elementArray) { // must be a multidimensional array, ie: even if we're only asking for one element, it's got to be $elementsArrays[0][0] = idnumber
 		foreach ($elementArray as $element) {
 			if (!isset($cachedJoinHandles[$element])) {
-				if ($element == -1) {
+				if($element === "" OR $element === 0 OR $element === "0") {
+					$cachedJoinHandles[$element] = 'creation_uid';
+				} elseif ($element == -1) {
 					$cachedJoinHandles[$element] = 'entry_id';
-				} else {
-					$metaData = formulize_getElementMetaData($element);
+				} elseif($metaData = formulize_getElementMetaData($element)) {
 					$cachedJoinHandles[$element] = $metaData['ele_handle'];
+				} else {
+					$cachedJoinHandles[$element] = ''; // no valid join element
 				}
 			}
 		}


### PR DESCRIPTION
So somehow this was never in there already? If a relationship involves a connection based on creation_uid (ie: "The user who created the entries") then the join was not happening. Huh. This little fix adds support for when the joining element is zero, we properly use creation_uid as the joining field.