### PR TITLE
Separate class files for each element type

### DIFF
--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -1366,3 +1366,19 @@ class formulizeDataHandler {
 
 }
 
+/**
+ * Take an array of element handle -> value pairs, and add default values for any elements in the form that don't already have a value
+ * @param array values - The values array that we're appending to
+ * @param int fid - The ID of the form we're getting default values for
+ * @return array Returns the passed array with default values added, if any
+ */
+function addDefaultValuesToDataToWrite($values, $fid) {
+	$defaultValueMap = getEntryDefaultsInDBFormat($fid);
+	foreach($defaultValueMap as $defaultValueElementHandle=>$defaultValueToWrite) {
+		// if the element is not a value that we received, then let's use the default value
+		if(!isset($values[$defaultValueElementHandle])) {
+			$values[$defaultValueElementHandle] = $defaultValueToWrite;
+		}
+	}
+	return $values;
+}

--- a/modules/formulize/class/dummyElement-example.php
+++ b/modules/formulize/class/dummyElement-example.php
@@ -101,11 +101,10 @@ class formulizeDummyElementHandler extends formulizeElementsHandler {
     }
 
 		/**
-		 * Returns the default value for this element, for a new entry in the specified form, or for a specific entry if one is specified.
-		 * Some elements might have defaults that depend on the values of other elements in the entry.
-		 * This method may replace the use of loadValue in the future
+		 * Returns the default value for this element, for a new entry in the specified form.
+		 * Determines database ready values, not necessarily human readable values
 		 * @param $element The element object
-		 * @param $entry_id The entry id that should be used as the context for the default value. Defaults to 'new'.
+		 * @param int|string $entry_id 'new' or the id of an entry we should use when evaluating the default value - only relevant when determining second pass at defaults when subform entries are written? (which would be better done by comprehensive conditional rendering?)
 		 * @return mixed The default value
 		 */
 		function getDefaultValue($element, $entry_id = 'new') {

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -189,7 +189,6 @@ class formulizeElement extends FormulizeObject {
 			$valueToWrite = is_array($value) ? $value : unserialize($value);
 			if($ele_type == 'derived'
 				OR (($ele_type == 'ib' OR $ele_type == 'areamodif') AND strstr((string)$valueToWrite[0], "\$value"))
-				OR ($ele_type == 'textarea' AND strstr((string)$valueToWrite[0], "\$default"))
 				) {
 				$filename = $ele_type.'_'.$this->getVar('ele_handle').'.php';
 				formulize_writeCodeToFile($filename, $valueToWrite[0]);
@@ -204,12 +203,10 @@ class formulizeElement extends FormulizeObject {
 			$format = $key == "ele_value" ? "f" : $format;
 			$value = parent::getVar($key, $format);
 			if($key == 'ele_value') {
-				$format = 'f';
 				$ele_type = $this->getVar('ele_type');
 				if(($ele_type == 'derived'
 					OR $ele_type == 'ib'
-					OR $ele_type == 'areamodif'
-					OR $ele_type == 'textarea')
+					OR $ele_type == 'areamodif')
 					AND is_array($value)) {
 						$filename = $ele_type.'_'.$this->getVar('ele_handle').'.php';
 						$filePath = XOOPS_ROOT_PATH.'/modules/formulize/code/'.$filename;
@@ -222,31 +219,6 @@ class formulizeElement extends FormulizeObject {
 			}
 			return $value;
 		}
-
-    // returns an array of the default values (since there could be more than one in some element types)
-    // entry_id is the entry for which we're getting the default value, if any
-    public function getDefaultValues($entry_id='new') {
-        $default = array();
-        $ele_value = $this->getVar('ele_value');
-        $ele_type = $this->getVar('ele_type');
-        switch($ele_type) {
-            case 'select':
-                if($this->isLinked === false) { // linked element support needs to be added!!
-                    foreach($ele_value[2] as $option=>$selected) {
-                        if($selected) {
-                            $default[] = $option;
-                        }
-                    }
-                }
-                break;
-            case 'text':
-            case 'textarea':
-               	$default[] = interpretTextboxValue($this, $entry_id);
-                break;
-            default: // other element types need to be implemented! And a new method needs to be added to custom classes???
-        }
-        return $default;
-    }
 
     // returns true if the option is one of the values the user can choose from in this element
     // returns false if the element does not have options

--- a/modules/formulize/class/sliderElement.php
+++ b/modules/formulize/class/sliderElement.php
@@ -90,11 +90,10 @@ class formulizeSliderElementHandler extends formulizeElementsHandler {
     }
 
 		/**
-		 * Returns the default value for this element, for a new entry in the specified form, or for a specific entry if one is specified.
-		 * Some elements might have defaults that depend on the values of other elements in the entry.
-		 * This method may replace the use of loadValue in the future
+		 * Returns the default value for this element, for a new entry in the specified form.
+		 * Determines database ready values, not necessarily human readable values
 		 * @param $element The element object
-		 * @param $entry_id The entry id that should be used as the context for the default value. Defaults to 'new'.
+		 * @param int|string $entry_id 'new' or the id of an entry we should use when evaluating the default value - only relevant when determining second pass at defaults when subform entries are written? (which would be better done by comprehensive conditional rendering?)
 		 * @return mixed The default value
 		 */
 		function getDefaultValue($element, $entry_id = 'new') {

--- a/modules/formulize/class/textareaElement.php
+++ b/modules/formulize/class/textareaElement.php
@@ -36,12 +36,12 @@ require_once XOOPS_ROOT_PATH . "/modules/formulize/include/functions.php";
 class formulizeTextElement extends formulizeElement {
 
     function __construct() {
-        $this->name = "Textbox";
+        $this->name = "Multi-line textbox";
         $this->hasData = true; // set to false if this is a non-data element, like the subform or the grid
         $this->needsDataType = true; // set to false if you're going force a specific datatype for this element using the overrideDataType
         $this->overrideDataType = ""; // use this to set a datatype for the database if you need the element to always have one (like 'date').  set needsDataType to false if you use this.
         $this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
-        $this->alwaysValidateInputs = true; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
+        $this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
         $this->canHaveMultipleValues = false;
         $this->hasMultipleOptions = false;
         parent::__construct();
@@ -51,14 +51,14 @@ class formulizeTextElement extends formulizeElement {
 		public function setVar($key, $value, $not_gpc = false) {
 			if($key == 'ele_value') {
 				$valueToWrite = is_array($value) ? $value : unserialize($value);
-				if(strstr((string)$valueToWrite[2], "\$default")) {
-					$filename = 'text_'.$this->getVar('ele_handle').'.php';
-					formulize_writeCodeToFile($filename, $valueToWrite[2]);
-					$valueToWrite[2] = '';
+				if(strstr((string)$valueToWrite[0], "\$default")) {
+					$filename = 'textarea_'.$this->getVar('ele_handle').'.php';
+					formulize_writeCodeToFile($filename, $valueToWrite[0]);
+					$valueToWrite[0] = '';
 					$value = is_array($value) ? $valueToWrite : serialize($valueToWrite);
 				}
 			}
-			parent::setVar($key, $value, $not_gpc);
+      parent::setVar($key, $value, $not_gpc);
 		}
 
 		// read code from a file
@@ -66,13 +66,13 @@ class formulizeTextElement extends formulizeElement {
 			$format = $key == "ele_value" ? "f" : $format;
 			$value = parent::getVar($key, $format);
 			if($key == 'ele_value' AND is_array($value)) {
-				$filename ='text_'.$this->getVar('ele_handle').'.php';
+				$filename = 'textarea_'.$this->getVar('ele_handle').'.php';
 				$filePath = XOOPS_ROOT_PATH.'/modules/formulize/code/'.$filename;
 				$fileValue = "";
 				if(file_exists($filePath)) {
 					$fileValue = strval(file_get_contents($filePath));
 				}
-				$value[2] = $fileValue ? $fileValue : (is_array($value) AND isset($value[2]) ? $value[2] : null);
+				$value[0] = $fileValue ? $fileValue : $value[0];
 			}
 			return $value;
 		}
@@ -138,7 +138,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 		/**
 		 * Returns the default value for this element, for a new entry in the specified form.
 		 * Determines database ready values, not necessarily human readable values
-		 * @param $element The element object
+		 * @param object $element The element object
 		 * @param int|string $entry_id 'new' or the id of an entry we should use when evaluating the default value - only relevant when determining second pass at defaults when subform entries are written? (which would be better done by comprehensive conditional rendering?)
 		 * @return mixed The default value
 		 */

--- a/modules/formulize/include/elementdisplay.php
+++ b/modules/formulize/include/elementdisplay.php
@@ -530,7 +530,7 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
 			$elementObject = $element_handler->get($filterElements[$i]);
 			if(is_object($elementObject)) {
                 // get defaults for certain element types, function needs expanding
-                $defaultValueMap = getEntryDefaults($elementObject->getVar('id_form'));
+                $defaultValueMap = getEntryDefaultsInDBFormat($elementObject);
                 $compValue = isset($defaultValueMap[$elementObject->getVar('ele_handle')]) ? $defaultValueMap[$elementObject->getVar('ele_handle')] : "";
 			} else {
 				$compValue = "";

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -2006,7 +2006,7 @@ function drawSubLinks($subform_id, $sub_entries, $uid, $groups, $frid, $mid, $fi
             if($valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "" AND $valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "{WRITEASNULL}") {
                 $proxyUser = $overrideOwnerOfNewEntries ? $mainFormOwner : false;
                 if($writtenEntryId = formulize_writeEntry($valuesToWrite, 'new', 'replace', $proxyUser, true)) { // last true forces writing even when not using POST method on page request. Necessary for prepop in modal drawing.
-                    writeEntryDefaults($subform_id,$writtenEntryId,array_keys($valuesToWrite));
+                    secondPassWritingSubformEntryDefaults($subform_id,$writtenEntryId,array_keys($valuesToWrite));
                     $sub_entries[$subform_id][] = $writtenEntryId;
                 }
             }

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -2753,13 +2753,13 @@ function removeOpeningPHPTag($string) {
 }
 
 /**
- * Interpret the value for a textbox or textarea, return the actual string we should display
+ * Interpret the value for a textbox or textarea, return the actual string we should display or should save in the DB
  * @param mixed $elementIdentifier The id number, handle, or object representing the element we're working with
- * @param int|string $entry_id The entry id number of the entry that we're working with, or 'new' for new entries not yet saved. Possibly referenced by eval'd code.
+ * @param int|string $entry_id Optional. Defaults to 'new'. The entry id number of the entry that we're working with, or 'new' for new entries not yet saved. Possibly referenced by eval'd code.
  * @param mixed $currentValue Optional. The current value of the element in the entry. More efficient to pass this in if known. If set to the string USEDEFAULTVALUEINSTEADOFCURRENTVALUE then the default value will be used instead of the current value. This is necessary when determining defaults for newly created subform entries, since they have an entry id in the database already.
- * @return mixed The default value that should be used for this element
+ * @return mixed The default value that should be used for this element, or the actual value in the database if this is a specific entry, unless there is no value saved in which case the default from the element settings would be interpretted.
  */
-function interpretTextboxValue($elementIdentifier, $entry_id, $currentValue = null) {
+function interpretTextboxValue($elementIdentifier, $entry_id = 'new', $currentValue = null) {
 
 		if(!$elementObject = _getElementObject($elementIdentifier)) {
 			return "";
@@ -6287,8 +6287,8 @@ function _buildConditionsFilterSQL($filterId, &$filterOps, &$filterTerms, $filte
 			} elseif ($curlyBracketEntry == "new") {
 				$elementObject = $element_handler->get($bareFilterTerm);
 				if (is_object($elementObject)) {
-					$default = $elementObject->getDefaultValues($curlyBracketEntry); // initially, only works for text, textarea, and non-linked selectboxes! Sliders return integer. All other elements will return an empty array, until/unless they have their own method in their class that corrects this!
-					$default = is_array($default) ? $default[0] : $default;
+					$defaults = getEntryDefaultsInDBFormat($elementObject);
+					$default = $defaults[$elementObject->getVar('ele_handle')];
 					if(is_numeric($default)) {
 							$conditionsFilterComparisonValue = $default;
 					} elseif($default) {
@@ -8090,9 +8090,12 @@ function export_prepColumns($columns,$include_metadata=0) {
 
 // this function figures out certain default values for elements in a given entry in a form, and writes them to that entry
 // used for setting values that are supposed to exist by default in newly created subform entries
-function writeEntryDefaults($target_fid,$target_entry,$excludeHandles = array()) {
+// will potentially get back values for elements that already have a value in the database, if the default value based on the given entry would result in a different default than the one that is saved already
+// the intention is for this function to be called after an entry has been written already, so that any dependent defaults would take the "first pass" defaults and other saved values into consideration
+// this double default operation is only performed when saving new subform entries
+function secondPassWritingSubformEntryDefaults($target_fid,$target_entry,$excludeHandles = array()) {
 
-  $defaultValueMap = getEntryDefaults($target_fid, $target_entry, keyByIds: true);
+  $defaultValueMap = getEntryDefaultsInDBFormat($target_fid, $target_entry, keyByIds: true);
   $defaultElementHandles = convertElementIdsToElementHandles(array_keys($defaultValueMap));
 
   $i = 0;
@@ -8106,55 +8109,62 @@ function writeEntryDefaults($target_fid,$target_entry,$excludeHandles = array())
 }
 
 /**
- * Gets the default values for elements in an entry, usually a new entry, but some element types can have defaults that depend on data already saved in other elements in an entry
- * Such as when a multipage form has elements on page 2 that have default values determined by answers on page 1
- * @param int $target_fid - The form id for which we're getting default values
- * @param int|string $target_entry - The entry id for which we're getting default values, or 'new' for new entries not yet saved. Only used in cases of element types where the default might depend on the entry. Defaults to 'new'.
+ * Gets the default values for all elements in an entry, or just one element, usually for a new entry, but there is a double pass case for subform entries
+ * Returns database level values, ie: what the default value would equate to in the database.
+ * If a target_entry was specified, and the default value of the element, when considering the other values in that entry already (if the element type is capable of doing so), would be the same as what is already in the database, then no default value is returned for that element
+ * @param int $targetObjectOrFormId - And element object to get the default value for, or a form object or form id to get all the default values for.
+ * @param int|string $target_entry - The entry id for which we're getting default values, or 'new' for new entries not yet saved. Only used in cases of element types where the default might depend on the entry. Defaults to 'new'. Only case where this is not 'new' is the second pass at default values when generating new subform entries?? See comment in new subform entry writing code... there is surly a better way to handle that? Properly conditional elements would update in real time before saving in response to the value typed in other elements on screen?
  * @param boolean $keyByIds - a flag to indicate if the resulting array should be keyed by element id. Default is false and array will be keyed by element handles.
- * @return array Returns an array of element id/default value pairs
+ * @return array Returns an array of element id/default value pairs. The values are database-ready values, not human readable values (ie: foreign keys, not text, if applicable. In many cases database values for elements are human readable)
  */
-function getEntryDefaults($target_fid,$target_entry = 'new', $keyByIds = false) {
+function getEntryDefaultsInDBFormat($targetObjectOrFormId, $target_entry = 'new', $keyByIds = false) {
+
+	$elementsForDefaults = array();
+	if(is_a($targetObjectOrFormId, 'formulizeElement')) {
+		$elementsForDefaults[] = $targetObjectOrFormId;
+		$target_fid = $targetObjectOrFormId->getVar('fid');
+	} elseif(is_a($targetObjectOrFormId, 'formulizeForm')) {
+		$target_fid = $targetObjectOrFormId->getVar('fid');
+	} elseif(is_numeric($targetObjectOrFormId)) {
+		$target_fid = intval($targetObjectOrFormId);
+	} else {
+		throw new Exception("Invalid target object or form id used for getting entry defaults.");
+	}
 
   static $cachedDefaults = array();
-
-  if(isset($cachedDefaults[$target_fid][$keyByIds][$target_entry])) {
-    return $cachedDefaults[$target_fid][$keyByIds][$target_entry];
-  }
-
   $defaultValueMap = array();
-
+	$targetFidDataHandler = new formulizeDataHandler($target_fid);
   $element_handler = xoops_getmodulehandler('elements', 'formulize');
 
-  $criteria = new CriteriaCompo();
-  $criteria->add(new Criteria('ele_type', 'text'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'textarea'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'date'), 'OR');
-	$criteria->add(new Criteria('ele_type', 'time'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'radio'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'checkbox'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'yn'), 'OR');
-  $criteria->add(new Criteria('ele_type', 'select'), 'OR');
-	$criteria->add(new Criteria('ele_type', 'slider'), 'OR');
-  $elementsForDefaults = $element_handler->getObjects($criteria,intval($target_fid)); // get all the text or textarea elements in the form
+	if(empty($elementsForDefaults)) {
+		$criteria = new CriteriaCompo();
+		$criteria->add(new Criteria('ele_type', 'text'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'textarea'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'date'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'time'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'radio'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'checkbox'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'yn'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'select'), 'OR');
+		$criteria->add(new Criteria('ele_type', 'slider'), 'OR');
+		$elementsForDefaults = $element_handler->getObjects($criteria,intval($target_fid)); // get all the text or textarea elements in the form
+	}
 
   foreach($elementsForDefaults as $thisDefaultEle) {
+
+		$key = $keyByIds ? $thisDefaultEle->getVar('ele_id') : $thisDefaultEle->getVar('ele_handle');
+
+		// used cached value if we have one
+		if(isset($cachedDefaults[$thisDefaultEle->getVar('ele_id')][$target_entry])) {
+    	$defaultValueMap[$key] = $cachedDefaults[$thisDefaultEle->getVar('ele_id')][$target_entry];
+			continue;
+		}
+
+		// figure out the default value for this element
     $defaultTextToWrite = "";
     $ele_value_for_default = $thisDefaultEle->getVar('ele_value');
 		$ele_type = $thisDefaultEle->getVar('ele_type');
     switch($ele_type) {
-      case "text":
-      case "textarea":
-        $defaultTextToWrite = interpretTextboxValue($thisDefaultEle, $target_entry);
-        // do not flag a default as a default if it is already in the database!
-        // text boxes might have dynamic defaults dependent on other values in their entry
-        // but if they don't and we'd just be overwriting the same value, skip it
-        if($target_entry AND $target_entry !== 'new') {
-            $dataHandler = new formulizeDataHandler($thisDefaultEle->getVar('id_form'));
-            if($defaultTextToWrite === $dataHandler->getElementValueInEntry($target_entry, $thisDefaultEle)) {
-                $defaultTextToWrite = null;
-            }
-        }
-        break;
 			case "time":
 				$defaultTextToWrite = interpretTimeElementValue($ele_value_for_default[0], $target_entry);
 				break;
@@ -8215,15 +8225,26 @@ function getEntryDefaults($target_fid,$target_entry = 'new', $keyByIds = false) 
 				if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$ele_type."Element.php")) {
 					$elementTypeHandler = xoops_getmodulehandler($ele_type."Element", "formulize");
 					if(method_exists($elementTypeHandler, 'getDefaultValue')) {
-						$defaultTextToWrite = $elementTypeHandler->getDefaultValue($thisDefaultEle);
+						$defaultTextToWrite = $elementTypeHandler->getDefaultValue($thisDefaultEle, $target_entry);
 					}
 				}
     }
-    if($defaultTextToWrite === "" OR $defaultTextToWrite === false OR $defaultTextToWrite === null) { continue; }
-		$key = $keyByIds ? $thisDefaultEle->getVar('ele_id') : $thisDefaultEle->getVar('ele_handle');
+		// if there's no value, move on
+    if($defaultTextToWrite === ""
+			OR $defaultTextToWrite === false
+			OR $defaultTextToWrite === null) {
+				continue;
+		}
+		// if the value matches what's in the DB already, move on
+		if($target_entry AND $target_entry !== 'new') {
+				if($defaultTextToWrite === $targetFidDataHandler->getElementValueInEntry($target_entry, $thisDefaultEle)) {
+						continue;
+				}
+    }
+		// otherwise, catalogue the default value
+		$cachedDefaults[$thisDefaultEle->getVar('ele_id')][$target_entry] = $defaultTextToWrite;
     $defaultValueMap[$key] = $defaultTextToWrite;
   }
-  $cachedDefaults[$target_fid][$keyByIds][$target_entry] = $defaultValueMap;
   return $defaultValueMap;
 }
 
@@ -9058,23 +9079,6 @@ function isMCPServerEnabled() {
     $formulizeConfig = $config_handler->getConfigsByCat(0, getFormulizeModId());
 
     return isset($formulizeConfig['formulizeMCPServerEnabled']) && $formulizeConfig['formulizeMCPServerEnabled'] == 1;
-}
-
-/**
- * Take an array of element handle -> value pairs, and add default values for any elements in the form that don't already have a value
- * @param array values - The values array that we're appending to
- * @param int fid - The ID of the form we're getting default values for
- * @return array Returns the passed array with default values added, if any
- */
-function addDefaultValuesToDataToWrite($values, $fid) {
-	$defaultValueMap = getEntryDefaults($fid);
-	foreach($defaultValueMap as $defaultValueElementHandle=>$defaultValueToWrite) {
-		// if the element is not a value that we received, then let's use the default value
-		if(!isset($values[$defaultValueElementHandle])) {
-			$values[$defaultValueElementHandle] = $defaultValueToWrite;
-		}
-	}
-	return $values;
 }
 
 /**

--- a/modules/formulize/include/subformSaveFunctions.php
+++ b/modules/formulize/include/subformSaveFunctions.php
@@ -101,7 +101,7 @@ function formulize_subformSave_writeNewEntry($element_to_write, $value_to_write,
 		// and take another pass at defaults
     foreach($sub_entry_written as $thisSubEntry) {
         // need to parse/write the defaults one more time, because some defaults may be dependent on other defaults -- dates mostly/only? -- problem is that when defaults are set in the normal writing of new entries, they don't take into account the default values of other elements. Should they? Kind of super awkward when there might be on before save happening after the default value is determined. Doing a second pass is really the only way??
-        writeEntryDefaults($target_sub,$thisSubEntry,array_keys($valuesToWrite));
+        secondPassWritingSubformEntryDefaults($target_sub,$thisSubEntry,array_keys($valuesToWrite));
         if($frid) {
             formulize_updateDerivedValues($entry,$mainFormFid,$frid);
         } else {


### PR DESCRIPTION
Finally, must do this for AI element creation tools, so each element can declare things cleanly/easily to the AI. All the other benefits will come along with this as well, especially streamlined element options, etc.