### PR TITLE
Add create_form and create_form_element tools to MCP

### DIFF
--- a/mcp/tools.php
+++ b/mcp/tools.php
@@ -261,7 +261,7 @@ Examples:
 					'properties' => (object)[]
 				],
 			]
-		];
+		] + $this->buildFormCreationTools();
 
 		// only webmasters can access certain tools
 		if(in_array(XOOPS_GROUP_ADMIN, $this->userGroups)) {
@@ -1219,6 +1219,240 @@ private function validateFilter($filter) {
 
 			// No semicolon found, return the whole string
 			return trim($sql);
+	}
+
+	/**
+	 * Build form creation tools with dynamic element type discovery
+	 * @return array Array of form creation tools
+	 */
+	private function buildFormCreationTools()
+	{
+		return [
+			'create_form' => $this->buildCreateFormTool(),
+			'create_form_element' => $this->buildCreateFormElementTool()
+		];
+	}
+
+	/**
+	 * Build the create_form tool schema
+	 * @return array Tool schema for creating forms
+	 */
+	private function buildCreateFormTool()
+	{
+		return [
+			'name' => 'create_form',
+			'description' => 'Create a new form in Formulize. This creates the basic form structure only. After creating a form, use the create_form_element tool to add elements (fields) to the form. Elements are the individual input fields like textboxes, dropdowns, checkboxes, etc. that users will fill out.',
+			'inputSchema' => [
+				'type' => 'object',
+				'properties' => [
+					'form_title' => [
+						'type' => 'string',
+						'description' => 'Required. The display title of the form'
+					],
+					'form_handle' => [
+						'type' => 'string',
+						'description' => 'Optional. Internal database handle for the form. If not provided, will be auto-generated from the title. Must be unique and contain only letters, numbers, and underscores.'
+					],
+					'singular' => [
+						'type' => 'string',
+						'description' => 'Optional. Singular name for entries in this form (e.g., \'Activity\', \'Contact\'). If not provided, will be derived from form title.'
+					],
+					'plural' => [
+						'type' => 'string',
+						'description' => 'Optional. Plural name for entries in this form (e.g., \'Activities\', \'Contacts\'). If not provided, will be derived from singular or form title.'
+					],
+					'menutext' => [
+						'type' => 'string',
+						'description' => 'Optional. Text to display in navigation menus. If not provided, will use form title.'
+					],
+					'single_entry' => [
+						'type' => 'string',
+						'enum' => ['off', 'user', 'group'],
+						'description' => 'Optional. Entry limitation: \'off\' = unlimited entries per user (default), \'user\' = one entry per user, \'group\' = one entry per group'
+					],
+					'application_id' => [
+						'type' => 'integer',
+						'description' => 'Optional. ID of the application to assign this form to. Applications are collections of related forms.'
+					]
+				],
+				'required' => ['form_title']
+			]
+		];
+	}
+
+	/**
+	 * Build the create_form_element tool schema with dynamic element discovery
+	 * @return array Tool schema for creating form elements
+	 */
+	private function buildCreateFormElementTool()
+	{
+		// Discover available element types and their descriptions
+		[$elementTypes, $elementDescriptions] = $this->discoverElementTypes();
+
+		// Build comprehensive description with examples from all element types
+		$description = "Create a new element (input field) in a Formulize form. Elements have different properties depending on their type.\n\n";
+		$description .= "Available element types and examples:\n\n";
+		$description .= implode("\n\n", $elementDescriptions);
+
+		return [
+			'name' => 'create_form_element',
+			'description' => $description,
+			'inputSchema' => [
+				'type' => 'object',
+				'properties' => [
+					'form_id' => [
+						'type' => 'integer',
+						'description' => 'Required. ID of the form to add this element to'
+					],
+					'element_type' => [
+						'type' => 'string',
+						'enum' => $elementTypes,
+						'description' => 'Required. Type of form element to create'
+					],
+					'caption' => [
+						'type' => 'string',
+						'description' => 'Required. Display label for this element'
+					],
+					'handle' => [
+						'type' => 'string',
+						'description' => 'Optional. Internal database handle for this element. If not provided, will be auto-generated from caption. Must be unique within the form and contain only letters, numbers, and underscores.'
+					],
+					'description' => [
+						'type' => 'string',
+						'description' => 'Optional. Descriptive help text to display with this element'
+					],
+					'required' => [
+						'type' => 'boolean',
+						'description' => 'Optional. Whether this element is required. Default is false.'
+					],
+					'column_header' => [
+						'type' => 'string',
+						'description' => 'Optional. Shorter text to use in column headers when displaying data in lists'
+					],
+					'properties' => [
+						'type' => 'object',
+						'description' => 'Element-specific properties. The contents depend on the element_type. See the tool description for examples of what properties are needed for different element types.',
+						'additionalProperties' => true
+					]
+				],
+				'required' => ['form_id', 'element_type', 'caption']
+			]
+		];
+	}
+
+	/**
+	 * Discover available element types and their MCP descriptions
+	 * @return array [elementTypes array, elementDescriptions array]
+	 */
+	private function discoverElementTypes()
+	{
+		$elementTypes = [];
+		$elementDescriptions = [];
+
+		// Scan for element class files
+		$elementClassPath = XOOPS_ROOT_PATH . '/modules/formulize/class';
+		$elementFiles = glob($elementClassPath . '/*Element.php');
+
+		foreach ($elementFiles as $file) {
+			$className = $this->getElementClassName($file);
+			
+			// Skip if class doesn't exist or doesn't have MCP description
+			if (!class_exists($className)) {
+				continue;
+			}
+
+			// Check if class has MCP description property
+			if (property_exists($className, 'mcpElementPropertiesDescription')) {
+				$elementType = $this->extractElementTypeFromClassName($className);
+				$elementTypes[] = $elementType;
+				$elementDescriptions[] = $className::$mcpElementPropertiesDescription;
+			}
+		}
+
+		// Fallback to core element types if no classes found with MCP descriptions
+		if (empty($elementTypes)) {
+			$elementTypes = $this->getFallbackElementTypes();
+			$elementDescriptions = $this->getFallbackElementDescriptions();
+		}
+
+		return [$elementTypes, $elementDescriptions];
+	}
+
+	/**
+	 * Extract class name from element file path
+	 * @param string $filePath Path to element class file
+	 * @return string Class name
+	 */
+	private function getElementClassName($filePath)
+	{
+		$filename = basename($filePath, '.php');
+		// Convert filename like 'textElement' to 'formulizeTextElement'
+		return 'formulize' . ucfirst($filename);
+	}
+
+	/**
+	 * Extract element type from class name
+	 * @param string $className Full class name like 'formulizeTextElement'
+	 * @return string Element type like 'text'
+	 */
+	private function extractElementTypeFromClassName($className)
+	{
+		// Remove 'formulize' prefix and 'Element' suffix, then lowercase
+		$type = str_replace(['formulize', 'Element'], '', $className);
+		return strtolower($type);
+	}
+
+	/**
+	 * Get fallback element types when no MCP-enabled classes are found
+	 * @return array Basic element types
+	 */
+	private function getFallbackElementTypes()
+	{
+		return [
+			'text', 'textarea', 'select', 'radio', 'checkbox', 
+			'date', 'time', 'yn', 'email', 'phone'
+		];
+	}
+
+	/**
+	 * Get fallback element descriptions when no MCP-enabled classes are found
+	 * @return array Basic element descriptions
+	 */
+	private function getFallbackElementDescriptions()
+	{
+		return [
+			'Example for text element:\n{\n  "form_id": 5,\n  "element_type": "text",\n  "caption": "Activity Name",\n  "handle": "activity_name",\n  "required": true,\n  "properties": {\n    "width": 30,\n    "max_length": 255,\n    "default_value": ""\n  }\n}',
+			'Example for select element:\n{\n  "form_id": 5,\n  "element_type": "select",\n  "caption": "Priority Level",\n  "handle": "priority",\n  "required": true,\n  "properties": {\n    "options": ["Low", "Medium", "High", "Critical"],\n    "default_selection": "Medium"\n  }\n}',
+			'Example for checkbox element:\n{\n  "form_id": 5,\n  "element_type": "checkbox",\n  "caption": "Categories",\n  "handle": "categories",\n  "required": false,\n  "properties": {\n    "options": ["Work", "Personal", "Health", "Education"],\n    "default_selections": ["Work"]\n  }\n}'
+		];
+	}
+
+	/**
+	 * Create a new form in Formulize
+	 * @param array $arguments Form creation parameters
+	 * @return array Result of form creation
+	 */
+	private function create_form($arguments)
+	{
+		// Implementation will be added separately
+		throw new FormulizeMCPException(
+			'create_form tool implementation pending',
+			'not_implemented'
+		);
+	}
+
+	/**
+	 * Create a new element in a Formulize form
+	 * @param array $arguments Element creation parameters
+	 * @return array Result of element creation
+	 */
+	private function create_form_element($arguments)
+	{
+		// Implementation will be added separately
+		throw new FormulizeMCPException(
+			'create_form_element tool implementation pending',
+			'not_implemented'
+		);
 	}
 
 }

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -247,6 +247,12 @@ class formulizeForm extends FormulizeObject {
         if ("form_handle" == $key) {
             $value = self::sanitize_handle_name($value);
         }
+				if("id_form" == $key) {
+					parent::setVar("fid", $value, $not_gpc);
+				}
+				if("fid" == $key) {
+					parent::setVar("id_form", $value, $not_gpc);
+				}
         parent::setVar($key, $value, $not_gpc);
         if ("on_before_save" == $key) {
             $this->cache_on_before_save_code();
@@ -833,6 +839,7 @@ class formulizeFormsHandler {
 					$id_form = $this->db->getInsertId();
 				}
 				$formObject->assignVar('id_form', $id_form);
+				$formObject->assignVar('fid', $id_form);
 
 				if( $form_handle == "" ){ // only occurs when forms have no handles specified by the user, which is probably only new forms, because non-new forms would default to the fid (but for new forms, fid is not known yet when insert is called)
 					$formObject->setVar('form_handle', $id_form);

--- a/modules/formulize/class/formulize.php
+++ b/modules/formulize/class/formulize.php
@@ -32,7 +32,6 @@
 ###############################################################################
 
 include_once XOOPS_ROOT_PATH.'/modules/formulize/include/common.php';
-
 #[AllowDynamicProperties]
 class FormulizeObject extends XoopsObject {
 
@@ -97,6 +96,182 @@ class FormulizeObject extends XoopsObject {
 				'datasets'
 			]
 		];
+	}
+
+}
+#[AllowDynamicProperties]
+class formulizeHandler {
+
+	function __construct() {
+	}
+
+	/**
+	 * Builds or updates a form, including creating or renaming the data table, creating default screens, and setting up permissions
+	 * @param array $formObjectProperties An associative array of properties to set on the form object.  If 'fid' is included and is non-zero, it will update that form.  If 'fid' is not included or is zero, it will create a new form.
+	 * @param array $groupIdsThatCanEdit An array of group ids that should be given edit permissions on this form (only used when creating a new form)
+	 * @throws Exception if there are any problems creating or updating the form
+	 * @return object The form object that was created or updated
+	 */
+	public static function buildForm($formObjectProperties = array(), $groupIdsThatCanEditForm = array()) {
+
+		$fid = 0;
+		if(isset($formObjectProperties['fid'])) {
+			$fid = intval($formObjectProperties['fid']);
+		}
+		$formObject = new FormulizeObject($fid); // get the form object that we care about, or start a new one from scratch if fid is 0, null, etc.
+		$formIsNew = $formObject->getVar('fid') ? true : false;
+		$originalFormNames = array(
+    	'singular' => $formObject->getSingular(),
+    	'plural' => $formObject->getPlural(),
+			'form_handle' => $formObject->getVar('form_handle')
+  	);
+		foreach($formObjectProperties as $property=>$value) {
+  		$formObject->setVar($property, $value);
+		}
+		global $xoopsDB;
+		$form_handler = xoops_getModuleHandler('forms', 'formulize');
+		if(!$form_handler->insert($formObject)) {
+  		throw new Exception("Could not save the form properly: ".$xoopsDB->error());
+		}
+
+		// existing form, so we may need to rename data table and screens and code files if the handle or singular/plural names changed
+		if(!$formIsNew) {
+			$singularPluralChanged = $form_handler->renameScreensAndMenuLinks($formObject, $originalFormNames);
+			if( $formObject->getVar( "form_handle" ) != $originalFormNames['form_handle']
+				AND !$renameResult = $form_handler->renameDataTable($originalFormNames['form_handle'], $formObject->getVar( "form_handle" ), $formObject)) {
+					throw new Exception("Could not rename the data table in the database.");
+			}
+			// update code files with this form handle
+			$events = array('on_before_save', 'on_after_save', 'on_delete', 'custom_edit_check');
+			foreach($events as $event) {
+				$oldFileName = XOOPS_ROOT_PATH.'/modules/formulize/code/'.$event.'_'.$originalFormNames['form_handle'].'.php';
+				$newFileName = XOOPS_ROOT_PATH.'/modules/formulize/code/'.$event.'_'.$formObject->getVar( "form_handle" ).'.php';
+				if(file_exists($oldFileName)) {
+					rename($oldFileName, $newFileName);
+				}
+			}
+
+		// new form, so create the data table and default screens, and set up permissions
+		} else {
+			if(!$tableCreateRes = $form_handler->createDataTable($formObject->getVar('fid'))) {
+   			throw new Exception("Could not create the data table for new form");
+  		}
+			// create the default screens for this form
+			$multiPageScreenHandler = xoops_getmodulehandler('multiPageScreen', 'formulize');
+			$defaultFormScreen = $multiPageScreenHandler->create();
+			$multiPageScreenHandler->setDefaultFormScreenVars($defaultFormScreen, $formObject);
+
+			if(!$defaultFormScreenId = $multiPageScreenHandler->insert($defaultFormScreen)) {
+				throw new Exception("Could not create default form screen");
+			}
+			$listScreenHandler = xoops_getmodulehandler('listOfEntriesScreen', 'formulize');
+			$screen = $listScreenHandler->create();
+			$listScreenHandler->setDefaultListScreenVars($screen, $defaultFormScreenId, $formObject);
+			if(!$defaultListScreenId = $listScreenHandler->insert($screen)) {
+				throw new Exception("Could not create default list screen");
+			}
+			$formObject->setVar('defaultform', $defaultFormScreenId);
+			$formObject->setVar('defaultlist', $defaultListScreenId);
+			if(!$form_handler->insert($formObject)) {
+				throw new Exception("Could not update form object with default screen ids: ".$xoopsDB->error());
+			}
+		  // add edit permissions for the selected groups, and view_form for Webmasters
+  		$gperm_handler = xoops_gethandler('groupperm');
+  		foreach($groupIdsThatCanEditForm as $thisGroupId) {
+				$gperm_handler->addRight('edit_form', $formObject->getVar('fid'), intval($thisGroupId), getFormulizeModId());
+			}
+			$gperm_handler->addRight('view_form', $formObject->getVar('fid'), XOOPS_GROUP_ADMIN, getFormulizeModId());
+		}
+
+		// if the revision history flag was on, then create the revisions history table, if it doesn't exist already
+		if($formObject->getVar('store_revisions') AND !$form_handler->revisionsTableExists($formObject)) {
+			if(!$form_handler->createDataTable($fid, revisionsTable: true)) { // 0 is the id of a form we're cloning, array() is the map of old elements to new elements when cloning so n/a here, true is the flag for making a revisions table
+				throw new Exception("Could not create the revision history table for the form");
+			}
+		}
+		return $formObject;
+	}
+
+	/**
+	 * Assigns a form to one or more applications, optionally creating a new application, and optionally creating menu links for the form in the applications
+	 * @param object $formObject The form object to assign to applications
+	 * @param array $applicationIds An array of existing application ids to assign this form to
+	 * @param array $newApplicationProperties An associative array of properties for a new application to create and assign this form to.  If empty, no new application will be created.
+	 * @param bool $createMenuLinksForApplications If true, menu links will be created for this form in the selected applications (and/or the new application if one is being created)
+	 * @param array $groupIdsThatCanEditForm An array of group ids that should be given edit permissions on this form, and will be able to see the menu link for this form in the applications.  Only used if $createMenuLinksForApplications is true.
+	 * @throws Exception if there are any problems assigning the form to applications
+	 * @return mixed True if successful, or the new application id if a new application was created
+	 */
+	public static function assignFormToApplications($formObject, $applicationIds = array(), $newApplicationProperties = array(), $createMenuLinksForApplications = false, $groupIdsThatCanEditForm = array()) {
+
+		if(!is_a($formObject, 'formulizeForm') OR !$formObject->getVar('fid')) {
+			throw new Exception("Cannot assign a non-form to applications.");
+		}
+
+		global $xoopsDB;
+		$application_handler = xoops_getmodulehandler('applications','formulize');
+		$fid = $formObject->getVar('fid');
+		$newAppObject = null;
+		if(!empty($newApplicationProperties)) {
+			$newApplicationProperties['forms'] = serialize(array($fid));
+			$newAppObject = $application_handler->create();
+  		foreach($newApplicationProperties as $property=>$value) {
+    		$newAppObject->setVar($property, $value);
+			}
+  	  if(!$application_handler->insert($newAppObject)) {
+    		throw new Exception("Could not save the new application properly: ".$xoopsDB->error());
+  		}
+  		$applicationIds[] = $newAppObject->getVar('appid');
+		}
+
+		// get all the applcations that we're supposed to assign this form object to
+	  $selectedAppObjects = $application_handler->get($applicationIds);
+		// get the applications this form is currently assigned to
+		$assignedAppsForThisForm = $application_handler->getApplicationsByForm($fid);
+
+		$selectedAppIds = array();
+		// assign this form as required to the selected applications
+		foreach($selectedAppObjects as $thisAppObject) {
+			$selectedAppIds[] = $thisAppObject->getVar('appid');
+			$thisAppForms = $thisAppObject->getVar('forms');
+			if(!in_array($fid, $thisAppForms)) {
+				$thisAppForms[] = $fid;
+				$thisAppObject->setVar('forms', serialize($thisAppForms));
+				if(!$application_handler->insert($thisAppObject)) {
+					throw new Exception("Could not add the form to one of the applications properly: ".$xoopsDB->error());
+				}
+			}
+		}
+
+		// now remove the form from any applications it used to be assigned to, which were not selected
+		foreach($assignedAppsForThisForm as $assignedApp) {
+			if(!in_array($assignedApp->getVar('appid'), $selectedAppIds)){
+				// the form is no longer assigned to this app, so remove it from the apps form list
+				$assignedAppForms = $assignedApp->getVar('forms');
+				$key = array_search($fid, $assignedAppForms);
+				unset($assignedAppForms[$key]);
+				sort($assignedAppForms); // resets all the keys so there's no gaps
+				$assignedApp->setVar('forms',serialize($assignedAppForms));
+				if(!$application_handler->insert($assignedApp)) {
+					throw new Exception("Could not update one of the applications this form used to be assigned to, so that it's not assigned anymore.");
+				}
+			}
+		}
+
+		if($createMenuLinksForApplications AND !empty($groupIdsThatCanEditForm)) {
+			$menuLinkText = ($formObject->getVar('single') == 'user' OR $formObject->getVar('single') == 'group') ? $formObject->getSingular() : $formObject->getPlural();
+			$menuitems = "null::" . formulize_db_escape($menuLinkText) . "::fid=" . formulize_db_escape($fid) . "::::".implode(',',$groupIdsThatCanEditForm)."::null";
+			if(!empty($selectedAppIds)) {
+				foreach($selectedAppIds as $appid) {
+					$application_handler->insertMenuLink(formulize_db_escape($appid), $menuitems);
+				}
+			} else {
+				$application_handler->insertMenuLink(0, $menuitems);
+			}
+		}
+
+		return is_object($newAppObject) ? $newAppObject->getVar('appid') : true;
+
 	}
 
 }

--- a/modules/formulize/include/common.php
+++ b/modules/formulize/include/common.php
@@ -78,3 +78,19 @@ if (file_exists(XOOPS_ROOT_PATH . "/modules/formulize/language/".$xoopsConfig['l
 formulize_handleHtaccessRewriteRule();
 
 $GLOBALS['formulize_subformInstance'] = 100;
+
+function formulize_exception_handler($exception) {
+	global $xoopsUser;
+	error_log($exception->getMessage());
+	writeToFormulizeLog(array(
+		'PHP_error_number' => $exception->getCode(),
+		'PHP_error_string' => $exception->getMessage(),
+		'PHP_error_file' => $exception->getFile(),
+		'PHP_error_errline' => $exception->getLine()
+	));
+	echo "<h1>There was an error when preparing this page:</h1><blockquote>".$exception->getMessage()."</blockquote><p>We apologize for the inconvenience. This error has been logged. Please advise a webmaster of what actions preceded this event.</p>";
+	include XOOPS_ROOT_PATH.'/footer.php';
+	exit;
+}
+
+set_exception_handler('formulize_exception_handler');


### PR DESCRIPTION
Start with the basics. Creating forms, adding elements to forms. Editing properties and so on will come later. Editing screens, etc, will come later. Right now, creating forms simply works the same as manual creation of forms on the admin side. This is meant to allow the AI to give you a head-start, a basic set of working stuff that you can refine through the interface.

The real magic is in the element handling, because creating the linked elements will result in the connections (relationships) being instantiated, and the embedding automatically of subforms, etc. 

To handle the element creation properly, each element class needs to declare an example/instructions string that is used in the tool schema for the create_form_element tool, so the AI knows the options that are possible for each kind of element. This necessitates the creation of class files for all the elements, finally!