### PR TITLE
Peg xdebug installation to version 3.2.2

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.1-apache
 RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libzip-dev zip libfreetype6-dev
 RUN docker-php-ext-configure gd --with-jpeg=/usr/include/ --with-freetype=/usr/include/
 RUN docker-php-ext-install mysqli pdo pdo_mysql gd zip
-RUN pecl install xdebug
+RUN pecl install xdebug-3.2.2
 RUN docker-php-ext-enable mysqli pdo pdo_mysql gd xdebug zip
 RUN a2enmod rewrite
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"


### PR DESCRIPTION
I ran into issues with xdebug, which seemed to be resolved by rolling back to a known stable version. Seems the image may have got rebuilt with a latest version at some point and that caused VSCode in Windows 11 (at least) to stop playing nice with the Docker container.