### PR TITLE
MCP - prepare new options

### DIFF
--- a/mcp/tools.php
+++ b/mcp/tools.php
@@ -850,7 +850,9 @@ private function validateFilter($filter) {
 
 			// Step 2: Prepare and validate the data
 			$preparedData = [];
+			$element_handler = xoops_getmodulehandler('elements', 'formulize');
 			foreach ($data as $elementHandle => $value) {
+
 				// Validate element handle type
 				if (!is_string($elementHandle)) {
 					throw new FormulizeMCPException('Element handle must be a string', 'invalid_data', context: [ "valid_element_handles" => $validHandles ]);
@@ -861,10 +863,15 @@ private function validateFilter($filter) {
 					throw new FormulizeMCPException('Invalid element handle for this form: ' . $elementHandle, 'unknown_element', context: [ "valid_element_handles" => $validHandles ]);
 				}
 
+				$elementObject = $element_handler->get($elementHandle);
+				$ele_value = $elementObject->getVar('ele_value');
+
 				// Prepare the value for database storage
 				$preparedValue = prepareLiteralTextForDB($elementHandle, $value);
 				if($preparedValue AND $preparedValue !== $value) {
 					$value = $preparedValue;
+				} elseif(!$preparedValue AND isset($ele_value[16]) AND $ele_value[16]) {
+					$value = handleCreatingNewOptions($elementHandle, "newvalue:$value", $entryId);
 				}
 
 				$preparedData[$elementHandle] = $value;

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -2075,7 +2075,11 @@ function getLinkedOptionsSourceForm($elementIdOrObject) {
 
 /**
  * Handle submitted values and create new options/source values in selectboxes, whether linked or not, if the selectbox supports creation of new values
- *
+ * @param string $elementIdentifier - the element identifier, either the id or the handle of the element, or the element object itself
+ * @param mixed $values - the values submitted from the form, either a single value or an array of values
+ * @param int $entry_id - the entry id, if known, used to write the new value to the source form if this is a linked selectbox
+ * @return mixed - the values, possibly modified to include new values that were created
+ * @note This function is used to handle the creation of new options in selectboxes, whether linked or not.
  */
 function handleCreatingNewOptions($elementIdentifier, $values, $entry_id) {
 
@@ -2206,7 +2210,7 @@ function handleCreatingNewOptions($elementIdentifier, $values, $entry_id) {
 					$values[] = $thisNewValue;
 			} else {
 					if(count((array) $newWrittenValues)>1) {
-							print "ERROR: more than one new value created in a selectbox, when the selectbox does not allow multiple values. Check the settings of element '".$element->getVar('ele_caption')."'.";
+							print "ERROR: more than one new value created in a selectbox, when the selectbox does not allow multiple values. Check the settings of element '".$elementObject->getVar('ele_caption')."'.";
 					}
 					$values = $thisNewValue;
 			}


### PR DESCRIPTION
This is a stub of work, aiming at allowing MCP to request creation of an entry, in which a specified option is not currently an option but new options are allowed for that element (linked selectbox autocomplete), and the system will do the creation automatically. Code is not finished, needs testing, but also semantics of how the AI would handle this is not clear, since the AI would likely create the source entry first and then create the entry that links to it, by using a foreign key explicitly. So what's the point? This approach needs further review and consideration. However, the encapsulation of the creation of new entries and cleanup of the prepDataForWrite function, is laudable all on its own.