### PR TITLE
Fix printable view buttons

### DIFF
--- a/modules/formulize/admin/ui.php
+++ b/modules/formulize/admin/ui.php
@@ -173,6 +173,9 @@ $adminPage['isSaveLocked'] = sendSaveLockPrefToTemplate();
 $module_handler = xoops_gethandler('module');
 $formulizeModule = $module_handler->getByDirname("formulize");
 $metadata = $formulizeModule->getInfo();
+$config_handler = xoops_gethandler('config');
+$formulizeConfig = $config_handler->getConfigsByCat(0, getFormulizeModId());
+$xoopsTpl->assign('formulizeConfig', $formulizeConfig);
 
 // assign the contents to the template and display
 $adminPage['formulizeModId'] = getFormulizeModId();

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -384,13 +384,19 @@ class formulize_themeForm extends XoopsThemeForm {
 				// Only show elements if they have values
 				// unless the user has specifically said we should show all elements regardless through the config option.
 				// Also skip any element trays that have no elements in them (this is the case for the ancient printable view button, which is not currently active, and may be resurrected in a different form)
-        if((
-					(!isset($xoopsModuleConfig['show_empty_elements_when_read_only']) OR !$xoopsModuleConfig['show_empty_elements_when_read_only'])
-					AND !$templateVariables['renderedElement']
-					AND !is_numeric($templateVariables['renderedElement'])
-					) OR (
-						is_object($ele) AND is_a($ele, 'XoopsFormElementTray') AND empty($ele->getElements()) AND $ele->getName() != 'button-controls'
-					)) {
+        if(
+						(
+							(
+								(!isset($xoopsModuleConfig['show_empty_elements_when_read_only']) OR !$xoopsModuleConfig['show_empty_elements_when_read_only'])
+								AND !$templateVariables['renderedElement']
+								AND !is_numeric($templateVariables['renderedElement'])
+							) OR (
+								is_object($ele) AND is_a($ele, 'XoopsFormElementTray') AND empty($ele->getElements())
+							)
+						) AND (
+							$ele->getName() != 'button-controls'
+						)
+					) {
 						return "";
 				}
 

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -1159,7 +1159,7 @@ function displayForm($formframe, $entry="", $mainform="", $done_dest="", $button
     }
 
 	// set the alldoneoverride if necessary -- August 22 2006
-	$config_handler =& xoops_gethandler('config');
+	$config_handler = xoops_gethandler('config');
 	$formulizeConfig = $config_handler->getConfigsByCat(0, $mid);
 	// remove the all done button if the config option says 'no', and we're on a single-entry form, or the function was called to look at an existing entry, or we're on an overridden Multi-entry form
 	$allDoneOverride = (!$formulizeConfig['all_done_singles'] AND (($single OR $overrideMulti OR $original_entry) AND !$_POST['target_sub'] AND !$_POST['goto_sfid'] AND !$_POST['deletesubsflag'] AND !$_POST['parent_form'])) ? true : false;
@@ -1633,121 +1633,122 @@ function addSubmitButton($form, $subButtonText, $go_back, $currentURL, $button_t
 
 	if(strstr($currentURL, "printview.php")) { // don't do anything if we're on the print view
 		return $form;
-	} else {
+	} 
 
-        drawGoBackForm($go_back, $currentURL, $settings, $entry, $screen);
+	drawGoBackForm($go_back, $currentURL, $settings, $entry, $screen);
 
-        $pv_text_temp = _formulize_PRINTVIEW;
-        if(!$button_text OR ($button_text == "{NOBUTTON}" AND $go_back['form'])) { // presence of a goback form (ie: parent form) overrides {NOBUTTON} -- assumption is the save button will not also be overridden at the same time
-        	$button_text = _formulize_DONE;
-        } elseif(is_array($button_text)) {
-            if(!$button_text[0]) {
-                $done_text_temp = _formulize_DONE;
-            } else {
-                $done_text_temp = $button_text[0];
-            }
-            if(!$button_text[1]) {
-                $save_text_temp = _formulize_SAVE;
-            } else {
-                $save_text_temp = $button_text[1];
-            }
-            if(!$button_text[2]) {
-                $save_and_leave_text_temp = _formulize_SAVE_AND_LEAVE;
-            } else {
-                $save_and_leave_text_temp = $button_text[2];
-            }
-            if($button_text[3]) {
-                $pv_text_temp = $button_text[3];
-            }
-        }
-
-        // formulize_displayingMultipageScreen is set in formdisplaypages to indicate we're displaying a multipage form
-        global $formulize_displayingMultipageScreen;
-        // do not use printable button for profile forms
-        if($pv_text_temp != "{NOBUTTON}") {
-
-            $newcurrentURL= XOOPS_URL . "/modules/formulize/printview.php";
-            print "<form name='printview' action='".$newcurrentURL."' method=post target=_blank>\n";
-
-            // add security token
-            if(isset($GLOBALS['xoopsSecurity'])) {
-                print $GLOBALS['xoopsSecurity']->getTokenHTML();
-            }
-
-            $currentPage = "";
-            $screenid = "";
-            if($screen) {
-                $screenid = $screen->getVar('sid');
-                // check for a current page setting
-                if(isset($settings['formulize_currentPage'])) {
-                    $currentPage = $settings['formulize_currentPage'];
-                }
-            }
-
-            print "<input type=hidden name=screenid value='".$screenid."'>";
-            print "<input type=hidden name=currentpage value='".$currentPage."'>";
-
-            print "<input type=hidden name=lastentry value=".$cur_entry.">";
-            if($go_back['form']) { // we're on a sub, so display this form only
-                print "<input type=hidden name=formframe value=".$fids[0].">";
-            } else { // otherwise, display like normal
-                print "<input type=hidden name=formframe value='".$formframe."'>";
-                print "<input type=hidden name=mainform value='".$mainform."'>";
-            }
-            if(is_array($elements_allowed)) {
-                $ele_allowed = implode(",",$elements_allowed);
-                print "<input type=hidden name=elements_allowed value='".$ele_allowed."'>";
-            } else {
-                print "<input type=hidden name=elements_allowed value=''>";
-            }
-            print "</form>";
-            //added by Cory Aug 27, 2005 to make forms printable
-
-            $printbutton = new XoopsFormButton('', 'printbutton',  $pv_text_temp, 'button');
-            if(is_array($elements_allowed)) {
-                $ele_allowed = implode(",",$elements_allowed);
-            }
-            $printbutton->setExtra("onclick='javascript:PrintPop(\"$ele_allowed\");'");
-            $rendered_buttons = $printbutton->render(); // nmc 2007.03.24 - added
-            if ($printall) {																					// nmc 2007.03.24 - added
-                $printallbutton = new XoopsFormButton('', 'printallbutton', str_replace(_formulize_PRINTVIEW, $pv_text_temp, _formulize_PRINTALLVIEW), 'button');	// nmc 2007.03.24 - added
-                $printallbutton->setExtra("onclick='javascript:PrintAllPop();'");								// nmc 2007.03.24 - added
-                $rendered_buttons .= "&nbsp;&nbsp;&nbsp;" . $printallbutton->render();							// nmc 2007.03.24 - added
-                }
-            $buttontray = new XoopsFormElementTray($rendered_buttons, "", 'button-controls'); // nmc 2007.03.24 - amended [nb: FormElementTray 'caption' is actually either 1 or 2 buttons]
-        } else {
-            $buttontray = new XoopsFormElementTray("", "", 'button-controls');
-        }
-        $buttontray->setClass("no-print");
-
-        if($save_text_temp) { $subButtonText = $save_text_temp; }
-
-        if($subButtonText != "{NOBUTTON}" AND formulizePermHandler::user_can_edit_entry($fid, $uid, $entry)) {
-            $saveButton = new XoopsFormButton('', 'submitx', trans($subButtonText), 'button'); // doesn't use name submit since that conflicts with the submit javascript function
-            $saveButton->setExtra("onclick=javascript:validateAndSubmit();");
-            $buttontray->addElement($saveButton);
-        }
-
-        if(isset($save_and_leave_text_temp) AND $save_and_leave_text_temp != "{NOBUTTON}" AND formulizePermHandler::user_can_edit_entry($fid, $uid, $entry)) {
-            // also add in the save and leave button
-            $saveAndLeaveButton = new XoopsFormButton('', 'submit_save_and_leave', trans($save_and_leave_text_temp), 'button');
-            $saveAndLeaveButton->setExtra("onclick=javascript:validateAndSubmit('leave');");
-            $buttontray->addElement($saveAndLeaveButton);
-        }
-
-        if((($button_text != "{NOBUTTON}" AND !$done_text_temp) OR (isset($done_text_temp) AND $done_text_temp != "{NOBUTTON}")) AND !$allDoneOverride) {
-            if($done_text_temp) { $button_text = $done_text_temp; }
-            $donebutton = new XoopsFormButton('', 'donebutton', trans($button_text), 'button');
-            $donebutton->setExtra("onclick=javascript:verifyDone();");
-            $buttontray->addElement($donebutton);
-        }
-
-        $trayElements = $buttontray->getElements();
-            if(count((array) $trayElements) > 0 OR $formulize_displayingMultipageScreen) {
-            $form->addElement($buttontray);
-        }
-        return $form;
+	$pv_text_temp = _formulize_PRINTVIEW;
+	if(!$button_text OR ($button_text == "{NOBUTTON}" AND $go_back['form'])) { // presence of a goback form (ie: parent form) overrides {NOBUTTON} -- assumption is the save button will not also be overridden at the same time
+		$button_text = _formulize_DONE;
+	} elseif(is_array($button_text)) {
+		if(!$button_text[0]) {
+			$done_text_temp = _formulize_DONE;
+		} else {
+			$done_text_temp = $button_text[0];
+		}
+		if(!$button_text[1]) {
+			$save_text_temp = _formulize_SAVE;
+		} else {
+			$save_text_temp = $button_text[1];
+		}
+		if(!$button_text[2]) {
+			$save_and_leave_text_temp = _formulize_SAVE_AND_LEAVE;
+		} else {
+			$save_and_leave_text_temp = $button_text[2];
+		}
+		if($button_text[3]) {
+			$pv_text_temp = $button_text[3];
+		}
 	}
+
+	$config_handler = xoops_gethandler('config');
+	$formulizeConfig = $config_handler->getConfigsByCat(0, getFormulizeModId());
+	if($pv_text_temp != "{NOBUTTON}" AND $formulizeConfig['formulizeShowPrintableViewButtons']) {
+
+		$newcurrentURL= XOOPS_URL . "/modules/formulize/printview.php";
+		print "<form name='printview' action='".$newcurrentURL."' method=post target=_blank>\n";
+
+		// add security token
+		if(isset($GLOBALS['xoopsSecurity'])) {
+			print $GLOBALS['xoopsSecurity']->getTokenHTML();
+		}
+
+		$currentPage = "";
+		$screenid = "";
+		if($screen) {
+			$screenid = $screen->getVar('sid');
+			// check for a current page setting
+			if(isset($settings['formulize_currentPage'])) {
+				$currentPage = $settings['formulize_currentPage'];
+			}
+		}
+
+		print "<input type=hidden name=screenid value='".$screenid."'>";
+		print "<input type=hidden name=currentpage value='".$currentPage."'>";
+
+		print "<input type=hidden name=lastentry value=".$cur_entry.">";
+		if($go_back['form']) { // we're on a sub, so display this form only
+			print "<input type=hidden name=formframe value=".$fids[0].">";
+		} else { // otherwise, display like normal
+			print "<input type=hidden name=formframe value='".$formframe."'>";
+			print "<input type=hidden name=mainform value='".$mainform."'>";
+		}
+		if(is_array($elements_allowed)) {
+			$ele_allowed = implode(",",$elements_allowed);
+			print "<input type=hidden name=elements_allowed value='".$ele_allowed."'>";
+		} else {
+			print "<input type=hidden name=elements_allowed value=''>";
+		}
+		print "</form>";
+		//added by Cory Aug 27, 2005 to make forms printable
+
+		$printbutton = new XoopsFormButton('', 'printbutton',  $pv_text_temp, 'button');
+		if(is_array($elements_allowed)) {
+			$ele_allowed = implode(",",$elements_allowed);
+		}
+		$printbutton->setExtra("onclick='javascript:PrintPop(\"$ele_allowed\");'");
+		$rendered_buttons = $printbutton->render(); // nmc 2007.03.24 - added
+		if ($printall) {																					// nmc 2007.03.24 - added
+			$printallbutton = new XoopsFormButton('', 'printallbutton', str_replace(_formulize_PRINTVIEW, $pv_text_temp, _formulize_PRINTALLVIEW), 'button');	// nmc 2007.03.24 - added
+			$printallbutton->setExtra("onclick='javascript:PrintAllPop();'");								// nmc 2007.03.24 - added
+			$rendered_buttons .= "&nbsp;&nbsp;&nbsp;" . $printallbutton->render();							// nmc 2007.03.24 - added
+			}
+		$buttontray = new XoopsFormElementTray($rendered_buttons, "", 'button-controls'); // nmc 2007.03.24 - amended [nb: FormElementTray 'caption' is actually either 1 or 2 buttons]
+	} else {
+		$buttontray = new XoopsFormElementTray("", "", 'button-controls');
+	}
+	$buttontray->setClass("no-print");
+
+	if($save_text_temp) { $subButtonText = $save_text_temp; }
+
+	if($subButtonText != "{NOBUTTON}" AND formulizePermHandler::user_can_edit_entry($fid, $uid, $entry)) {
+		$saveButton = new XoopsFormButton('', 'submitx', trans($subButtonText), 'button'); // doesn't use name submit since that conflicts with the submit javascript function
+		$saveButton->setExtra("onclick=javascript:validateAndSubmit();");
+		$buttontray->addElement($saveButton);
+	}
+
+	if(isset($save_and_leave_text_temp) AND $save_and_leave_text_temp != "{NOBUTTON}" AND formulizePermHandler::user_can_edit_entry($fid, $uid, $entry)) {
+		// also add in the save and leave button
+		$saveAndLeaveButton = new XoopsFormButton('', 'submit_save_and_leave', trans($save_and_leave_text_temp), 'button');
+		$saveAndLeaveButton->setExtra("onclick=javascript:validateAndSubmit('leave');");
+		$buttontray->addElement($saveAndLeaveButton);
+	}
+
+	if((($button_text != "{NOBUTTON}" AND !$done_text_temp) OR (isset($done_text_temp) AND $done_text_temp != "{NOBUTTON}")) AND !$allDoneOverride) {
+		if($done_text_temp) { $button_text = $done_text_temp; }
+		$donebutton = new XoopsFormButton('', 'donebutton', trans($button_text), 'button');
+		$donebutton->setExtra("onclick=javascript:verifyDone();");
+		$buttontray->addElement($donebutton);
+	}
+
+	// formulize_displayingMultipageScreen is set in formdisplaypages to indicate we're displaying a multipage form
+	global $formulize_displayingMultipageScreen;
+	$trayElements = $buttontray->getElements();
+	if(count((array) $trayElements) > 0 OR $formulize_displayingMultipageScreen) {
+		$form->addElement($buttontray);
+	}
+	return $form;
+	
 }
 
 // this function draws in the hidden form that handles the All Done logic that sends user off the form

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -389,7 +389,7 @@ class formulize_themeForm extends XoopsThemeForm {
 					AND !$templateVariables['renderedElement']
 					AND !is_numeric($templateVariables['renderedElement'])
 					) OR (
-						is_object($ele) AND is_a($ele, 'XoopsFormElementTray') AND empty($ele->getElements())
+						is_object($ele) AND is_a($ele, 'XoopsFormElementTray') AND empty($ele->getElements()) AND $ele->getName() != 'button-controls'
 					)) {
 						return "";
 				}

--- a/modules/formulize/language/english/admin.php
+++ b/modules/formulize/language/english/admin.php
@@ -656,7 +656,7 @@ define("_AM_FORMULIZE_SCREEN_PREVBUTTONTEXT", "Text for the Save and Go Back but
 define("_AM_FORMULIZE_SCREEN_SAVEBUTTONTEXT", "Text for the Save button");
 define("_AM_FORMULIZE_SCREEN_NEXTBUTTONTEXT", "Text for the Save and Continue button");
 define("_AM_FORMULIZE_SCREEN_FINISHBUTTONTEXT", "Text for the Save and Finish button");
-define("_AM_FORMULIZE_SCREEN_PRINTALL", "Make the 'Printable View - All Pages' button available at the end of the form"); //nmc 2007.03.24
+define("_AM_FORMULIZE_SCREEN_PRINTALL", "Make the 'Printable View - All Pages' button available at the bottom of each page"); //nmc 2007.03.24 //jwe 2025.06.05
 define("_AM_FORMULIZE_SCREEN_PRINTALL_Y", "Yes"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_N", "No"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_NONE", "No, and not the regular 'Printable View' button either");

--- a/modules/formulize/language/english/modinfo.php
+++ b/modules/formulize/language/english/modinfo.php
@@ -172,3 +172,5 @@ define("_MI_formulize_EIC_ALWAYSAPOS", "Always prefix strings with an apostrophe
 define("_MI_formulize_EIC_ALWAYSTAB", "Always prefix strings with a TAB (for Excel)");
 define("_MI_formulize_EIC_PLAIN", "Never prefix strings (for programs that need clean, raw data)");
 
+define('_MI_formulize_SHOWPRINTABLEVIEWBUTTONS', 'Enable Printable View buttons for all form screens (you can still turn them on and off per screen)');
+define('_MI_formulize_SHOWPRINTABLEVIEWBUTTONS_DESC', 'If this is on, then the Printable View buttons are available on all form screens and can be turned on and off in the usual way through the screen settings. If this is off, Printable View buttons will not show up on any screens.');

--- a/modules/formulize/printview.php
+++ b/modules/formulize/printview.php
@@ -67,7 +67,10 @@ print "<HTML>
 print "<HEAD>";
 
 if (!$formulizeConfig['printviewStylesheets']) {
-    print "<link rel='stylesheet' type='text/css' media='all' href='".getcss($xoopsConfig['theme_set'])."'>\n";
+    print "
+		<link rel='stylesheet' type='text/css' media='all' href='".getcss($xoopsConfig['theme_set'])."'>
+		<link rel='stylesheet' type='text/css' media='all' href='".XOOPS_URL."/modules/formulize/templates/css/formulize.css'>
+";
 
     // figure out if this is XOOPS or ICMS
     if (file_exists(XOOPS_ROOT_PATH."/class/icmsform/index.html")) {
@@ -140,7 +143,12 @@ EOF;
         print "<link rel='stylesheet' type='text/css' media='all' href='$styleSheet' />\n";
     }
 }
-print "</HEAD>";
+print "
+	</HEAD>
+	<body>
+		<center>
+			<table width=100%><tr><td width=5%></td><td width=90%>
+				<div id=\"formulize-printpreview\">";
 
 } // end of if we're making a PDF - leave out the head and stuff
 
@@ -185,27 +193,7 @@ if (! is_array($formframe) && $screenid && !$ele_allowed) {
         $screen_handler = xoops_getmodulehandler('multiPageScreen', 'formulize');
         $multiPageScreen = $screen_handler->get($screenid);
         $conditions = $multiPageScreen->getConditions();
-        $pages = $multiPageScreen->getVar('pages');
-
-        $elements = array();
-        $printed_elements = array();
-        foreach ($pages as $currentPage=>$page) {
-            if(pageMeetsConditions($conditions, $currentPage+1, $ventry, $fid, $frid)) {
-                foreach ($page as $element) {
-                    // on a multipage form, some elements such a persons name may repeat on each page. print only once
-                    if (!isset($printed_elements[$element])) {
-                        $elements[] = $element;
-                        $printed_elements[$element] = true;
-                    }
-                }
-            }
-        }
-
-        $formframetemp = $formframe;
-        unset($formframe);
-        $formframe['elements'] = $elements;
-        $formframe['formframe'] = $formframetemp;
-        $pages = $multiPageScreen->getVar('pages');
+				$pages = $multiPageScreen->getVar('pages');
         $pagetitles = $multiPageScreen->getVar('pagetitles');
         ksort($pages); // make sure the arrays are sorted by key, ie: page number
         ksort($pagetitles);
@@ -216,32 +204,34 @@ if (! is_array($formframe) && $screenid && !$ele_allowed) {
         array_unshift($pagetitles, "");
         unset($pages[0]); // get rid of the part we just unshifted, so the page count is correct
         unset($pagetitles[0]);
-        $formframe['pagetitles'] = $pagetitles;
-        $formframe['pages'] = $pages;
 
-        // use the screen title
-        $titleOverride = $multiPageScreen->getVar('title');
+        foreach ($pages as $currentPage=>$page) {
+            if(pageMeetsConditions($conditions, $currentPage, $ventry, $fid, $frid)) {
+								$elements = array();
+                foreach ($page as $element) {
+                  $elements[] = $element;
+                }
+								displayForm(array('formframe' => $formframe, 'elements' => $elements), $ventry, $mainform, "", "{NOBUTTON}", "", $pagetitles[$currentPage]);
+            }
+        }
     }
+} else {
+	// if it's a single
+	displayForm($formframe, $ventry, $mainform, "", "{NOBUTTON}", "", $titleOverride);
 }
+
 
 
 if(!$makingPDF) {
 
-print "<center>";
-print "<table width=100%><tr><td width=5%></td><td width=90%>";
-print "<div id=\"formulize-printpreview\">";
-include_once XOOPS_ROOT_PATH . "/modules/formulize/include/formdisplay.php";
-include_once XOOPS_ROOT_PATH . "/modules/formulize/include/extract.php"; // needed to get the benchmark function available
-// if it's a single and they don't have group or global scope
-displayForm($formframe, $ventry, $mainform, "", "{NOBUTTON}", "", $titleOverride);
-print "</div>";
-print "</td><td width=5%></td></tr></table>";
-    print "</center>";
+print "
+				</div>
+			</td><td width=5%></td></tr></table>
+		</center>
+	</body>
+</HTML>";
 
-    print "</body>";
-print "</HTML>";
-
-                    } else {
+} else {
 
     include_once XOOPS_ROOT_PATH.'/modules/formulize/include/elementdisplay.php';
     $element_handler = xoops_getmodulehandler('elements', 'formulize');

--- a/modules/formulize/templates/admin/screen_form_options.html
+++ b/modules/formulize/templates/admin/screen_form_options.html
@@ -79,13 +79,13 @@
           <div class="description">If you are sending users to a location on this site, then you don't have to type the root part of the site's URL.  Just start the destination with a slash, ie: /modules/formulize/index.php?sid=12</div>
         </div>
 	  </div>
-        
+    <{if $formulizeConfig.formulizeShowPrintableViewButtons}>
 	  <div class="form-item">
 		  <p><label for="screens-printableviewbuttontext">What text should be used on the <b>Printable View</b> button?</label></p>
 		  <input type="text" id="screens-printableviewbuttontext" name="screens-printableviewbuttontext" value="<{$content.printableviewbuttontext}>"/>
           <div class="description">You can leave this blank, that will remove this button from the form.</div> 
 	  </div>
-        
+    <{/if}>
 	  <div class="form-item">
 		  <p><label for="screens-reloadblank">How should the form reload, after the user has saved a <b>new</b> entry?</label></p>
 				<div class="form-radios">

--- a/modules/formulize/templates/admin/screen_multipage_options.html
+++ b/modules/formulize/templates/admin/screen_multipage_options.html
@@ -88,6 +88,7 @@
 		  <label for="finishButtonText"><{$smarty.const._AM_FORMULIZE_SCREEN_FINISHBUTTONTEXT}></label><br>
       <input type="text" id="finishButtonText" name="finishButtonText" value="<{$content.finishButtonText}>" size="50" maxlength="255"/><br><br>
       </div>
+      <{if $formulizeConfig.formulizeShowPrintableViewButtons}>
       <div class="form-item">
         <label for="printableViewButtonText">Text for the Printable View button?</label><br>
 		<input type="text" id="printableViewButtonText" name="printableViewButtonText" value="<{$content.printableViewButtonText}>"/><br><br>
@@ -104,6 +105,7 @@
             <label for="2"><input type="radio" id="screens-printall" name="screens-printall"<{if $content.printall eq 2}> checked="checked"<{/if}> value="2"/><{$smarty.const._AM_FORMULIZE_SCREEN_PRINTALL_NONE}></label>
         </div>
       </div>
+      <{/if}>
 	</fieldset>
     
     <fieldset>

--- a/modules/formulize/templates/css/formulize.css
+++ b/modules/formulize/templates/css/formulize.css
@@ -534,6 +534,14 @@ td.head div.xoops-form-element-caption, td.head div.xoops-form-element-caption-r
     font-weight: normal;
 }
 
+div#formulize-printpreview div.formulize-subform-table-scrollbox {
+		overflow-y: visible !important;
+}
+
+div#formulize-printpreview div#multipage-controls {
+	display: none !important
+}
+
 @media print {
 
   body {

--- a/modules/formulize/xoops_version.php
+++ b/modules/formulize/xoops_version.php
@@ -1060,6 +1060,26 @@ $modversion['config'][] = array(
 	'default' => 0,
 );
 
+// set printable view default to one (1)
+// unless it does not exist in the database already, and there are forms in the database already
+global $xoopsDB;
+$printableViewButtonDefault = 1;
+if($xoopsDB) {
+	$printableViewConfigExists = q("SELECT 1 FROM ".$xoopsDB->prefix('config')." WHERE conf_name = 'formulizeShowPrintableViewButtons'");
+	$formsExist = q("SELECT 1 FROM ".$xoopsDB->prefix('formulize_id')." WHERE id_form > 0");
+	if($printableViewConfigExists == false AND $formsExist == true) {
+		$printableViewButtonDefault = 0;
+	}
+}
+$modversion['config'][] = array(
+	'name' => 'formulizeShowPrintableViewButtons',
+	'title' => '_MI_formulize_SHOWPRINTABLEVIEWBUTTONS',
+	'description' => '_MI_formulize_SHOWPRINTABLEVIEWBUTTONS_DESC',
+	'formtype' => 'yesno',
+	'valuetype' => 'int',
+	'default' => $printableViewButtonDefault,
+);
+
 $modversion['blocks'][1] = array(
 	'file' => "mymenu.php",
 	'name' => _MI_formulizeMENU_BNAME,

--- a/themes/Anari/css/style.css
+++ b/themes/Anari/css/style.css
@@ -733,9 +733,11 @@ button:focus, input[type="submit"]:focus, input[type="button"]:focus, input[type
 button, input[type="submit"], input[type="button"], input[type="reset"],
 .btn {
     min-width: 200px;
-    max-width: 100%;
   }
 
+div#formulize-button-controls label[for=button-controls] {
+	display: flex;
+}
 
 @media print {
   button, input[type="submit"], input[type="button"], input[type="reset"],


### PR DESCRIPTION
They have not shown up for quite some time. They now blend with Anari theme when displayed. A preference will be added to turn them off universally, and that defaults to on for existing installations, off for new ones, so existing systems don't suddenly have them showing up all over.