### PR TITLE
Control form order in screens

### DIFF
--- a/modules/formulize/admin/patches/001_schema_migrations.php
+++ b/modules/formulize/admin/patches/001_schema_migrations.php
@@ -464,6 +464,7 @@ function formulize_run_schema_migrations($prev_dbversion, $required_dbversion) {
 				$sql['add_tfa_last_attempt'] = "ALTER TABLE ".$xoopsDB->prefix("tfa_codes"). " ADD `last_attempt` int(11) unsigned NOT NULL default 0";
 				$sql['add_tfa_created'] = "ALTER TABLE ".$xoopsDB->prefix("tfa_codes"). " ADD `created` int(11) unsigned NOT NULL default 0";
 				$sql['add_ele_handle_index'] = "ALTER TABLE ".$xoopsDB->prefix("formulize")." ADD INDEX i_ele_handle (`ele_handle`)";
+				$sql['form_screen_multipage_formorder'] = "ALTER TABLE ".$xoopsDB->prefix("formulize_screen_multipage") . " ADD `formorder` text NOT NULL";
 
         $needToSetSaveAndLeave = true;
         $needToSetPrintableView = true;
@@ -621,6 +622,8 @@ function formulize_run_schema_migrations($prev_dbversion, $required_dbversion) {
 									print "2FA attempt-limiting fields already added. result: OK<br>";
 								} elseif($key === "add_ele_handle_index") {
 									print "ele_handle index already added. result: OK<br>";
+								} elseif($key === "form_screen_multipage_formorder") {
+									print "formorder field already added. result: OK<br>";
 								} else {
                     exit("Error patching DB for Formulize $versionNumber. SQL dump:<br>" . $thissql . "<br>".$xoopsDB->error()."<br>Please contact <a href=mailto:info@formulize.org>info@formulize.org</a> for assistance.");
                 }

--- a/modules/formulize/admin/save/screen_multipage_options_save.php
+++ b/modules/formulize/admin/save/screen_multipage_options_save.php
@@ -84,6 +84,20 @@ if(isset($_POST['singlecolumn1width']) AND isset($screens['displaycolumns']) AND
     $column1width = $_POST['doublecolumn1width'];
 }
 
+// parse the drag-to-reorder form order (jQuery UI sortable serialize string, eg: formorderitem[]=3&formorderitem[]=5)
+// only present/relevant when the screen unifies more than one form; skip the property entirely when absent so we don't wipe an existing order
+$formorder = null;
+if(isset($_POST['formorder']) AND trim($_POST['formorder']) !== "") {
+    $formorderParts = explode("formorderitem[]=", str_replace("&", "", $_POST['formorder']));
+    unset($formorderParts[0]); // the piece before the first key is empty
+    $formorder = array();
+    foreach($formorderParts as $formorderFid) {
+        if(is_numeric($formorderFid)) {
+            $formorder[] = intval($formorderFid);
+        }
+    }
+}
+
 // delegate persistence to the shared upsert apparatus (handles the insert serialization quirk, handle uniqueness, etc.)
 $properties = array(
     'paraentryform' => $screens['paraentryform'],
@@ -102,6 +116,9 @@ $properties = array(
     'elementdefaults' => isset($screens['elementdefaults']) ? $screens['elementdefaults'] : "",
     'reloadblank' => $screens['reloadblank'],
 );
+if(is_array($formorder)) {
+    $properties['formorder'] = $formorder; // upsert serializes it (formorder is an array field)
+}
 try {
   formulizeHandler::upsertMultiPageScreen($properties, $sid);
 } catch (Exception $e) {

--- a/modules/formulize/admin/screen.php
+++ b/modules/formulize/admin/screen.php
@@ -411,6 +411,35 @@ if ($screen_id != "new" && $settings['type'] == 'multiPage') {
     $multipageOptions['element_list'] = $element_list;
     $multipageOptions['elementdefaults'] = $screen->getVar('elementdefaults');
 
+    // build the list of forms for the manual form-order UI, only relevant when multiple related forms are unified into this screen
+    $multipageOptions['formorder_list'] = array();
+    if($frid) {
+        $framework_handler = xoops_getModuleHandler('frameworks', 'formulize');
+        $frameworkObject = $framework_handler->get($frid);
+        $unifiedFids = $frameworkObject->getUnifiedDisplayFids($form_id);
+        if(count($unifiedFids) > 1) {
+            // apply any saved order: saved fids first (those still valid), then any remaining forms in canonical order (so newly connected forms still appear)
+            $savedFormOrder = $screen->getVar('formorder');
+            $orderedFids = array();
+            if(is_array($savedFormOrder)) {
+                foreach($savedFormOrder as $savedFid) {
+                    if(in_array($savedFid, $unifiedFids) AND !in_array($savedFid, $orderedFids)) {
+                        $orderedFids[] = $savedFid;
+                    }
+                }
+            }
+            foreach($unifiedFids as $unifiedFid) {
+                if(!in_array($unifiedFid, $orderedFids)) {
+                    $orderedFids[] = $unifiedFid;
+                }
+            }
+            foreach($orderedFids as $orderedFid) {
+                $formObject = new formulizeForm($orderedFid);
+                $multipageOptions['formorder_list'][$orderedFid] = printSmart(trans(strip_tags($formObject->title)), 60);
+            }
+        }
+    }
+
 
 }
 

--- a/modules/formulize/class/formulize.php
+++ b/modules/formulize/class/formulize.php
@@ -66,7 +66,8 @@ class FormulizeObject extends XoopsObject {
 				'pages',
 				'pagetitles',
 				'conditions',
-				'elementdefaults'
+				'elementdefaults',
+				'formorder'
 			],
 			'formulize_screen_listofentries' => [
 				'limitviews',
@@ -444,7 +445,7 @@ class formulizeHandler {
 		}
 
 		// keys that this method sets explicitly below, so they are skipped by the generic scalar loop
-		$arrayFields = array('pages', 'pagetitles', 'conditions', 'elementdefaults');
+		$arrayFields = array('pages', 'pagetitles', 'conditions', 'elementdefaults', 'formorder');
 		$handledSpecially = array_merge($arrayFields, array('fid', 'sid', 'screen_handle', 'thankstext', 'introtext', 'buttontext'));
 
 		// apply plain scalar/text properties (partial update - only what was provided)

--- a/modules/formulize/class/frameworks.php
+++ b/modules/formulize/class/frameworks.php
@@ -125,6 +125,30 @@ class formulizeFramework extends XoopsObject {
 		return array($cachedHandles[$key],($mainformFid==$targetFid));
 	}
 
+	// this method returns an ordered array of form ids that should be unified into a single display anchored on $fid (ie: a form/multipage screen showing elements from multiple related forms)
+	// the first element is always $fid itself, followed by each connected form that qualifies, in the order its link appears in the framework
+	// for each link that has unifiedDisplay turned on, the form on the OTHER side of the link from $fid is added, but only when $fid's own role in that link is one of:
+	//   - a participant in a one-to-one relationship (the other form is then also part of the one-to-one), or
+	//   - the "many" side of a one-to-many relationship (the other form is then the "one" side)
+	// the conditions below are therefore all tests on $fid's role, not on the form being added
+	// (relationship codes: 1 = one-to-one; 2 = one-to-many with form1 as the "one" side and form2 as the "many" side; 3 = one-to-many with form1 as the "many" side and form2 as the "one" side)
+	// usage: $fids = $framework->getUnifiedDisplayFids($fid);
+	function getUnifiedDisplayFids($fid) {
+		$fids = array($fid);
+		foreach($this->getVar("links") as $thisLinkObject) {
+			if ($thisLinkObject->getVar("unifiedDisplay") AND (( $thisLinkObject->getVar("relationship") == 1 AND ($thisLinkObject->getVar("form1") == $fid OR $thisLinkObject->getVar("form2") == $fid))
+				OR ($thisLinkObject->getVar("relationship") == 2 AND $thisLinkObject->getVar("form1") != $fid AND $thisLinkObject->getVar("form2") == $fid)
+				OR ($thisLinkObject->getVar("relationship") == 3 AND $thisLinkObject->getVar("form2") != $fid AND $thisLinkObject->getVar("form1") == $fid)
+					)) {
+						$thisFid = $thisLinkObject->getVar("form1") == $fid ? $thisLinkObject->getVar("form2") : $thisLinkObject->getVar("form1");
+						if(!in_array($thisFid, $fids)) {
+							$fids[] = $thisFid;
+						}
+			}
+		}
+		return $fids;
+	}
+
 
     function __get($name) {
         if (!isset($this->$name)) {

--- a/modules/formulize/class/multiPageScreen.php
+++ b/modules/formulize/class/multiPageScreen.php
@@ -66,6 +66,7 @@ class formulizeMultiPageScreen extends formulizeScreen {
 		$this->initVar('displayheading', XOBJ_DTYPE_INT);
 		$this->initVar('reloadblank', XOBJ_DTYPE_INT);
 		$this->initVar('elementdefaults', XOBJ_DTYPE_ARRAY);
+		$this->initVar('formorder', XOBJ_DTYPE_ARRAY); // ordered array of fids controlling the order that forms appear in when the screen unifies elements from multiple related forms
 	}
 
 	/**
@@ -154,7 +155,7 @@ class formulizeMultiPageScreenHandler extends formulizeScreenHandler {
 
 		// note: conditions is not written to the DB yet, since we're not gathering that info from the UI
 		if (!$update) {
-                 $sql = sprintf("INSERT INTO %s (sid, introtext, thankstext, donedest, buttontext, finishisdone, pages, pagetitles, conditions, printall, paraentryform, paraentryrelationship, navstyle, displaycolumns, column1width, column2width, showpagetitles, showpageindicator, showpageselector, displayheading, reloadblank, elementdefaults) VALUES (%u, %s, %s, %s, %s, %u, %s, %s, %s, %u, %u, %u, %u, %u, %s, %s, %u, %u, %u, %u, %u, %s)",
+                 $sql = sprintf("INSERT INTO %s (sid, introtext, thankstext, donedest, buttontext, finishisdone, pages, pagetitles, conditions, printall, paraentryform, paraentryrelationship, navstyle, displaycolumns, column1width, column2width, showpagetitles, showpageindicator, showpageselector, displayheading, reloadblank, elementdefaults, formorder) VALUES (%u, %s, %s, %s, %s, %u, %s, %s, %s, %u, %u, %u, %u, %u, %s, %s, %u, %u, %u, %u, %u, %s, %s)",
                     $this->db->prefix('formulize_screen_multipage'),
                     $screen->getVar('sid'),
                     $this->db->quoteString($screen->getVar('introtext', "e")),
@@ -177,11 +178,12 @@ class formulizeMultiPageScreenHandler extends formulizeScreenHandler {
                     $screen->getVar('showpageselector'),
                     $screen->getVar('displayheading'),
                     $screen->getVar('reloadblank'),
-                    $this->db->quoteString(serialize($screen->getVar('elementdefaults')))
+                    $this->db->quoteString(serialize($screen->getVar('elementdefaults'))),
+                    $this->db->quoteString(serialize($screen->getVar('formorder')))
                     );
                     //nmc 2007.03.24 added 'printall' & fixed pagetitles
              } else {
-                 $sql = sprintf("UPDATE %s SET introtext = %s, thankstext = %s, donedest = %s, buttontext = %s, finishisdone = %u, pages = %s, pagetitles = %s, conditions = %s, printall = %u, paraentryform = %u, paraentryrelationship = %u, navstyle = %u, displaycolumns = %u, column1width = %s, column2width = %s, showpagetitles = %u, showpageindicator = %u, showpageselector = %u, displayheading = %u, reloadblank = %u, elementdefaults = %s WHERE sid = %u", $this->db->prefix('formulize_screen_multipage'), $this->db->quoteString($screen->getVar('introtext', "e")), $this->db->quoteString($screen->getVar('thankstext', "e")), $this->db->quoteString($screen->getVar('donedest')), $this->db->quoteString(serialize($screen->getVar('buttontext'))), $screen->getVar('finishisdone'), $this->db->quoteString(serialize($screen->getVar('pages'))), $this->db->quoteString(serialize($screen->getVar('pagetitles'))), $this->db->quoteString(serialize($screen->getVar('conditions'))), $screen->getVar('printall'), $screen->getVar('paraentryform'), $screen->getVar('paraentryrelationship'), $screen->getVar('navstyle'),  $screen->getVar('displaycolumns'), $this->db->quoteString($screen->getVar('column1width')), $this->db->quoteString($screen->getVar('column2width')), $screen->getVar('showpagetitles'), $screen->getVar('showpageindicator'), $screen->getVar('showpageselector'), $screen->getVar('displayheading'), $screen->getVar('reloadblank'), $this->db->quoteString(serialize($screen->getVar('elementdefaults'))), $screen->getVar('sid')); //nmc 2007.03.24 added 'printall'
+                 $sql = sprintf("UPDATE %s SET introtext = %s, thankstext = %s, donedest = %s, buttontext = %s, finishisdone = %u, pages = %s, pagetitles = %s, conditions = %s, printall = %u, paraentryform = %u, paraentryrelationship = %u, navstyle = %u, displaycolumns = %u, column1width = %s, column2width = %s, showpagetitles = %u, showpageindicator = %u, showpageselector = %u, displayheading = %u, reloadblank = %u, elementdefaults = %s, formorder = %s WHERE sid = %u", $this->db->prefix('formulize_screen_multipage'), $this->db->quoteString($screen->getVar('introtext', "e")), $this->db->quoteString($screen->getVar('thankstext', "e")), $this->db->quoteString($screen->getVar('donedest')), $this->db->quoteString(serialize($screen->getVar('buttontext'))), $screen->getVar('finishisdone'), $this->db->quoteString(serialize($screen->getVar('pages'))), $this->db->quoteString(serialize($screen->getVar('pagetitles'))), $this->db->quoteString(serialize($screen->getVar('conditions'))), $screen->getVar('printall'), $screen->getVar('paraentryform'), $screen->getVar('paraentryrelationship'), $screen->getVar('navstyle'),  $screen->getVar('displaycolumns'), $this->db->quoteString($screen->getVar('column1width')), $this->db->quoteString($screen->getVar('column2width')), $screen->getVar('showpagetitles'), $screen->getVar('showpageindicator'), $screen->getVar('showpageselector'), $screen->getVar('displayheading'), $screen->getVar('reloadblank'), $this->db->quoteString(serialize($screen->getVar('elementdefaults'))), $this->db->quoteString(serialize($screen->getVar('formorder'))), $screen->getVar('sid')); //nmc 2007.03.24 added 'printall'
              }
 					if($force) {
 						$result = $this->db->queryF($sql);
@@ -641,16 +643,13 @@ function multiPageScreen_addToOptionsList($fid, $frid=0) {
 		$options = multiPageScreen_addToOptionsListByFid($fid, $frid);
 		if($frid) {
 			// figure out which forms in the relationship we care about, and append them to the array
+			// getUnifiedDisplayFids returns $fid first followed by the connected forms that qualify, so skip the first one which we've already added
 			$framework_handler =& xoops_getModuleHandler('frameworks', 'formulize');
 			$frameworkObject = $framework_handler->get($frid);
-			foreach($frameworkObject->getVar("links") as $thisLinkObject) {
-					if ($thisLinkObject->getVar("unifiedDisplay") AND (( $thisLinkObject->getVar("relationship") == 1 AND ($thisLinkObject->getVar("form1") == $fid OR $thisLinkObject->getVar("form2") == $fid))
-						OR ($thisLinkObject->getVar("relationship") == 2 AND $thisLinkObject->getVar("form1") != $fid AND $thisLinkObject->getVar("form2") == $fid)
-						OR ($thisLinkObject->getVar("relationship") == 3 AND $thisLinkObject->getVar("form2") != $fid AND $thisLinkObject->getVar("form1") == $fid)
-							)) {
-								$thisFid = $thisLinkObject->getVar("form1") == $fid ? $thisLinkObject->getVar("form2") : $thisLinkObject->getVar("form1");
-								$options = multiPageScreen_addToOptionsListByFid($thisFid, $frid, $options); // append to the array
-					}
+			$unifiedFids = $frameworkObject->getUnifiedDisplayFids($fid);
+			array_shift($unifiedFids); // drop $fid itself, already handled above
+			foreach($unifiedFids as $thisFid) {
+				$options = multiPageScreen_addToOptionsListByFid($thisFid, $frid, $options); // append to the array
 			}
 		}
 		return $options;

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -1307,6 +1307,22 @@ function displayForm($formframe, $entry="", $mainform="", $done_dest="", $button
 					}
 				}
 			}
+			// if this is a form (multipage) screen with a manually specified form order, honour it:
+			// list the forms in the saved order first (only those actually present), then append any remaining forms in their existing order (so forms added since the order was saved still render)
+			if(is_a($screen, "formulizeMultiPageScreen") AND is_array($savedFormOrder = $screen->getVar('formorder')) AND count($savedFormOrder) > 0) {
+				$orderedFidsToRender = array();
+				foreach($savedFormOrder as $orderedFid) {
+					if(isset($fidsToRender[$orderedFid])) {
+						$orderedFidsToRender[$orderedFid] = $fidsToRender[$orderedFid];
+					}
+				}
+				foreach($fidsToRender as $remainingFid) {
+					if(!isset($orderedFidsToRender[$remainingFid])) {
+						$orderedFidsToRender[$remainingFid] = $remainingFid;
+					}
+				}
+				$fidsToRender = $orderedFidsToRender;
+			}
 		}
 
 		// only loop through the fids that have elements we are going to show

--- a/modules/formulize/language/english/admin.php
+++ b/modules/formulize/language/english/admin.php
@@ -866,6 +866,9 @@ define("_AM_FORMULIZE_SCREEN_PRINTALL", "Make the 'Printable Version - All Pages
 define("_AM_FORMULIZE_SCREEN_PRINTALL_Y", "Yes"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_N", "No"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_NONE", "No, and not the regular 'Printable Version' button either");
+define("_AM_FORMULIZE_SCREEN_FORMORDER", "Order of forms");
+define("_AM_FORMULIZE_SCREEN_FORMORDER_INTRO", "This screen shows elements from more than one connected form. Click and drag to set the order the forms appear in:");
+define("_AM_FORMULIZE_SCREEN_FORMORDER_DESC", "Elements within each form always appear in the form's own order. This setting only controls the order of the forms relative to each other.");
 define("_AM_FORMULIZE_DELETE_THIS_PAGE", "Delete this page");
 define("_AM_FORMULIZE_CONFIRM_SCREEN_DELETE", "Are you sure you want to delete this screen?  Please confirm!");
 define("_AM_FORMULIZE_CONFIRM_SCREEN_DELETE_PAGE", "Are you sure you want to delete this page?  Please confirm!");

--- a/modules/formulize/language/english/admin.php
+++ b/modules/formulize/language/english/admin.php
@@ -867,8 +867,8 @@ define("_AM_FORMULIZE_SCREEN_PRINTALL_Y", "Yes"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_N", "No"); //nmc 2007.03.24
 define("_AM_FORMULIZE_SCREEN_PRINTALL_NONE", "No, and not the regular 'Printable Version' button either");
 define("_AM_FORMULIZE_SCREEN_FORMORDER", "Order of forms");
-define("_AM_FORMULIZE_SCREEN_FORMORDER_INTRO", "This screen shows elements from more than one connected form. Click and drag to set the order the forms appear in:");
-define("_AM_FORMULIZE_SCREEN_FORMORDER_DESC", "Elements within each form always appear in the form's own order. This setting only controls the order of the forms relative to each other.");
+define("_AM_FORMULIZE_SCREEN_FORMORDER_INTRO", "Click and drag the form names below to set the order in which the forms should be appear in the screen.");
+define("_AM_FORMULIZE_SCREEN_FORMORDER_DESC", "This setting only takes effect if you show elements from multiple forms on the same page. All the elements from one form will appear first, followed by the elements from the next, etc. The precise order of the elements within each form is controled in the form's own settings.");
 define("_AM_FORMULIZE_DELETE_THIS_PAGE", "Delete this page");
 define("_AM_FORMULIZE_CONFIRM_SCREEN_DELETE", "Are you sure you want to delete this screen?  Please confirm!");
 define("_AM_FORMULIZE_CONFIRM_SCREEN_DELETE_PAGE", "Are you sure you want to delete this page?  Please confirm!");

--- a/modules/formulize/sql/mysql.sql
+++ b/modules/formulize/sql/mysql.sql
@@ -234,6 +234,7 @@ CREATE TABLE `formulize_screen_multipage` (
   `displayheading` tinyint(1) NOT NULL default 0,
   `reloadblank` tinyint(1) NOT NULL default 0,
   `elementdefaults` text NOT NULL,
+  `formorder` text NOT NULL,
   PRIMARY KEY (`multipageid`),
   INDEX i_sid (`sid`)
 ) ENGINE=InnoDB;

--- a/modules/formulize/templates/admin/screen_multipage_options.html
+++ b/modules/formulize/templates/admin/screen_multipage_options.html
@@ -113,6 +113,21 @@
       <{/if}>
 	</fieldset>
 
+		<{if $content.formorder_list|@count gt 1}>
+    <fieldset>
+        <legend><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER}></legend>
+        <div class="form-item">
+            <p><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_INTRO}></p>
+            <ul id="formorder-sortable" class="formorder-sortable">
+                <{foreach from=$content.formorder_list key=fid item=formTitle}>
+                <li id="formorderitem-<{$fid}>" class="formorder-item ui-corner-all"><{$formTitle}></li>
+                <{/foreach}>
+            </ul>
+            <div class="description"><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_DESC}></div>
+        </div>
+    </fieldset>
+    <{/if}>
+
     <fieldset>
 		<legend>Element Defaults</legend>
 		<div class="form-item">
@@ -127,21 +142,6 @@
 			<div class="description">Defaults that you set for elements here, will take effect only on this screen. The elements will behave normally on other screens (if those screens do not have any defaults set of their own).</div>
 		</div>
 	</fieldset>
-
-    <{if $content.formorder_list|@count gt 1}>
-    <fieldset>
-        <legend><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER}></legend>
-        <div class="form-item">
-            <p><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_INTRO}></p>
-            <ul id="formorder-sortable" class="formorder-sortable">
-                <{foreach from=$content.formorder_list key=fid item=formTitle}>
-                <li id="formorderitem-<{$fid}>" class="formorder-item"><{$formTitle}></li>
-                <{/foreach}>
-            </ul>
-            <div class="description"><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_DESC}></div>
-        </div>
-    </fieldset>
-    <{/if}>
 
     <fieldset>
       <legend>Answers from a previous entry</legend>
@@ -215,14 +215,18 @@ if($("#formorder-sortable").length) {
         padding: 0;
         max-width: 400px;
     }
-    .formorder-item {
-        border: 1px solid #ccc;
-        background: #f6f6f6;
+    /* #xo-canvas-content li carries an ID selector (color: #000; background-color: inherit;) which outranks a
+       plain .formorder-item class on specificity alone, regardless of source order, so this rule must be scoped
+       under the #formorder-sortable id to win the cascade */
+    #formorder-sortable .formorder-item {
+        border: 1px solid #94daf2;
+        background-color: #0085b6;
+        color: #FFF;
+        opacity: 1;
         padding: 0.5em 0.75em;
         margin-bottom: 4px;
         cursor: move;
-    }
-    .formorder-item:hover {
-        background: #eee;
+        position: relative;
+        z-index: 1;
     }
 </style>

--- a/modules/formulize/templates/admin/screen_multipage_options.html
+++ b/modules/formulize/templates/admin/screen_multipage_options.html
@@ -130,15 +130,15 @@
 
     <{if $content.formorder_list|@count gt 1}>
     <fieldset>
-        <legend>Order of forms</legend>
+        <legend><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER}></legend>
         <div class="form-item">
-            <p>This screen shows elements from more than one connected form. Click and drag to set the order the forms appear in:</p>
+            <p><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_INTRO}></p>
             <ul id="formorder-sortable" class="formorder-sortable">
                 <{foreach from=$content.formorder_list key=fid item=formTitle}>
                 <li id="formorderitem-<{$fid}>" class="formorder-item"><{$formTitle}></li>
                 <{/foreach}>
             </ul>
-            <div class="description">Elements within each form always appear in the form's own order. This setting only controls the order of the forms relative to each other.</div>
+            <div class="description"><{$smarty.const._AM_FORMULIZE_SCREEN_FORMORDER_DESC}></div>
         </div>
     </fieldset>
     <{/if}>

--- a/modules/formulize/templates/admin/screen_multipage_options.html
+++ b/modules/formulize/templates/admin/screen_multipage_options.html
@@ -7,6 +7,7 @@
 <{$securitytoken}>
 <input type="hidden" name="formulize_admin_handler" value="screen_multipage_options">
 <input type="hidden" name="formulize_admin_key" value="<{$content.sid}>">
+<input type="hidden" name="formorder" value="">
 
 
 <div class="panel-content content">
@@ -127,6 +128,21 @@
 		</div>
 	</fieldset>
 
+    <{if $content.formorder_list|@count gt 1}>
+    <fieldset>
+        <legend>Order of forms</legend>
+        <div class="form-item">
+            <p>This screen shows elements from more than one connected form. Click and drag to set the order the forms appear in:</p>
+            <ul id="formorder-sortable" class="formorder-sortable">
+                <{foreach from=$content.formorder_list key=fid item=formTitle}>
+                <li id="formorderitem-<{$fid}>" class="formorder-item"><{$formTitle}></li>
+                <{/foreach}>
+            </ul>
+            <div class="description">Elements within each form always appear in the form's own order. This setting only controls the order of the forms relative to each other.</div>
+        </div>
+    </fieldset>
+    <{/if}>
+
     <fieldset>
       <legend>Answers from a previous entry</legend>
 	  <div class="form-item">
@@ -174,6 +190,17 @@ function appendDefault(id, elementText, defaultText) {
     $('#addeddefaults').append('<input type="hidden" name="screens-elementdefaults['+id+']" id="hidden_'+id+'" value="'+defaultText+'"><span class="adefault" id="def_'+id+'">'+elementText+' >> '+defaultText+'<br></span>');
 }
 
+// form order drag-to-reorder (only present when the screen unifies more than one form)
+if($("#formorder-sortable").length) {
+    $("#formorder-sortable").sortable();
+    $("#formorder-sortable").bind("sortupdate", function(event, ui) {
+        setDisplay('savewarning','block');
+    });
+    $(".savebutton").click(function() {
+        $("[name=formorder]").val($("#formorder-sortable").sortable('serialize'));
+    });
+}
+
 </script>
 
 <style>
@@ -181,5 +208,21 @@ function appendDefault(id, elementText, defaultText) {
         color: red;
         text-decoration: line-through;
         cursor: pointer;
+    }
+    .formorder-sortable {
+        list-style: none;
+        margin: 0.5em 0;
+        padding: 0;
+        max-width: 400px;
+    }
+    .formorder-item {
+        border: 1px solid #ccc;
+        background: #f6f6f6;
+        padding: 0.5em 0.75em;
+        margin-bottom: 4px;
+        cursor: move;
+    }
+    .formorder-item:hover {
+        background: #eee;
     }
 </style>

--- a/modules/formulize/xoops_version.php
+++ b/modules/formulize/xoops_version.php
@@ -39,7 +39,7 @@ $modversion = array(
 	'license' => "GPL-2.0",
 	'image' => "images/formulize.gif",
 	'dirname' => "formulize",
-	'dbversion' => 6,
+	'dbversion' => 7,
 	'onUpdate' => "include/on_update.php"
 );
 


### PR DESCRIPTION
This lets you control which form gets processed first, second, etc, when the elements are put together in the screen. All the first form's elements go first, then the second, etc.