### PR TITLE
Docs for clean functions for gathering data

### DIFF
--- a/docs/function-gatherDataset.md
+++ b/docs/function-gatherDataset.md
@@ -1,0 +1,88 @@
+---
+layout: default
+permalink: developers/API/functions/gatherDataset/
+title: gatherDataset
+---
+
+# gatherDataset( <span style='font-size: 14pt;'>(int) $values, (int | string) $entry_id = "new", $action, (int) $proxyUser, (bool) $forceUpdate = false, (bool) $writeOwnerInfo = true</span> )
+
+## Location
+
+/modules/formulize/include/functions.php
+
+## Description
+
+Writes values to the database for a given record, or for a new record. Values are meant to be the database-ready values, ie: foreign keys rather than human-readable values in the case of linked elements, multiple values joined with a separator string in the case of checkboxes, etc.
+
+Also writes the entry ownership information to the database when the entry being written is a new record.
+
+Note that the form id does not need to be specified, since element ids and handles are globally unique, so they identify the form implicitly.
+
+This function calls the [writeEntry](../../classes/data_handler/writeEntry/) method and the [setEntryOwnerGroups](../../classes/data_handler/setEntryOwnerGroups/) methods of the [data handler](../../classes/data_handler/) class.
+
+## Parameters
+
+__$values__ - An array of the values to write to the database. The keys must be the element ids or element handles. "{WRITEASNULL}" indicates to write null as the value of the element. Setting actual NULL will work as well.<br>
+__$entry_id__ - Optional. The entry id to write the values to. If omitted then a new entry is written to the database.<br>
+__$action__ - Deprecated. Has no effect. Left in as a placeholder due to legacy code.<br>
+__$proxyUser__ - Optional. An alternate user id to use as the creator and owner of _new_ entries. By default, the creator is the user of the active session. This has no effect on existing entries.<br>
+__$forceUpdate__ - Optional. A boolean to indicate whether the query should be performed on GET requests. By default data can only be written to the database through a POST request.<br>
+__$writeOwnerInfo__ - Optional. A boolean to indicate whether the ownership information should be written to the database. Has an effect only when $entry_id is "new". The only time you would want to set this to false, is if you are writing multiple entries to the database, and are going to use the [setEntryOwnerGroups](../../classes/data_handler/setEntryOwnerGroups/) method of the [data handler](../../classes/data_handler/) class at a later point in time, to set the ownership for all the entries at once. It is more efficient to write the ownership information all at once for multiple new entries, than to write them one at a time when the entries are inserted into the database.
+
+## Return Values
+
+Returns the __entry id of the entry that was written__ to the database.
+
+Returns __nothing__ if no data was written to the database. Nothing will be written if all the values in the $values array match the existing values in the database. In this case, a notice is written to the error log.
+
+If the first key of the $values array is invalid, then page execution terminates and backtrace information is displayed.
+
+If the query fails, then page execution terminates and an error message is displayed. The This will occur if the second key in the $values array, or any subsequent key, is invalid.
+
+## Examples
+
+~~~php
+// write a new entry in the database
+$values = array(
+    'survey_first_name'=>'John',
+    'survey_last_name'='Smith'
+);
+formulize_writeEntry($values);
+~~~
+
+~~~php
+// Update entry 6 in the survey form with a new value for first name
+$values = array(
+    'survey_first_name'=>'Jonathan'
+);
+formulize_writeEntry($values, 6);
+~~~
+
+~~~php
+// get the entry id of the 'Toronto' entry in form 6 (a catalogue of cities),
+// and write a new entry in a survey form, with 'Toronto' as the value for a
+// linked element that points to form 6
+$form_id = 6;
+$dataHandler = new formulizeDataHandler($form_id);
+$entry_id = $dataHandler->findFirstEntryWithValue('cities_name', 'Toronto');
+formulize_writeEntry(array('survey_city_name'=>$entry_id));
+~~~
+
+~~~php
+// Write a new entry to the database, and record the owner as user 24
+$values = array(
+    'survey_first_name'=>'John',
+    'survey_last_name'='Smith'
+);
+formulize_writeEntry($values, proxyUser: 24);
+~~~
+
+~~~php
+// Write a new entry to the database as part of a regular page load that is
+// not the result of a form submission
+$values = array(
+    'survey_first_name'=>'John',
+    'survey_last_name'='Smith'
+);
+formulize_writeEntry($values, forceUpdate: true);
+~~~

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -306,6 +306,23 @@ function microtime_float()
 	return microtime(true);
 }
 
+// cleaner behaving alias of getData
+// mostly making frid default to PR, and just naming things more nicely
+// also surfacing the select of elementHandles nicely - multi dimensional array, keyed by fid first, and then each has an array of element handles in it
+// filter is the wild and crazy filter string, or array, etc
+function gatherDataset($fid,
+	$elementHandles=array(),
+	$filter="", 
+	$andOr="AND", 
+	$scope="", 
+	$limitStart = "",
+	$limitSize = "",
+	$sortField = "",
+	$sortOrder = "",
+	$frid=-1) {
+		return getData($frid, $fid, $filter, $andOr, $scope, $limitStart, $limitSize, $sortField, $sortOrder, filterElements: $elementHandles);
+}
+
 function getData(
 	$framework,
 	$form,
@@ -477,16 +494,11 @@ function dataExtraction($frame, $form, $filter, $andor, $scope, $limitStart, $li
 	$frid = "";
 	if (is_numeric($frame)) {
 		$frid = $frame;
-	} elseif ($frame != "") {
-		$frameid = go("SELECT frame_id FROM " . DBPRE . "formulize_frameworks WHERE frame_name='$frame'");
-		$frid = $frameid[0]['frame_id'];
-	}
+	} 
 	$fid = "";
 	if (is_numeric($form)) {
 		$fid = $form;
-	} else {
-		exit("The passed in value $form does not correspond to an existing form");
-	}
+	} 
 
 	$form_handler = xoops_getmodulehandler('forms', 'formulize');
 	$formObject = $form_handler->get($fid);
@@ -2538,6 +2550,14 @@ function getFormHandlesFromEntry($entry)
 		return array_keys($entry);
 	}
 	return "";
+}
+
+// more semantically correct aliases for display and displayDB
+function fetch($entry, $handle, $datasetKey = null, $localEntryId = null, $returnRawDBValue = false ) {
+	return display($entry, $handle, $datasetKey, $localEntryId, $returnRawDBValue);
+}
+function fetchRawVal($entry, $handle, $datasetKey = null, $localEntryId = null) {
+	return display($entry, $handle, $datasetKey, $localEntryId, returnRawDBValue: true);
 }
 
 /**


### PR DESCRIPTION
The old functions have needed semantic cleanup for a while. Now...

getData -> gatherDataset
display -> fetch
displayDB -> fetchRawVal (a new option! enabled by some of the 7.4 optimizations to how data is gathered vs prepped)

And documentation for the three functions.

Importantly, this also surfaces the ability to select only certain fields, which has been in getData for ages. But is not used generally because when building the entire interface, we don't know what fields someone might be referring to in code, so we get them all, just in case. We could be smarter about that with some static analysis of template code and derived values and stuff, but that's a lot of work! Regardless, end users of the functions should always select only the fields they want, to cut down on processing time, etc.