### PR TITLE
A flag in the queue process method, that forces synchronous operation

### DIFF
--- a/docs/queue-process.md
+++ b/docs/queue-process.md
@@ -4,7 +4,7 @@ permalink: developers/API/classes/queue_handler/process/
 title: process
 ---
 
-# process( <span style='font-size: 14pt;'>(object|string) $queue_or_queue_handle</span> )
+# process( <span style='font-size: 14pt;'>(object|string) $queue_or_queue_handle, (boolean) $synchronous = false</span> )
 
 ## Description
 
@@ -16,9 +16,12 @@ If the queue is processed asynchronously, certain PHP environment constraints ma
 
 If the queue processing times out, triggering the processing of the queue again will pick up where the previous process left off. It is possible that the last item from the timed out processing will be processed again when the queue resumes.
 
+The normal way to trigger the queue through cron, is to hit the right endpoint of the [Public API](../../../../Public_API). But if your server does not support the right URL rewriting necessary for the public API to function, you can write a custom PHP file, or make a Template Screen in Formulize, accessible to Anonymous users, and have code in there which calls the queue process. You can then set a cron job to trigger that URL as required. In such cases, it may be necessary to use the __$synchronous__ flag set to true, if the queue is not processing otherwise.
+
 ## Parameters
 
 __$queue_or_queue_handle__ - [a queue object](../../queue_object), or a string used to identify the queue
+__$synchronous__ - Optional. A boolean flag to indicate if we should run the queue synchronously, even if we could run it asynchronously through 'exec' on the server. Defaults to false. Useful as a fallback in manual code, if you can't get the queue to run any other way.
 
 ## Return Values
 
@@ -29,4 +32,10 @@ Returns __true__ if asynchronous queue processing was triggered. Returns __an ar
 ~~~
 $queueHandler = xoops_getModuleHandler('queue', 'formulize');
 $queueHandler->process('my-queue');
+~~~
+
+~~~
+// force the queue to run the old-fashioned way
+$queueHandler = xoops_getModuleHandler('queue', 'formulize');
+$queueHandler->process('my-queue', synchronous: true);
 ~~~

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -8,7 +8,7 @@ title: queue
 
 Requests for the queue process method with a valid _queue_handle_, will trigger processing of the specified queue.
 
-To trigger processing of all queues, use __all__ as the queue_handle.
+To trigger processing of all queues, use __all__ as the queue_handle. This can be a useful endpoint to setup a cron job for, to ensure automated processing of whatever goes into the queue.
 
 If the queue is processed asynchronously, then the API will return true. If the queue is processed synchronously as part of the http request, then the API will return a JSON string that contains an array of the filenames that were processed in the queue.
 

--- a/modules/formulize/class/queue.php
+++ b/modules/formulize/class/queue.php
@@ -179,9 +179,10 @@ try {
 	/**
 	 * Process a queue or all the queues. If command line execution is available, entire queue processed that way without time limit. If not, then attempt as many queue items as possible in the time available for the current request.
 	 * @param object queue Optional. A queue object that represents the queue we're processing. If omitted, all queues are processed, items handled in the order they were created.
+	 * @param bool synchronous Optional. A flag to indicate whether we should process the queue synchronously (as part of this request) or hand it off to the command line for processing. Default is false, meaning we will hand it off to the command line if possible.
 	 * @return mixed An array of the queue filenames that were processed, if done as part of this request. True if the queue was handed off to the command line
 	 */
-	function process($queue_or_queue_handle=null) {
+	function process($queue_or_queue_handle=null, $synchronous = false) {
 		if(is_object($queue_or_queue_handle) AND is_a($queue_or_queue_handle, 'formulizeQueue')) {
 			$queueHandle = $queue_or_queue_handle->getVar('queue_handle');
 		} elseif($queue_or_queue_handle) {
@@ -190,7 +191,7 @@ try {
 			$queueHandle = 'all';
 		}
 		$queueIncludeFile = XOOPS_ROOT_PATH.'/modules/formulize/include/queue.php';
-		if(isEnabled('exec')) {
+		if(!$synchronous AND isEnabled('exec')) {
 			exec('php -f '.$queueIncludeFile.' '.escapeshellarg($queueHandle).' > /dev/null 2>&1 & echo $!');
 			return true;
 		} else {


### PR DESCRIPTION
Depending on server setup, you might not be able to get the Public API to run, and also 'exec' might be available or PHP thinks it is, but it doesn't actually work, due to firewall issues or who knows what. In that case, you need a fallback way of triggering the queue. Here it is.