### PR TITLE
Fix select element default value UI to use radio buttons instead of c…

### DIFF
--- a/modules/formulize/class/selectElement.php
+++ b/modules/formulize/class/selectElement.php
@@ -522,7 +522,13 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 				list($_POST['ele_value'], $ele_uitext) = formulize_extractUIText($_POST['ele_value']);
 				foreach($_POST['ele_value'] as $id=>$text) {
 					if($text !== "") {
-						$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = isset($_POST['defaultoption'][$id]) ? 1 : 0;
+						// For select elements, defaultoption is a single value (radio button)
+						// For other elements (listbox, autocomplete), it's an array (checkboxes)
+						if($selectTypeName == 'select') {
+							$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = (isset($_POST['defaultoption']) && $_POST['defaultoption'] == $id) ? 1 : 0;
+						} else {
+							$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = isset($_POST['defaultoption'][$id]) ? 1 : 0;
+						}
 					}
 				}
 			}

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -5,19 +5,19 @@
 <{if isset($content.useroptions) AND $content.useroptions|is_array AND $content.useroptions|@count > 0}>
   <{foreach from=$content.useroptions key=text item=checked name=optionsloop}>
     <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>">
-    <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
+    <{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text|replace:'"':'&quot;'}>" onchange="checkForNames()"></input> <span class='sorthandle'>&equiv;</span></p>
   <{/foreach}>
 <{else}>
   <p class="useroptions" name="0">
-  <{if $content.type == "radio"}><input type="radio" name="defaultoption" value=0></input>
+  <{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value=0></input>
   <{else}><input type="checkbox" name="defaultoption[0]" value=0></input>
   <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]" onchange="checkForNames()"></input> <span class='sorthandle'>&equiv;</span></p>
 <{/if}>
 </div>
 
-<{if $content.type == "radio"}>
+<{if $content.type == "radio" || $content.type == "select"}>
 <p><input type="button" class="formButton" name="cleardef" value="<{$smarty.const._AM_CLEAR_DEFAULT}>"/></p>
 <{/if}>
 
@@ -61,7 +61,7 @@
   $("[name=addoption]").click(function (){
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
-    appendContents1 = '<{if $content.type == "radio"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
+    appendContents1 = '<{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
     appendContents2 = '<input type="text" name="ele_value['+number+']"></input>';
     $(".optionlist").append('<p class="useroptions" name="'+number+'"></p>');
     $(".useroptions:last").append(appendContents1);
@@ -73,7 +73,7 @@
     $("#no").attr('checked',1);
   });
 
-  <{if $content.type == "radio"}>
+  <{if $content.type == "radio" || $content.type == "select"}>
   $("[name=cleardef]").click(function () {
     $("[name=defaultoption]").attr('checked',0);
     $("[name=cleardef]").blur();


### PR DESCRIPTION
…heckboxes

Fixes #770

- Updated element_optionlist.html template to render radio buttons for select elements
- Added conditional logic to distinguish select type from other list types (listbox, autocomplete)
- Updated selectElement.php adminSave method to handle single value from radio button
- Added "Clear Default" button for select elements like radio button elements
- Updated JavaScript handlers for dynamic option addition and default clearing

Select (dropdown) elements can only have one default value, so radio buttons are the semantically correct UI control. Other list element types (listbox, autocomplete) continue to use checkboxes for multiple default value selection.