### PR TITLE
Adding EAU/EAG awareness to AI tools

### DIFF
--- a/EAG_PI_INVARIANT_PLAN.md
+++ b/EAG_PI_INVARIANT_PLAN.md
@@ -1,0 +1,130 @@
+# Plan: Ensure entries-are-groups forms always have a PI set
+
+Addresses the long-standing TODO ("ensure forms with entries_are_groups always have a PI set")
+that was noted in `readelements.php` but never implemented. Entry-group names for an
+entries_are_groups (EAG) form are built as `"{PI value} - {Category name}"`, so an EAG form with
+no PI (or a PI pointing at a deleted element) cannot create or rename its entry groups —
+`syncEntryGroups()` bails out at the "no PI value" / "no PI element" guards and the form is
+effectively broken.
+
+## Current state — a PI can be cleared three ways on an EAG form
+
+1. **Settings dropdown → "None".** `primary_identifier_selection.html` renders
+   `<option value="">…None…</option>`. Selecting it submits `forms-pi=""`, which is applied via
+   `$formObject->setVar('pi', '')` in `formulizeHandler::upsertFormSchemaAndResources()`
+   (`modules/formulize/class/formulize.php:341`).
+2. **Un-checking "principal identifier"** on the element names page →
+   `$formObject->setVar('pi', 0)` (`modules/formulize/admin/save/element_names_save.php:112`).
+3. **Deleting the PI element** → element row + data column removed, then
+   `$formObject->setVar('pi', 0)` (`modules/formulize/class/elements.php:1120`).
+
+`forms-pi` is persisted through `setVar('pi', …)`, so cases 1 and 2 share a single chokepoint:
+the form object's `setVar` override (`modules/formulize/class/forms.php`).
+
+## Goal (invariant)
+
+**An entries_are_groups form always references a valid, existing PI element.**
+
+## Design constraints already established
+
+- `formulizeForm::setVar` is the one chokepoint every PI designation/clearing flows through
+  (admin settings dropdown, element names page, upsert, MCP, relationship options). Object
+  hydration from the DB uses `assignVar()`, **not** `setVar()`, so guards added to `setVar` never
+  fire on load.
+- A naive "refuse `pi=0`" guard alone is **not safe for case 3**: on deletion the element is
+  already gone by the time `setVar('pi', 0)` runs, so refusing the clear would leave `pi` pointing
+  at a **deleted** element — a dangling reference worse than the current "cleanly set to 0".
+  Therefore the delete path needs its own guard so it never tries to clear the PI on an EAG form.
+- Related, already-completed work this builds on: EAG PI elements are now forced
+  `ele_required = 1` (in `formulizeForm::setVar` when `pi` is set on an EAG form), and hyphens in
+  EAG PI values are recast to underscores at write time (`formulizeDataHandler::writeEntry`).
+
+## Plan — three guards
+
+### 1. Backend safety net — `setVar` guard (blocks cases 1 & 2)
+**File:** `modules/formulize/class/forms.php` (`formulizeForm::setVar`).
+
+At the top of `setVar`, before `parent::setVar`, refuse to clear the PI on an EAG form:
+
+```php
+// Do not allow clearing the PI on an entries_are_groups form — its entry-group names depend on it.
+if ("pi" == $key AND intval($value) < 1 AND $this->getVar('entries_are_groups')) {
+    return; // leave the existing PI in place
+}
+```
+
+- Silently ignores the clear (leaves `pi` unchanged); the subsequent `$form_handler->insert()`
+  persists the form with the old PI intact.
+- Covers the settings dropdown "None" and the names-page un-designation.
+- Benign edge case: disabling EAG **and** clearing the PI in the same save is order-dependent on
+  which property `setVar` receives first; a non-EAG form keeping a stale-but-valid PI is harmless.
+
+### 2. Delete guard (closes case 3 — required so guard #1 doesn't regress deletion)
+**File:** `modules/formulize/class/elements.php` (`formulizeElementsHandler::delete`).
+
+At the very top of `delete()` (before any row/column removal), refuse to delete an element that is
+the PI of an EAG form:
+
+```php
+$form_handler = xoops_getmodulehandler('forms', 'formulize');
+if (($parentForm = $form_handler->get($elementObject->getVar('fid')))
+    AND $parentForm->getVar('entries_are_groups')
+    AND $elementObject->getVar('ele_id') == $parentForm->getVar('pi')) {
+    print "Error: cannot delete the principal identifier element of an entries-are-groups form; its entry group names depend on it. Designate a different PI first, or disable entries-are-groups.";
+    return false;
+}
+```
+
+- Uses `print` + `return false`, matching the existing error-reporting style in `delete()`.
+- Because deletion is blocked up front, the `setVar('pi', 0)` cleanup at `elements.php:1120` is
+  never reached for an EAG PI, so guard #1 cannot produce a dangling reference.
+
+### 3. UI polish — hide "None" for EAG forms
+**File:** `modules/formulize/templates/admin/primary_identifier_selection.html`.
+
+Wrap the `None` option so it is not offered when the form is EAG:
+
+```smarty
+<{if !$content.entries_are_groups}>
+    <option value=""><{$smarty.const._AM_SETTINGS_FORM_PI_NONE}></option>
+<{/if}>
+```
+
+- `entries_are_groups` is assigned into the settings content in `modules/formulize/admin/form.php`
+  (line ~203/990) alongside `pioptions`/`defaultpi`; confirm it is reachable as
+  `$content.entries_are_groups` inside this included template before relying on it. If it is not,
+  pass it through explicitly from `form_settings.html`'s include.
+- This is UX only; the backend guards (#1, #2) remain the authoritative enforcement.
+
+## Open decision (confirm before implementing)
+
+The **delete guard (#2)** is a behavior change beyond the originally proposed two fixes: an admin
+who tries to delete the PI field of an EAG form is blocked and must re-designate a PI (or disable
+EAG) first. Options:
+
+- **(A) Block deletion** (this plan) — simplest, preserves the invariant, clear error message.
+- **(B) Allow deletion but auto-pick another element as the new PI** — more convenient, but the
+  auto-choice may be surprising and there may be no other suitable element.
+- **(C) Leave deletion as-is** — then case 3 can still clear the PI, and guard #1 must be made
+  aware of the delete-cleanup path to avoid the dangling reference. Not recommended.
+
+Default recommendation: **(A)**.
+
+## Verification
+
+- `php -l` on each edited file (`forms.php`, `elements.php`).
+- Trace the three clearing paths to confirm each is blocked / not offered.
+- e2e (`005-create-users-and-groups.spec.js`) considerations — extend Block L (or add a block) to:
+  - assert the settings PI dropdown has no "None" option for the Departments (EAG) form;
+  - attempt to delete the Departments PI ("Name") element and assert it is refused and the PI is
+    unchanged;
+  - (optional) assert the Departments PI element is `required`.
+- Note: guard #2 changes deletion behavior for EAG PI elements — check no existing test deletes an
+  EAG PI element as part of its flow.
+
+## Touched files summary
+
+- `modules/formulize/class/forms.php` — setVar guard (block clearing PI on EAG).
+- `modules/formulize/class/elements.php` — delete guard (block deleting an EAG PI element).
+- `modules/formulize/templates/admin/primary_identifier_selection.html` — hide "None" for EAG.
+- `tests/e2e/formulize-core/setup/005-create-users-and-groups.spec.js` — coverage (optional but recommended).

--- a/mcp/tools.php
+++ b/mcp/tools.php
@@ -1989,6 +1989,12 @@ private function validateFilter($filter, $form_ids, $andOr = 'AND') {
 	 * Write entry data to a form (used by both create and update tools)
 	 * The form id is not actually required in the underlying formulize_writeEntry function, because the element references are globally unique and the form can be derived from them.
 	 * However, this method still validates that the form exists and that the elements are part of the form, which is useful since the AI assistant might have hallucinated elements!
+	 *
+	 * NOTE: Writing is NOT atomic. Entries are written one at a time in a loop with no surrounding
+	 * transaction, so a failure anywhere (a thrown validation error, a permission problem, a base
+	 * conditions failure, etc.) cancels the whole operation but leaves everything written up to that
+	 * point committed. A batch can therefore be partially applied when it throws.
+	 *
 	 * @param int $formId The ID of the form to write the entry to
 	 * @param string $operation Either 'create' or 'update'
 	 * @param array $data The data to write. Each value is an array of key-value pairs, representing the element handles and values of the data to store. If $operation is 'update', entry_id must be a key and the value is the entry ID to update.
@@ -2152,17 +2158,102 @@ private function validateFilter($filter, $form_ids, $andOr = 'AND') {
 
 		}
 
-		// Step 3: Write the entry
+		// Load form object for EAU/EAG detection
+		$form_handler = xoops_getmodulehandler('forms', 'formulize');
+		$formObject = $form_handler->get($formId);
+		$isEauForm = $formObject && $formObject->getVar('entries_are_users');
+		$isEagForm = $formObject && $formObject->getVar('entries_are_groups');
+		$isSystemUsersTableForm = $formObject && $formObject->isSystemUsersTableForm();
+
+		$allWrittenEntryIds = []; // Track written entry IDs for connected-form EAU processing
+		$userIdsFromSubmission = []; // entryId => userId for entries where processUserAccountSubmission ran
+
+		// Step 3: Write the entries
 		// keys are entry ids when updating, or sequential integers when creating
-		foreach($preparedData as $i => $entryData) {
+		foreach(array_keys($preparedData) as $i) {
 			$entryId = $operation == 'create' ? 'new' : $i;
-			$resultEntryId = formulize_writeEntry($entryData, $entryId); // writes data and manages ownership info
+			// For EAU creates, use a unique sentinel per iteration so the processUserAccountSubmission
+			// static cache (keyed on formId-entryId) doesn't collapse multiple creates into one result.
+			// intval('new_N') === 0, so loadOrCreateUserContext still treats it as a new user.
+			$postEntryId = $operation == 'create' ? 'new_'.$i : $i;
+			$userId = null;
+
+			// EAU: move user account element values from preparedData into $_POST, then call processUserAccountSubmission
+			if($isEauForm && !$isSystemUsersTableForm) {
+				$injectedPostKeys = [];
+				foreach($preparedData[$i] as $handle => $value) {
+					$elementObj = _getElementObject($handle);
+					if(!$elementObj || !$elementObj->isUserAccountElement) {
+						continue;
+					}
+					if($elementObj->readOnly) {
+						// UID element — cannot be set directly; it is set by processUserAccountSubmission
+						unset($preparedData[$i][$handle]);
+						continue;
+					}
+					$elementId = $elementObj->getVar('ele_id');
+					$_POST['decue_'.$formId.'_'.$postEntryId.'_'.$elementId] = 1;
+					$_POST['de_'.$formId.'_'.$postEntryId.'_'.$elementId] = $value;
+					$injectedPostKeys[] = 'decue_'.$formId.'_'.$postEntryId.'_'.$elementId;
+					$injectedPostKeys[] = 'de_'.$formId.'_'.$postEntryId.'_'.$elementId;
+					unset($preparedData[$i][$handle]);
+				}
+				if(!empty($injectedPostKeys)) {
+					$userId = formulizeElementsHandler::processUserAccountSubmission($formId, $postEntryId);
+					foreach($injectedPostKeys as $postKey) {
+						unset($_POST[$postKey]);
+					}
+					if($userId) {
+						$preparedData[$i]['formulize_user_account_uid_'.$formId] = $userId;
+					} else {
+						// No user id came back. Validation failures (missing/invalid fields, duplicate
+						// username/email) throw and surface via the dispatcher, so a falsy return here means
+						// the account was silently not created/updated — either the entry does not meet the
+						// form's base conditions, or the user/profile write failed. Surface it rather than
+						// reporting a misleading success with a null entry id.
+						$entryDescriptor = $entryId === 'new' ? 'the new entry' : "entry ID $entryId";
+						if(!formulizeHandler::entriesAreUsersEntryMeetsBaseConditions($formId, $postEntryId, cacheId: 'preWrite')) {
+							throw new FormulizeMCPException("$entryDescriptor does not meet the base conditions required to become a user account on form $formId, so no user account was created.", 'invalid_data');
+						}
+						throw new FormulizeMCPException("Failed to create or update the user account for $entryDescriptor on form $formId.", 'database_error');
+					}
+				}
+			}
+
+			// Write the entry
+			$resultEntryId = null;
+			if(!empty($preparedData[$i])) {
+				$resultEntryId = formulize_writeEntry($preparedData[$i], $entryId); // writes data and manages ownership info
+			}
 			$finalEntryId = ($entryId === 'new') ? $resultEntryId : $entryId; // for updates, formulize_writeEntry can return null if no data actually changed from current DB state
+
 			// Step 4: Update derived values
-			formulize_updateDerivedValues($finalEntryId, $formId, $relationshipId);
+			if($finalEntryId) {
+				formulize_updateDerivedValues($finalEntryId, $formId, $relationshipId);
+			}
+
+			// Track written entry IDs and user IDs for EAU/EAG post-processing
+			if($finalEntryId) {
+				$allWrittenEntryIds[] = $finalEntryId;
+				if($userId) {
+					$userIdsFromSubmission[$finalEntryId] = $userId; // re-key from 'new' to real entry ID
+				}
+			}
+
+			// EAG post-write: sync entry-specific groups
+			if($isEagForm && $finalEntryId) {
+				formulizeHandler::syncEntryGroups($formId, $finalEntryId);
+			}
+
 			// Lastly, put the entry id into the prepared data for reference
 			$preparedData[$i] = array_merge(array('entry_id' => $finalEntryId), $preparedData[$i]);
 		}
+
+		// EAU post-write: process group memberships for all written entries (direct, connected-form, and fallback)
+		formulizeHandler::processEauGroupMembershipsForWrittenEntries(
+			[$formId => $allWrittenEntryIds],
+			[$formId => $userIdsFromSubmission]
+		);
 
 		$response = [
 			'success' => true,

--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -1134,6 +1134,20 @@ class formulizeDataHandler {
 			}
 		}
 
+		// entries_are_groups forms build their entry-group names as "{PI value} - {Category}", so a
+		// hyphen in the PI value would collide with the " - " separator. Recast hyphens in the PI value
+		// to underscores (silently) before storing. $values may be keyed by element id or by handle,
+		// so cover whichever key addresses the PI element.
+		if($formObject AND $formObject->getVar('entries_are_groups') AND ($piEleId = intval($formObject->getVar('pi')))) {
+			$piElementObj = xoops_getmodulehandler('elements', 'formulize')->get($piEleId);
+			$piHandle = $piElementObj ? $piElementObj->getVar('ele_handle') : null;
+			foreach(array($piEleId, $piHandle) as $piKey) {
+				if($piKey !== null AND isset($values[$piKey]) AND is_string($values[$piKey])) {
+					$values[$piKey] = str_replace('-', '_', $values[$piKey]);
+				}
+			}
+		}
+
     $encrypt_element_handles = array(); // array of element handles which should be encrypted
 
 		// get handle/id equivalents directly from database in one query, since we'll need them later

--- a/modules/formulize/class/forms.php
+++ b/modules/formulize/class/forms.php
@@ -310,6 +310,21 @@ class formulizeForm extends FormulizeObject {
         if ("custom_edit_check" == $key) {
             $this->cache_custom_edit_check_code();
         }
+        if ("pi" == $key AND intval($value) > 0 AND $this->getVar('entries_are_groups')) {
+            // On entries_are_groups forms the PI element must always be required: the entry-group
+            // names are built from the PI value, so every entry needs one. Limited to EAG forms on
+            // purpose — enforcing it for all forms would also make the auto-designated PI (the first
+            // data element on any form) required, which is too aggressive for regular forms.
+            // setVar('pi', ...) is the single chokepoint for designating a form's PI, so this covers
+            // every path (admin element names page, the upsert, MCP, relationship connection options).
+            // Object hydration from the database goes through assignVar(), not setVar(), so this never
+            // fires on load — only on an actual (re)designation, by which point the element exists.
+            $element_handler = xoops_getmodulehandler('elements', 'formulize');
+            if (($piElement = $element_handler->get(intval($value))) AND $piElement->getVar('ele_required', 'n') != 1) {
+                $piElement->setVar('ele_required', 1);
+                $element_handler->insert($piElement);
+            }
+        }
     }
 
     protected function on_before_save_function_name() {

--- a/modules/formulize/class/formulize.php
+++ b/modules/formulize/class/formulize.php
@@ -1248,12 +1248,15 @@ class formulizeHandler {
 	 * by name before creating a new one. This handles the case where the feature is first turned on
 	 * and pre-existing groups should be adopted rather than duplicated.
 	 *
+	 * On updates, an existing entry group is located by its form_id + entry_id association and the
+	 * category suffix in its name, then renamed to match the current PI value — so the previous PI
+	 * value is not needed to detect or perform a rename.
+	 *
 	 * @param int $fid The form ID
 	 * @param int $entryId The entry ID
-	 * @param string|null $oldPiValue The old PI value (for updates, to check if rename needed). Null for new entries.
 	 * @return bool True if groups were created/updated, false if form doesn't use entries_are_groups
 	 */
-	public static function syncEntryGroups($fid, $entryId, $oldPiValue = null) {
+	public static function syncEntryGroups($fid, $entryId) {
 		$form_handler = xoops_getmodulehandler('forms', 'formulize');
 		if(!$formObject = $form_handler->get($fid)) {
 			throw new Exception("Cannot synch groups with entry for entries_are_group form. Form with ID $fid does not exist.");
@@ -1387,6 +1390,149 @@ class formulizeHandler {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Process EAU group memberships for all entries written in a single save operation.
+	 *
+	 * Covers three scenarios:
+	 * 1. The EAU form itself was written to (entries seeded directly from $allWrittenEntryIds).
+	 * 2. A connected form was written to and that form contains elements referenced in the EAU
+	 *    form's entries_are_users_default_groups_element_links — those connected EAU entries are
+	 *    found via framework traversal.
+	 * 3. EAU entries where processUserAccountSubmission ran but no formulize data actually changed
+	 *    (e.g. no-op updates, or system users table form submissions) — covered by the
+	 *    $userIdsForUserAccountElements fallback.
+	 *
+	 * Called from both readelements.php (web-form path) and mcp/tools.php (MCP path).
+	 *
+	 * @param array $allWrittenEntryIds         All entries written this save, keyed by form ID: [formId => [entryId, ...]]
+	 * @param array $userIdsForUserAccountElements  Cached user IDs from processUserAccountSubmission: [formId => [entryId => userId]]
+	 */
+	public static function processEauGroupMembershipsForWrittenEntries(array $allWrittenEntryIds, array $userIdsForUserAccountElements = []): void {
+		if(empty($allWrittenEntryIds) && empty($userIdsForUserAccountElements)) {
+			return;
+		}
+
+		$pendingGroupMembershipEntryUpdates = []; // eauFormId => [entryId, ...]
+
+		if(!empty($allWrittenEntryIds)) {
+			global $xoopsDB;
+			$eauFormsResult = $xoopsDB->query("SELECT id_form FROM " . $xoopsDB->prefix('formulize_id') . " WHERE entries_are_users = 1");
+			if($eauFormsResult) {
+				$form_handler = xoops_getmodulehandler('forms', 'formulize');
+				$element_handler = xoops_getmodulehandler('elements', 'formulize');
+				include_once XOOPS_ROOT_PATH . '/modules/formulize/class/frameworks.php';
+				$frameworks_handler = new formulizeFrameworksHandler($xoopsDB);
+
+				while($eauRow = $xoopsDB->fetchArray($eauFormsResult)) {
+					$eauFormId = intval($eauRow['id_form']);
+
+					// Scenario 1: EAU form itself was written — seed pending list directly
+					if(isset($allWrittenEntryIds[$eauFormId])) {
+						$pendingGroupMembershipEntryUpdates[$eauFormId] = $allWrittenEntryIds[$eauFormId];
+					}
+
+					// Scenario 2: Check connected forms for element_links referencing elements in this EAU form
+					$eauFormObject = $form_handler->get($eauFormId);
+					if(!$eauFormObject) {
+						continue;
+					}
+					$elementLinks = $eauFormObject->getVar('entries_are_users_default_groups_element_links');
+					if(!is_array($elementLinks) || empty($elementLinks)) {
+						continue;
+					}
+
+					// Find which forms contain the linked elements and were written to
+					$linkedElementForms = []; // formId => true
+					foreach($elementLinks as $gid => $eleIds) {
+						if(!is_array($eleIds)) {
+							continue;
+						}
+						foreach($eleIds as $eleId) {
+							$linkedElement = $element_handler->get(intval($eleId));
+							if($linkedElement) {
+								$linkedElementForms[intval($linkedElement->getVar('id_form'))] = true;
+							}
+						}
+					}
+					foreach(array_keys($linkedElementForms) as $linkedFid) {
+						if(!isset($allWrittenEntryIds[$linkedFid]) || $linkedFid == $eauFormId) {
+							continue; // skip if not written to, or element is in the EAU form itself (already seeded above)
+						}
+						// Find the framework connecting the linked form to the EAU form
+						$frameworks = $frameworks_handler->getFrameworksByForm($linkedFid, includePrimaryRelationship: true);
+						$targetFrid = null;
+						foreach($frameworks as $framework) {
+							$frameworkLinks = $framework->getVar('links');
+							foreach($frameworkLinks as $link) {
+								if(($link->getVar('form1') == $linkedFid && $link->getVar('form2') == $eauFormId) ||
+								   ($link->getVar('form2') == $linkedFid && $link->getVar('form1') == $eauFormId)) {
+									$targetFrid = $framework->getVar('frid');
+									break 2;
+								}
+							}
+						}
+						if(!$targetFrid) {
+							continue;
+						}
+						// Traverse the framework to find connected EAU entries for each written entry
+						foreach($allWrittenEntryIds[$linkedFid] as $writtenEntryId) {
+							$linkedResult = checkForLinks($targetFrid, [$linkedFid], $linkedFid, [$linkedFid => [$writtenEntryId]]);
+							if(isset($linkedResult['entries'][$eauFormId])) {
+								foreach($linkedResult['entries'][$eauFormId] as $eauEntryId) {
+									$pendingGroupMembershipEntryUpdates[$eauFormId][] = $eauEntryId;
+								}
+							}
+							if(isset($linkedResult['sub_entries'][$eauFormId])) {
+								foreach($linkedResult['sub_entries'][$eauFormId] as $eauEntryId) {
+									$pendingGroupMembershipEntryUpdates[$eauFormId][] = $eauEntryId;
+								}
+							}
+						}
+					}
+				}
+
+				// Process all collected EAU entries; use cached userId where available, otherwise look it up
+				foreach($pendingGroupMembershipEntryUpdates as $eauFormId => $entryIds) {
+					$eauDataHandler = null;
+					foreach(array_unique($entryIds) as $eauEntryId) {
+						if(isset($userIdsForUserAccountElements[$eauFormId][$eauEntryId]) && $userIdsForUserAccountElements[$eauFormId][$eauEntryId]) {
+							$userId = $userIdsForUserAccountElements[$eauFormId][$eauEntryId];
+						} else {
+							if(!$eauDataHandler) {
+								$eauDataHandler = new formulizeDataHandler($eauFormId);
+							}
+							$userId = intval($eauDataHandler->getElementValueInEntry($eauEntryId, 'formulize_user_account_uid_'.$eauFormId));
+						}
+						if($userId) {
+							require_once XOOPS_ROOT_PATH . '/modules/formulize/class/userAccountGroupMembershipElement.php';
+							require_once XOOPS_ROOT_PATH . '/modules/formulize/class/GroupMembershipService.php';
+							formulizeElementsHandler::processUserGroupMemberships($userId, $eauFormId, $eauEntryId);
+						}
+					}
+				}
+			}
+		}
+
+		// Scenario 3: Fallback for EAU submissions not covered above — processUserAccountSubmission ran
+		// but the entry was never added to $allWrittenEntryIds (system users form with no formulize data
+		// table, or EAU entry where only group memberships changed and no data column actually changed).
+		if(!empty($userIdsForUserAccountElements)) {
+			foreach($userIdsForUserAccountElements as $_gmFormId => $_gmEntryUserIds) {
+				foreach($_gmEntryUserIds as $_gmEntryId => $_gmUserId) {
+					if(!$_gmUserId) {
+						continue;
+					}
+					if(isset($pendingGroupMembershipEntryUpdates[$_gmFormId]) && in_array($_gmEntryId, $pendingGroupMembershipEntryUpdates[$_gmFormId])) {
+						continue; // already processed above
+					}
+					require_once XOOPS_ROOT_PATH . '/modules/formulize/class/userAccountGroupMembershipElement.php';
+					require_once XOOPS_ROOT_PATH . '/modules/formulize/class/GroupMembershipService.php';
+					formulizeElementsHandler::processUserGroupMemberships($_gmUserId, $_gmFormId, $_gmEntryId);
+				}
+			}
+		}
 	}
 
 	/**

--- a/modules/formulize/class/userAccountElement.php
+++ b/modules/formulize/class/userAccountElement.php
@@ -470,7 +470,12 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				$rawSubmitted2faMethod = $changes['rawSubmitted2faMethod'];
 				$passwordChanged = $changes['passwordChanged'];
 				$cleanupAppSecret = $changes['cleanupAppSecret'];
-				
+
+				// For new user accounts, validate required fields before writing anything
+				if(!$entryUserId) {
+					self::validateNewUserAccountVars($formId, $pendingUserVars, $pendingProfileVars);
+				}
+
 				// Validate 2FA transition if user is editing their own account
 				if(!self::validateOwnAccount2faTransition(
 					$entryUserId, $userObject, $profile, $pendingUserVars, $pendingProfileVars,
@@ -575,6 +580,96 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			'old2faPhone' => $old2faPhone,
 			'oldEmail' => $oldEmail
 		);
+	}
+
+	/**
+	 * Validate required fields for a new user account before writing.
+	 * Replicates the JS validation rules from each userAccount element type.
+	 * Only called when $entryUserId is falsy (creating a new user, not updating).
+	 * Throws Exception with a user-facing message if validation fails.
+	 *
+	 * @param int   $formId           The EAU form ID
+	 * @param array $pendingUserVars  Collected user-table changes (from collectPendingUserVars)
+	 * @param array $pendingProfileVars  Collected profile-table changes (from collectPendingUserVars)
+	 */
+	private static function validateNewUserAccountVars(int $formId, array $pendingUserVars, array $pendingProfileVars): void {
+		$element_handler = xoops_getmodulehandler('elements', 'formulize');
+
+		// Username (login_name): required if the element exists on this form
+		$hasUsernameElement = (bool)$element_handler->get('formulize_user_account_username_'.$formId);
+		if($hasUsernameElement && empty($pendingUserVars['login_name'])) {
+			throw new Exception('A username is required to create a user account.');
+		}
+
+		// Username uniqueness
+		if(!empty($pendingUserVars['login_name'])) {
+			global $xoopsDB;
+			$result = $xoopsDB->query("SELECT uid FROM " . $xoopsDB->prefix('users') . " WHERE login_name = " . $xoopsDB->quoteString($pendingUserVars['login_name']));
+			if($xoopsDB->fetchArray($result)) {
+				throw new Exception('Username "' . htmlspecialchars($pendingUserVars['login_name'], ENT_QUOTES) . '" is already taken.');
+			}
+		}
+
+		// First and last name (both write to uname): required if either element exists
+		$hasFirstNameElement = (bool)$element_handler->get('formulize_user_account_firstname_'.$formId);
+		$hasLastNameElement  = (bool)$element_handler->get('formulize_user_account_lastname_'.$formId);
+		if(($hasFirstNameElement || $hasLastNameElement) && empty($pendingUserVars['uname'])) {
+			throw new Exception('A name is required to create a user account.');
+		}
+
+		// Password: required for new users if the element exists on this form
+		$hasPasswordElement = (bool)$element_handler->get('formulize_user_account_password_'.$formId);
+		if($hasPasswordElement && empty($pendingUserVars['pass'])) {
+			throw new Exception('A password is required to create a user account.');
+		}
+
+		// Email and phone: at least one required if either element exists on this form
+		$emailElement = $element_handler->get('formulize_user_account_email_'.$formId);
+		$phoneElement = $element_handler->get('formulize_user_account_phone_'.$formId);
+		$hasEmailElement = (bool)$emailElement;
+		$hasPhoneElement = (bool)$phoneElement;
+
+		$hasEmail = !empty($pendingUserVars['email']);
+		$hasPhone = !empty($pendingProfileVars['2faphone']);
+
+		if($hasEmailElement || $hasPhoneElement) {
+			if(!$hasEmail && !$hasPhone) {
+				if($hasEmailElement && $hasPhoneElement) {
+					throw new Exception('Please provide either an email address or a phone number.');
+				} elseif($hasEmailElement) {
+					throw new Exception('An email address is required to create a user account.');
+				} else {
+					throw new Exception('A phone number is required to create a user account.');
+				}
+			}
+		}
+
+		// Email format: must match the pattern enforced in the JS
+		if($hasEmail) {
+			if(!preg_match('/^\w+([\.\-]?\w+)*@\w+([\.\-]?\w+)*(\.\w{2,63})+$/', $pendingUserVars['email'])) {
+				throw new Exception('The email address "' . htmlspecialchars($pendingUserVars['email'], ENT_QUOTES) . '" is not valid.');
+			}
+		}
+
+		// Email uniqueness
+		if($hasEmail) {
+			global $xoopsDB;
+			$result = $xoopsDB->query("SELECT uid FROM " . $xoopsDB->prefix('users') . " WHERE email = " . $xoopsDB->quoteString($pendingUserVars['email']));
+			if($xoopsDB->fetchArray($result)) {
+				throw new Exception('The email address "' . htmlspecialchars($pendingUserVars['email'], ENT_QUOTES) . '" is already in use.');
+			}
+		}
+
+		// Phone digit count: must match the number of X's in the element's configured format
+		// (pendingProfileVars['2faphone'] is already digits-only after collectPendingUserVars strips formatting)
+		if($hasPhone && $phoneElement) {
+			$phoneOptions = $phoneElement->getVar('ele_value');
+			$format = is_array($phoneOptions) && isset($phoneOptions['format']) ? $phoneOptions['format'] : 'XXX-XXX-XXXX';
+			$requiredDigits = substr_count($format, 'X');
+			if($requiredDigits > 0 && strlen($pendingProfileVars['2faphone']) !== $requiredDigits) {
+				throw new Exception('Phone number must have exactly ' . $requiredDigits . ' digits (format: ' . $format . ').');
+			}
+		}
 	}
 
 	/**

--- a/modules/formulize/class/usersGroupsPerms.php
+++ b/modules/formulize/class/usersGroupsPerms.php
@@ -199,7 +199,7 @@ class formulizePermHandler {
             $member_handler =& xoops_gethandler('member');
             $groups = $user_id == 0 ? array(XOOPS_GROUP_ANONYMOUS) : $member_handler->getGroupsByUser($user_id);
 
-            if ("new" == $entry_id or "" == $entry_id) {
+            if (formulize_isNewEntryId($entry_id) or "" == $entry_id) {
                 if ("update" == $action) {
                     // user has permission to add new entries
                     self::$cached_permissions[$cache_key] = $gperm_handler->checkRight("add_own_entry", $form_id, $groups, self::$formulize_module_id);

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -610,6 +610,27 @@ function formulize_anonHoldsEntry($form_id, $entry_id) {
 
 
 /**
+ * Determine whether an entry id represents a not-yet-saved (new) entry.
+ *
+ * The canonical sentinel for a new entry is the string "new". Some callers that create
+ * several entries in a single request need per-entry-unique sentinels so that caches keyed
+ * on the entry id do not collapse multiple creations together (e.g. the MCP write loop uses
+ * "new_0", "new_1", ...). Those suffixed sentinels are still logically "new", so permission
+ * and access checks must treat them the same as "new".
+ *
+ * Matches exactly "new" or "new_" followed by one or more digits. It deliberately does NOT
+ * match the subform new-entry patterns used elsewhere (e.g. "new1", "new1x5"), which are
+ * normalised to "new" before they ever reach the permission functions.
+ *
+ * @param mixed $entry_id The entry id to test
+ * @return bool True if the entry id is a new-entry sentinel
+ */
+function formulize_isNewEntryId($entry_id) {
+    return $entry_id === "new" || (is_string($entry_id) && preg_match('/^new_\d+$/', $entry_id) === 1);
+}
+
+
+/**
  * Perform security check for a form and entry
  *
  * Checks if a user has permission to access a specific form and entry.
@@ -691,7 +712,7 @@ function security_check($form_id, $entry_id="", $user_id="", $owner="", $groups=
         return false;
     }
 
-    if ($entry_id == "new" AND !$gperm_handler->checkRight("add_own_entry", $form_id, $groups, $mid)) {
+    if (formulize_isNewEntryId($entry_id) AND !$gperm_handler->checkRight("add_own_entry", $form_id, $groups, $mid)) {
 				$cachedSecurityChecks[$form_id][$entry_id] = false;
         return false;
     }
@@ -701,7 +722,7 @@ function security_check($form_id, $entry_id="", $user_id="", $owner="", $groups=
     // any entry if they have view_globalscope
     // other users in the appropriate group if they have view_groupscope
     // --report overrides added in here for display of entries in reports
-    if ($entry_id AND $entry_id != "new" AND $entry_id != "proxy") {
+    if ($entry_id AND !formulize_isNewEntryId($entry_id) AND $entry_id != "proxy") {
         $view_globalscope = $gperm_handler->checkRight("view_globalscope", $form_id, $groups, $mid);
         if (!$view_globalscope) {
 
@@ -10854,7 +10875,7 @@ function getSortTitleAndIcon($elementHandle) {
 function checkConditionsAgainstAnEntry($elementFilterSettings, $form_id, $entry_id, $elementObject = null, $frid = 0, $cacheId = "") {
 	// need to check if there's a condition on this element that is met or not
 	static $cachedEntries = array();
-	if($entry_id != "new") {
+	if(!formulize_isNewEntryId($entry_id)) {
 		$cacheKey = $form_id.'_'.$entry_id.'_'.$frid.$cacheId;
 		if(!isset($cachedEntries[$cacheKey])) {
 			$cachedEntries[$cacheKey] = gatherDataset($form_id, filter: $entry_id, frid: $frid, bypassCache: true);
@@ -10984,8 +11005,8 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
 		if(substr($filterTerms[$i],0,1) == "{" AND substr($filterTerms[$i],-1)=="}") {
 			$handle_reference = substr($filterTerms[$i],1,-1);
 			if($filterElements[$i] != 'creation_uid' AND $filterElements[$i] != 'mod_uid') { // comparing to a regular element, get the db value
-				$filterTerms[$i] = $entry == 'new' ? '' : getValue($entryData[0], $handle_reference); // get blank, but we could try to get defaults like below
-			} elseif($entry != 'new') { // comparing to user metadata field, entry is not new
+				$filterTerms[$i] = formulize_isNewEntryId($entry) ? '' : getValue($entryData[0], $handle_reference); // get blank, but we could try to get defaults like below
+			} elseif(!formulize_isNewEntryId($entry)) { // comparing to user metadata field, entry is not new
 				// take a wild guess that the reference is to something that should be a uid in the db...
 				$element_handler = xoops_getmodulehandler('elements', 'formulize');
 				$form_handler = xoops_getmodulehandler('forms', 'formulize');
@@ -11004,7 +11025,7 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
 		$entryKey = is_numeric($entry) ? intval($entry) : $entry;
 		if(isset($GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entryKey]) AND array_key_exists($filterElements[$i], $GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entryKey])) {
 			$compValue = $GLOBALS['formulize_asynchronousFormDataInAPIFormat'][$entryKey][$filterElements[$i]];
-		} elseif($entry == "new") {
+		} elseif(formulize_isNewEntryId($entry)) {
 			$elementObject = $element_handler->get($filterElements[$i]);
 			if(is_object($elementObject)) {
 				$defaultValueMap = getEntryDefaultsInDBFormat($elementObject);

--- a/modules/formulize/include/readelements.php
+++ b/modules/formulize/include/readelements.php
@@ -282,7 +282,6 @@ foreach($formulize_elementData as $elementFid=>$entryData) { // for every form w
 					}
 				}
 
-				$oldPiValue = null;
 				$writtenEntryId = null;
         if(substr($currentEntry, 0 , 3) == "new") {
             // handle entries in the form that are new. if there is more than one new entry, they will be listed as new1, new2, new3, etc
@@ -304,15 +303,6 @@ foreach($formulize_elementData as $elementFid=>$entryData) { // for every form w
 									if($formulize_formObject->getVar('entries_are_users') AND $formulize_formObject->getVar('entries_are_users_user_is_owner') AND isset($userIdsForUserAccountElements[$elementFid][$currentEntry]) AND $userIdsForUserAccountElements[$elementFid][$currentEntry]) {
 										$creation_user = $userIdsForUserAccountElements[$elementFid][$currentEntry];
 									}
-										// capture old PI value for entries_are_groups forms before update
-										// TODO ensure forms with entries_are_groups always have a PI set!!
-										if ($formulize_formObject->getVar('entries_are_groups')
-											AND $piElementId = $formulize_formObject->getVar('pi')
-											AND $piElement = $element_handler->get($piElementId)
-										) {
-											$dataHandler = new formulizeDataHandler($elementFid);
-											$oldPiValue = $dataHandler->getElementValueInEntry($currentEntry, $piElementId);
-										}
 
 										if($writtenEntryId = formulize_writeEntry($values, $currentEntry, "", $creation_user, "", false)) { // last false causes setting ownership data to be skipped...it's more efficient for readelements to package up all the ownership info and write it all at once below.
                         if(isset($formulize_subformBlankCues[$elementFid])) {
@@ -368,7 +358,7 @@ foreach($formulize_elementData as $elementFid=>$entryData) { // for every form w
 				// WHAT ABOUT MCP?? OR OTHER SITUATIONS. IF AN ENTRIES-ARE-GROUPS RECORD IS CREATED/UPDATED, WE NEED TO DO THE SYNC AT THAT POINT TOO, NOT JUST HERE IN THE WEB APP LOGIC
 		    // create entry-specific groups if this form has entries_are_groups enabled
 				if ($formulize_formObject->getVar('entries_are_groups') AND $writtenEntryId) {
-						formulizeHandler::syncEntryGroups($elementFid, $writtenEntryId, $oldPiValue);
+						formulizeHandler::syncEntryGroups($elementFid, $writtenEntryId);
 				}
     }
 }
@@ -573,125 +563,8 @@ if($frid) {
 	}
 }
 
-// Process group memberships for entries_are_users forms.
-// This covers two scenarios:
-// 1. The entries_are_users form itself was saved. This includes saves that went
-//    through processUserAccountSubmission (user account elements in the submission) and saves that did not.
-// 2. A connected form was saved, and that form contains elements referenced in
-//    the EAU form's element_links for template group resolution. On-before-save,
-//    on-after-save, or derived value updates may all affect the linked values,
-//    so we re-evaluate whenever any entry is saved in a form that contains
-//    element_link elements, without checking which specific elements were modified.
-if(!empty($formulize_allWrittenEntryIds)) {
-	global $xoopsDB;
-	$eauFormsResult = $xoopsDB->query("SELECT id_form FROM " . $xoopsDB->prefix('formulize_id') . " WHERE entries_are_users = 1");
-	if($eauFormsResult) {
-		// For each EAU form, seed the pending list from any written entries, then find any additionally affected entries via framework traversal
-		$pendingGroupMembershipEntryUpdates = array(); // eauFormId => [entryId, ...]
-		include_once XOOPS_ROOT_PATH . '/modules/formulize/class/frameworks.php';
-		$frameworks_handler = new formulizeFrameworksHandler($xoopsDB);
-		while($eauRow = $xoopsDB->fetchArray($eauFormsResult)) {
-			$eauFormId = intval($eauRow['id_form']);
-			if(isset($formulize_allWrittenEntryIds[$eauFormId])) {
-				$pendingGroupMembershipEntryUpdates[$eauFormId] = $formulize_allWrittenEntryIds[$eauFormId];
-			}
-			$eauFormObject = $form_handler->get($eauFormId);
-			if(!$eauFormObject) {
-				continue;
-			}
-			$elementLinks = $eauFormObject->getVar('entries_are_users_default_groups_element_links');
-			if(!is_array($elementLinks) || empty($elementLinks)) {
-				continue;
-			}
-			// Find which connected forms contain the linked elements and were written to
-			$linkedElementForms = array(); // form ID => true
-			foreach($elementLinks as $gid => $eleIds) {
-				if(!is_array($eleIds)) {
-					continue;
-				}
-				foreach($eleIds as $eleId) {
-					$linkedElement = $element_handler->get(intval($eleId));
-					if($linkedElement) {
-						$linkedElementForms[intval($linkedElement->getVar('id_form'))] = true;
-					}
-				}
-			}
-			foreach(array_keys($linkedElementForms) as $linkedFid) {
-				if(!isset($formulize_allWrittenEntryIds[$linkedFid]) || $linkedFid == $eauFormId) {
-					continue; // skip if not written to, or if the element is in the EAU form itself (already added above)
-				}
-				// Find the framework connecting the linked form to the EAU form
-				$frameworks = $frameworks_handler->getFrameworksByForm($linkedFid, includePrimaryRelationship: true);
-				$targetFrid = null;
-				foreach($frameworks as $framework) {
-					$frameworkLinks = $framework->getVar('links');
-					foreach($frameworkLinks as $link) {
-						if(($link->getVar('form1') == $linkedFid && $link->getVar('form2') == $eauFormId) ||
-						   ($link->getVar('form2') == $linkedFid && $link->getVar('form1') == $eauFormId)) {
-							$targetFrid = $framework->getVar('frid');
-							break 2;
-						}
-					}
-				}
-				if(!$targetFrid) {
-					continue; // no framework connecting these forms
-				}
-				// Find connected EAU entries for each written entry in the linked form
-				foreach($formulize_allWrittenEntryIds[$linkedFid] as $writtenEntryId) {
-					$linkedResult = checkForLinks($targetFrid, array($linkedFid), $linkedFid, array($linkedFid => array($writtenEntryId)));
-					if(isset($linkedResult['entries'][$eauFormId])) {
-						foreach($linkedResult['entries'][$eauFormId] as $eauEntryId) {
-							$pendingGroupMembershipEntryUpdates[$eauFormId][] = $eauEntryId;
-						}
-					}
-					if(isset($linkedResult['sub_entries'][$eauFormId])) {
-						foreach($linkedResult['sub_entries'][$eauFormId] as $eauEntryId) {
-							$pendingGroupMembershipEntryUpdates[$eauFormId][] = $eauEntryId;
-						}
-					}
-				}
-			}
-		}
-
-		// Process all collected EAU entries; use the cached userId where available, otherwise look it up
-		foreach($pendingGroupMembershipEntryUpdates as $eauFormId => $entryIds) {
-			$eauDataHandler = null;
-			foreach(array_unique($entryIds) as $eauEntryId) {
-				if(isset($userIdsForUserAccountElements[$eauFormId]) AND isset($userIdsForUserAccountElements[$eauFormId][$eauEntryId]) && $userIdsForUserAccountElements[$eauFormId][$eauEntryId]) {
-					$userId = $userIdsForUserAccountElements[$eauFormId][$eauEntryId];
-				} else {
-					if(!$eauDataHandler) {
-						$eauDataHandler = new formulizeDataHandler($eauFormId);
-					}
-					$userId = intval($eauDataHandler->getElementValueInEntry($eauEntryId, 'formulize_user_account_uid_'.$eauFormId));
-				}
-				if($userId) {
-					formulizeElementsHandler::processUserGroupMemberships($userId, $eauFormId, $eauEntryId);
-				}
-			}
-		}
-	}
-}
-
-// Process group memberships for user account form submissions not covered above:
-// (1) System users forms never write Formulize entries, so they are
-//     never in formulize_allWrittenEntryIds.
-// (2) EAU forms where only group memberships were submitted and nothing else changed —
-//     nothing is written to the data table so the entry never appears in formulize_allWrittenEntryIds.
-if(!empty($userIdsForUserAccountElements)) {
-	$_groupMembershipAlreadyProcessed = isset($pendingGroupMembershipEntryUpdates) ? $pendingGroupMembershipEntryUpdates : array();
-	foreach($userIdsForUserAccountElements as $_gmFormId => $_gmEntryUserIds) {
-		foreach($_gmEntryUserIds as $_gmEntryId => $_gmUserId) {
-			if(!$_gmUserId) {
-				continue;
-			}
-			if(isset($_groupMembershipAlreadyProcessed[$_gmFormId]) && in_array($_gmEntryId, $_groupMembershipAlreadyProcessed[$_gmFormId])) {
-				continue;
-			}
-			formulizeElementsHandler::processUserGroupMemberships($_gmUserId, $_gmFormId, $_gmEntryId);
-		}
-	}
-}
+// Process EAU group memberships for all written entries (direct, connected-form, and fallback cases).
+formulizeHandler::processEauGroupMembershipsForWrittenEntries($formulize_allWrittenEntryIds, $userIdsForUserAccountElements);
 
 // send notifications
 foreach($notEntriesList as $notEvent=>$notDetails) {

--- a/tests/e2e/formulize-core/setup/005-create-users-and-groups.spec.js
+++ b/tests/e2e/formulize-core/setup/005-create-users-and-groups.spec.js
@@ -783,3 +783,76 @@ test.describe('J. Frontend menu visibility for Users/Groups', () => {
 		await expect(page).not.toHaveURL(/users\.php(?:[?#]|$)/);
 	});
 });
+
+// ============================================================
+// Block L — Entry group names track PI value renames (syncEntryGroups)
+// ============================================================
+// Verifies formulizeHandler::syncEntryGroups() renames an entry's groups when
+// the entry's PI value changes (the rename branch at formulize.php:1343-1348,
+// reached here via the web save path readelements.php -> syncEntryGroups).
+//
+// IMPORTANT — where we assert: this MUST be checked against the real group.name,
+// NOT the formulize groups.php Members/entries columns. Those columns build
+// their labels from the PI value in the entry's DATA table (viewEntryLink in
+// injectGroupMembersData/injectGroupEntriesData), so they would reflect a PI
+// change even if the group rename had silently failed. The XOOPS system groups
+// admin page renders each group's actual group.name via getVar('name'), so we
+// assert there. A webmaster sees every group on that page because its
+// checkRight('group_manager', ...) row-gate auto-passes when the webmaster
+// group (id 1) is among the checked groups.
+//
+// Uses a throwaway department "Astronmy" -> "Astronomy" (a unique typo->fix).
+// A unique name is deliberate: renaming onto an existing department's PI (e.g.
+// the real "Ancient History") would trip syncEntryGroups' cross-entry name
+// collision disambiguation and append a numeric suffix, muddying the assertion.
+// Placed last so the extra department cannot perturb the earlier blocks.
+test.describe('L. Entry group names follow PI renames', () => {
+
+	const CATEGORIES = ['All Users', 'Staff', 'Curators'];
+	const entryGroupNames = (piValue) => CATEGORIES.map((cat) => `${piValue} - ${cat}`);
+
+	// Assert, on the system groups admin page, which entry-group names exist.
+	// Group names render in <td class="head"> cells (system/admin/groups/groups.php).
+	async function assertEntryGroups(page, { present = [], absent = [] }) {
+		await page.goto('/modules/system/admin.php?fct=groups');
+		await page.waitForLoadState('domcontentloaded');
+		for (const name of present) {
+			await expect(page.locator('td.head').filter({ hasText: name })).toHaveCount(1);
+		}
+		for (const name of absent) {
+			await expect(page.locator('td.head').filter({ hasText: name })).toHaveCount(0);
+		}
+	}
+
+	test('Correcting an entry PI (Astronmy -> Astronomy) renames its entry groups', async ({ page }) => {
+		await login(page, E2E_TEST_ADMIN_USERNAME, E2E_TEST_ADMIN_PASSWORD);
+		expect(phase1.departmentsFid, 'Departments form must exist from Block A').toBeTruthy();
+
+		// 1. Create the department with the misspelled PI. Saving runs
+		//    readelements -> syncEntryGroups, which creates one group per category.
+		await page.goto(`/modules/formulize/master.php?fid=${phase1.departmentsFid}`);
+		await page.locator('#formulize_addButton').click();
+		await page.getByRole('textbox', { name: 'Name' }).fill('Astronmy');
+		await saveFormulizeForm(page, 'Save');
+		await clearEntryLocks(page);
+
+		// 2. The three misspelled entry groups now exist under their real names.
+		await assertEntryGroups(page, { present: entryGroupNames('Astronmy') });
+
+		// 3. Open the entry and correct the PI value.
+		await page.goto(`/modules/formulize/master.php?fid=${phase1.departmentsFid}`);
+		await page.getByRole('row', { name: /Astronmy/ }).getByRole('link').first().click();
+		const nameBox = page.getByRole('textbox', { name: 'Name' });
+		await expect(nameBox).toHaveValue('Astronmy');
+		await nameBox.fill('Astronomy');
+		await saveFormulizeForm(page, 'Save');
+		await clearEntryLocks(page);
+
+		// 4. The SAME groups now carry the corrected names, and the misspelled
+		//    names are gone — proving they were renamed in place, not duplicated.
+		await assertEntryGroups(page, {
+			present: entryGroupNames('Astronomy'),
+			absent: entryGroupNames('Astronmy'),
+		});
+	});
+});


### PR DESCRIPTION
When making entries via AI tools in a form, if it is an entries-are-users or entries-are-groups form, the correct behaviours need to occur, same as if you're using the normal UI.