### PR TITLE
Extendable element classes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,4 +9,4 @@ title: API
 * [The flow through the code](../API/code_flow)
 * [Classes](../API/classes)
 * [Functions](../API/functions)
-* [Making your own form elements](../API/custom_form_elements)
+* [Writing your own element classes](../API/custom_form_elements)

--- a/docs/custom_form_elements.md
+++ b/docs/custom_form_elements.md
@@ -36,7 +36,7 @@ formulizeShuffledRadioElement       formulizeShuffledRadioElementHandler
     extends formulizeElement            extends formulizeElementsHandler
 ~~~
 
-This matters because Formulize discovers what "family" your element belongs to by examining the element class hierarchy, and then calls family-specific methods on your **handler**. For example, code that knows it is dealing with a radio-family element will call __getOptionLabel()__ and __previousEntryOptionKey()__ on your handler — methods that exist on __formulizeRadioElementHandler__. If your handler extended the base __formulizeElementsHandler__ instead, those calls would fail.
+This matters because Formulize discovers what "family" your element belongs to by examining the element class hierarchy, and then calls family-specific methods on your **handler**. For example, code that knows it is dealing with a radio-family element will call __previousEntryOptionKey()__ on your handler — a method that exists on __formulizeRadioElementHandler__. If your handler extended the base __formulizeElementsHandler__ instead, that call would fail. (Family-specific methods on the *element* class, like the radio family's __getListOptions()__, are inherited automatically since your element class extends the family's element class — the parallel-hierarchy rule is what extends that same guarantee to the handler side.)
 
 ## What you inherit when you extend an existing type
 
@@ -93,26 +93,37 @@ class formulizeShuffledRadioElementHandler extends formulizeRadioElementHandler 
 		// ele_value is the element-specific settings for the element
 		// in radio buttons it is the set of options (as keys), with the value indicating
 		// if it's the selected option, so 1 if it is selected, 0 if it is not
+		// example with bananas selected: ['apples' => 0, 'pears' => 0, 'bananas' => 1]
 		$selectedOption = "";
 		foreach($ele_value as $optionText=>$selected) {
 			if($selected > 0) {
 				$selectedOption = $optionText;
+				break;
 			}
 		}
 		// disabled elements just render as plain, non-interactable text
 		if($isDisabled) {
-			$disabledLabel = htmlspecialchars($selectedOption);
-			return new XoopsFormLabel($caption, $disabledLabel, $markupName);
+			return new XoopsFormLabel($caption, $selectedOption);
 		}
 
 		// gather the option texts, and shuffle them - the whole point of this element type!
 		$optionTexts = array_keys($ele_value);
 		shuffle($optionTexts);
-		$formElement = new XoopsFormRadio($caption, $markupName, $selectedOption, "<br />"); // separate with line breaks
-		$formElement->addOptionArray($optionTexts);
+
+		// construct the key-value pairs for rendering
+		// we're going with the literal option text (random order now), as value and as label
+		$keyValuePairs = array();
+		foreach($optionTexts as $optionText) {
+			$keyValuePairs[$optionText] = $optionText;
+		}
+
+		// create a radio button series with these key-value pairs, and the selectedOption
+		// separate with line breaks
+		$formElement = new XoopsFormRadio($caption, $markupName, $selectedOption, "<br />");
+		$formElement->addOptionArray($keyValuePairs);
 
 		// A lot of saving and validation behaviours depend on this global javascript value being set
-		// So we make sure to set it when there's a change in the selection
+		// So we make sure to add code to the element so this is set when there's a change in the selection
 		$formElement->setExtra("onchange=\"javascript:formulizechanged=1;\"");
 
 		return $formElement;

--- a/docs/custom_form_elements.md
+++ b/docs/custom_form_elements.md
@@ -1,0 +1,145 @@
+---
+layout: default
+permalink: developers/API/custom_form_elements/
+title: Writing your own element classes
+---
+
+# Writing your own element classes
+
+Every element type in Formulize is defined by a pair of classes in a single file in the __/modules/formulize/class/__ folder. You can add your own element types by adding your own class files to that folder. Formulize scans the folder, so as soon as your file is there, your element type appears in the "Add an element" interface in the admin UI, and works everywhere that elements work: forms, lists, searches, imports, the API, and so on.
+
+There are two ways to write an element class:
+
+1. **Start from scratch**, by extending the base classes. Do this when your element is genuinely a new kind of thing.
+2. **Extend an existing element type**, by extending its classes. Do this when your element is a variation on something that already exists. You inherit all the behaviour of the type you extend, and override only what you want to change. There is [a simple example below](#example-radio-buttons-in-random-order).
+
+## The conventions
+
+Formulize finds and instantiates element classes based on naming conventions. For an element type called __myThing__:
+
+* The file must be __/modules/formulize/class/myThingElement.php__ — the type name, plus "Element.php".
+* The file must contain an element class called __formulizeMyThingElement__ — "formulize", plus the type name with the first letter capitalized, plus "Element".
+* The file must contain a handler class called __formulizeMyThingElementHandler__ — the same, plus "Handler".
+* The handler class must have a __create()__ method that returns a new instance of your element class.
+* The type name (__myThing__) is what gets stored in the __ele_type__ property of elements, in the database.
+
+The element class represents an element and its settings (it extends the underlying data object pattern used throughout Formulize and XOOPS). The handler class does everything else: rendering the element in forms, saving user input, preparing values for display in lists, converting search text into database values, and providing the admin UI for configuring the element. When you look inside any of the standard element class files, you will find comments on each method explaining what it does and what it must return.
+
+### Parallel class hierarchies — important!
+
+If your element class extends another type's element class, **your handler class must extend that type's handler class**. The two hierarchies must be parallel:
+
+~~~php
+// element class hierarchy          // handler class hierarchy
+formulizeShuffledRadioElement       formulizeShuffledRadioElementHandler
+  extends formulizeRadioElement       extends formulizeRadioElementHandler
+    extends formulizeElement            extends formulizeElementsHandler
+~~~
+
+This matters because Formulize discovers what "family" your element belongs to by examining the element class hierarchy, and then calls family-specific methods on your **handler**. For example, code that knows it is dealing with a radio-family element will call __getOptionLabel()__ and __previousEntryOptionKey()__ on your handler — methods that exist on __formulizeRadioElementHandler__. If your handler extended the base __formulizeElementsHandler__ instead, those calls would fail.
+
+## What you inherit when you extend an existing type
+
+Formulize resolves element types through the class hierarchy, so everywhere the code makes decisions based on the type of an element, your custom type is automatically treated like the type it extends, unless you override the relevant method. That includes:
+
+* **Rendering** in forms, and **saving** what users enter.
+* **The admin UI.** The Options tab (and Advanced tab, if any) of the type you extend is used automatically for your type. You do not need to create or register any templates. (If you *want* a custom admin UI, create __/modules/formulize/templates/admin/element_type_myThing.html__, register it in __xoops_version.php__, and update the module — but for most custom types, inheriting the parent's admin UI is exactly right.)
+* **Searching and filtering** in lists of entries, including the filter options users can pick from.
+* **Imports, exports, and the API**, wherever behaviour depends on the element type.
+
+## Example: radio buttons in random order
+
+Here is a complete, working element type that behaves exactly like the standard Radio Buttons element, except the options appear in a random order on every page load. This is useful in surveys, where the order of options can bias which ones people pick.
+
+Save this as __/modules/formulize/class/shuffledRadioElement.php__ and it will appear as "Radio Buttons (shuffled order)" when adding elements in the admin UI. You configure it exactly like a normal radio button element — it inherits the radio element's admin Options tab.
+
+### Why not just shuffle ele_value and call the parent's render()?
+
+It's tempting to override __render()__ with only two lines — shuffle the incoming __$ele_value__ array, then call __parent::render()__ — and leave everything else inherited. That does not work, and it's worth understanding why, because the reason is a trap that applies to more than just this example.
+
+The standard radio element's __render()__ does not submit the option text as the value of each radio button. It submits the option's __position__ — 1, 2, 3, and so on, counting through __$ele_value__ in whatever order it was given. The __prepareDataForSaving()__ method is called when the form is submitted, and it converts the position number into the text value for that option.
+
+This is a standard practice with all the list element types (dropdowns, radio buttons, checkboxes, etc). The way to deal with this, used below, is to make the submitted value the option text, rather than its position. Then we can just validate that the submitted text is a real option for the element, and we're done.
+
+~~~php
+<?php
+
+if (!defined('XOOPS_ROOT_PATH')) {
+	exit();
+}
+
+require_once XOOPS_ROOT_PATH . "/modules/formulize/class/radioElement.php"; // make sure the classes we're extending have been read in first!
+
+class formulizeShuffledRadioElement extends formulizeRadioElement {
+
+	function __construct() {
+		parent::__construct(); // sets up all the standard radio button properties
+		$this->name = "Radio Buttons (shuffled order)"; // the name webmasters see when adding elements
+	}
+
+}
+
+class formulizeShuffledRadioElementHandler extends formulizeRadioElementHandler {
+
+	function create() {
+		return new formulizeShuffledRadioElement();
+	}
+
+	// Render the element for display in a form, with the options in a random order on every page load.
+	// The submitted value is the option text itself, not its position - see the "Why not just shuffle
+	// ele_value..." explanation above for why that matters here.
+	function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null) {
+
+		// ele_value is the element-specific settings for the element
+		// in radio buttons it is the set of options (as keys), with the value indicating
+		// if it's the selected option, so 1 if it is selected, 0 if it is not
+		$selectedOption = "";
+		foreach($ele_value as $optionText=>$selected) {
+			if($selected > 0) {
+				$selectedOption = $optionText;
+			}
+		}
+		// disabled elements just render as plain, non-interactable text
+		if($isDisabled) {
+			$disabledLabel = htmlspecialchars($selectedOption);
+			return new XoopsFormLabel($caption, $disabledLabel, $markupName);
+		}
+
+		// gather the option texts, and shuffle them - the whole point of this element type!
+		$optionTexts = array_keys($ele_value);
+		shuffle($optionTexts);
+		$formElement = new XoopsFormRadio($caption, $markupName, $selectedOption, "<br />"); // separate with line breaks
+		$formElement->addOptionArray($optionTexts);
+
+		// A lot of saving and validation behaviours depend on this global javascript value being set
+		// So we make sure to set it when there's a change in the selection
+		$formElement->setExtra("onchange=\"javascript:formulizechanged=1;\"");
+
+		return $formElement;
+	}
+
+	// Package up what the user submitted, for insertion into the form's data table.
+	//
+	// Never trust a submitted value just because it came back through a field your own render()
+	// method produced - a user can submit any string they like, regardless of what your HTML offered.
+	// optionIsValid() (inherited from the radio element) confirms the text we received is genuinely
+	// one of this element's configured options before we accept it.
+	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
+		if (!$element->optionIsValid($value)) {
+			return null;
+		}
+		return htmlspecialchars($value);
+	}
+
+}
+~~~
+
+### What the example deliberately leaves out
+
+The standard radio element's render method supports several extra features that this simple example does not reproduce: the "other" write-in option (__{OTHER|...}__), alternate on-screen text for options (uitext), configurable delimiters between options, and the preservation of out-of-range values saved under an older set of options. If your custom element needs those, study the render and prepareDataForSaving methods in __radioElement.php__ — but note that they work in terms of option positions, so you would need to carry the presented order through to the save step yourself.
+
+## Tips
+
+* Everything the handler methods must do is documented in comments inside the standard element class files. __provinceListElement.php__ is a compact example of a complete element type built from scratch; __ynElement.php__ is a compact example of extending another type (it extends the radio element).
+* Test your element as all the different kinds of users: make entries, edit entries, view them in a list, search and filter on your element's column, and check the element in a disabled state (viewing an entry without edit permission).
+* Keep your custom class files in your own version control. They live inside the Formulize module folder, so make sure your deployment process preserves them when you upgrade Formulize.

--- a/mcp/tools.php
+++ b/mcp/tools.php
@@ -2154,14 +2154,23 @@ private function validateFilter($filter, $form_ids, $andOr = 'AND') {
 
 		// Step 3: Write the entry
 		// keys are entry ids when updating, or sequential integers when creating
+		$writtenEntryIds = [];
 		foreach($preparedData as $i => $entryData) {
 			$entryId = $operation == 'create' ? 'new' : $i;
-			$resultEntryId = formulize_writeEntry($entryData, $entryId); // writes data and manages ownership info
+			if($resultEntryId = formulize_writeEntry($entryData, $entryId)) {  // writes data and manages ownership info
+				$writtenEntryIds[] = $resultEntryId;
+			}
 			$finalEntryId = ($entryId === 'new') ? $resultEntryId : $entryId; // for updates, formulize_writeEntry can return null if no data actually changed from current DB state
 			// Step 4: Update derived values
 			formulize_updateDerivedValues($finalEntryId, $formId, $relationshipId);
 			// Lastly, put the entry id into the prepared data for reference
 			$preparedData[$i] = array_merge(array('entry_id' => $finalEntryId), $preparedData[$i]);
+		}
+
+		// Step 5: send notifications
+		if(!empty($writtenEntryIds)) {
+			$event = $operation == 'create' ? 'new_entry' : 'update_entry';
+			sendNotifications($formId, $event, $writtenEntryIds);
 		}
 
 		$response = [

--- a/modules/formulize/admin/element.php
+++ b/modules/formulize/admin/element.php
@@ -286,7 +286,8 @@ $options['ele_uitextshow'] = $ele_uitextshow;
 // falls back to an ancestor type's template for custom types that extend a built-in type. If nothing is
 // found anywhere in the ancestry, pass the type's own template name, and the failure will be an obvious
 // missing-template error, rather than a mysteriously blank tab
-$options['typetemplate'] = formulize_elementTypeAdminTemplate($ele_type) ? formulize_elementTypeAdminTemplate($ele_type) : "db:admin/element_type_".$ele_type.".html";
+$typetemplate = formulize_elementTypeAdminTemplate($ele_type);
+$options['typetemplate'] = $typetemplate ? $typetemplate : "db:admin/element_type_".$ele_type.".html";
 
 
 

--- a/modules/formulize/admin/element.php
+++ b/modules/formulize/admin/element.php
@@ -226,7 +226,7 @@ if ($_GET['ele_id'] != "new") {
 
 $advanced['ele_use_default_when_blank'] = $ele_use_default_when_blank;
 $advanced['datatypeui'] = createDataTypeUI($ele_type, $elementObject,$fid,$ele_encrypt);
-$advanced['advancedTypeTemplate'] = file_exists(XOOPS_ROOT_PATH."/modules/formulize/templates/admin/element_type_".$ele_type."_advanced.html") ? "db:admin/element_type_".$ele_type."_advanced.html" : "";
+$advanced['advancedTypeTemplate'] = formulize_elementTypeAdminTemplate($ele_type, "_advanced"); // falls back to an ancestor type's template for custom types that extend a built-in type
 
 list($dynamicDefaultElement, $dynamicDefaultSourceElementId) = createFieldList($advanced['ele_dynamicdefault_source'], false, false, "elements-ele_dynamicdefault_source", _NONE);
 $advanced['dynamicDefaultSourceList'] = $dynamicDefaultElement->render();
@@ -283,7 +283,10 @@ $options['ele_delim_custom_value'] = $ele_delim_custom_value;
 $options['ele_delimit_space_numspaces_value'] = $ele_delim_space_numspaces_value;
 $options['ele_uitext'] = $ele_uitext;
 $options['ele_uitextshow'] = $ele_uitextshow;
-$options['typetemplate'] = "db:admin/element_type_".$ele_type.".html";
+// falls back to an ancestor type's template for custom types that extend a built-in type. If nothing is
+// found anywhere in the ancestry, pass the type's own template name, and the failure will be an obvious
+// missing-template error, rather than a mysteriously blank tab
+$options['typetemplate'] = formulize_elementTypeAdminTemplate($ele_type) ? formulize_elementTypeAdminTemplate($ele_type) : "db:admin/element_type_".$ele_type.".html";
 
 
 

--- a/modules/formulize/admin/element.php
+++ b/modules/formulize/admin/element.php
@@ -68,6 +68,8 @@ $firstElementOrder = "";
 $advanced['ele_index_show'] = false;
 
 $customTypeHandler = false;
+$customTypeObject = false;
+$elementObject = false;
 if ($_GET['ele_id'] != "new") {
     $ele_id = intval($_GET['ele_id']);
     $elementObject = $element_handler->get($ele_id);
@@ -177,7 +179,6 @@ if ($_GET['ele_id'] != "new") {
 	$elementName = "New element";
 	$defaultOrder = "bottom";
 	$defaultSort = "";
-	$elementObject = false;
 	$names['ele_caption'] = $elementName;
 	$ele_type = $_GET['type'];
 	if (file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$ele_type."Element.php")) {
@@ -272,10 +273,32 @@ $common['fid'] = $fid;
 $common['formhandle']=$formHandle;
 $common['aid'] = $aid;
 $common['type'] = $ele_type;
-$common['typeIsSelect'] = anySelectElementType($ele_type);
 $common['uid'] = $xoopsUser->getVar('uid');
-$common['isSystemElement'] = $elementObject ? $elementObject->isSystemElement : false;
-$common['isUserAccountElement'] = $elementObject ? $elementObject->isUserAccountElement : false;
+
+// Everything the templates need to know about what kind of element this is, is worked out here, and passed to them
+// as plain true/false flags. Templates must never test the ele_type themselves: a custom element type that extends a
+// built-in type behaves like the type it extends, but its ele_type matches none of the names a template could list.
+// Two different questions are answered below, and they are easy to confuse:
+//   - which FAMILY the type belongs to (is it a radio button of some kind?), answered by the anyXElementType helpers
+//     in elements.php, which test the element class hierarchy
+//   - what the type is CAPABLE of, and what the webmaster is allowed to configure, answered by properties the element
+//     class sets on itself (canHaveMultipleValues, adminCanAllowMultipleValues, isLinked, and so on)
+$elementProperties = $elementObject ? $elementObject : $customTypeObject; // an existing element, or a blank one of the requested type when adding a new element
+$common['typeIsSelect'] = anySelectElementType($ele_type);
+$common['typeIsRadio'] = anyRadioElementType($ele_type);
+$common['typeIsCheckbox'] = anyCheckboxElementType($ele_type);
+$common['typeIsGrid'] = elementTypeIsOrExtends($ele_type, 'grid');
+$common['typeIsSubformFullForm'] = elementTypeIsOrExtends($ele_type, 'subformFullForm');
+$common['typeIsSubformEditableRow'] = elementTypeIsOrExtends($ele_type, 'subformEditableRow');
+$common['isSystemElement'] = $elementProperties ? (bool) $elementProperties->isSystemElement : false;
+$common['isUserAccountElement'] = $elementProperties ? (bool) $elementProperties->isUserAccountElement : false;
+$common['isLinkedType'] = $elementProperties ? (bool) $elementProperties->isLinked : false;
+$common['isUserList'] = $elementProperties ? (bool) $elementProperties->isUserList : false;
+// whether the element currently holds more than one value (which is what the default value UI has to match), versus
+// whether the webmaster is allowed to turn multiple values on and off (which is whether to offer that choice at all)
+$common['canHaveMultipleValues'] = $elementProperties ? (bool) $elementProperties->canHaveMultipleValues : false;
+$common['canAllowMultipleValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowMultipleValues : false;
+$common['canAllowNewValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowNewValues : false;
 
 $options = array();
 $options['ele_delim'] = $ele_delim;

--- a/modules/formulize/admin/element.php
+++ b/modules/formulize/admin/element.php
@@ -297,8 +297,8 @@ $common['isUserList'] = $elementProperties ? (bool) $elementProperties->isUserLi
 // whether the element currently holds more than one value (which is what the default value UI has to match), versus
 // whether the webmaster is allowed to turn multiple values on and off (which is whether to offer that choice at all)
 $common['canHaveMultipleValues'] = $elementProperties ? (bool) $elementProperties->canHaveMultipleValues : false;
-$common['canAllowMultipleValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowMultipleValues : false;
-$common['canAllowNewValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowNewValues : false;
+$common['adminCanAllowMultipleValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowMultipleValues : false;
+$common['adminCanAllowNewValues'] = $elementProperties ? (bool) $elementProperties->adminCanAllowNewValues : false;
 
 $options = array();
 $options['ele_delim'] = $ele_delim;

--- a/modules/formulize/admin/form.php
+++ b/modules/formulize/admin/form.php
@@ -248,6 +248,11 @@ if ($_GET['fid'] != "new") {
         $elements[$i]['content']['ele_handle'] = $ele_handle;
 				$elements[$i]['content']['inLink'] = in_array($ele_id, $elementsInRelationshipLinks);
         $ele_type = $thisElement->getVar('ele_type');
+        // NOTE: element conversion is deliberately offered only for the exact built-in types below,
+        // not for custom types that extend them. Conversion depends on the precise ele_value
+        // structure and stored data format of both the source and target types, and a custom
+        // subclass may repurpose either, so offering conversion for subclasses could corrupt them.
+        // If element classes ever grow a conversion API of their own, this switch should defer to it.
         switch($ele_type) {
           case("text"):
             $converttext = _AM_ELE_CONVERT_ML;

--- a/modules/formulize/admin/save/element_advanced_save.php
+++ b/modules/formulize/admin/save/element_advanced_save.php
@@ -221,7 +221,9 @@ if(isset($_POST['exportoptions_onoff']) AND $_POST['exportoptions_onoff']) {
 }
 
 // call the adminSave method. IT SHOULD SET ele_value ON THE ELEMENT OBJECT, AND MUST SET IT IF IT IS MAKING CHANGES.
-if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/templates/admin/element_type_".$ele_type."_advanced.html")) {
+// the template check falls back to ancestor types' templates, so custom types that extend a built-in type
+// get their advanced tab saved the same way it was rendered (with the ancestor's template and methods)
+if(formulize_elementTypeAdminTemplate($ele_type, "_advanced")) {
   $customTypeHandler = xoops_getmodulehandler($ele_type."Element", 'formulize');
   $changed = $customTypeHandler->adminSave($element, $element->getVar('ele_value'), advancedTab: true);
   if($changed) {

--- a/modules/formulize/admin/save/element_advanced_save.php
+++ b/modules/formulize/admin/save/element_advanced_save.php
@@ -208,7 +208,7 @@ if($element->getVar('ele_dynamicdefault_source') != intval($_POST['elements-ele_
 if(isset($_POST['exportoptions_onoff']) AND $_POST['exportoptions_onoff']) {
     // linked elements cannot have exportoptions_onoff set, so we assume that ele_value[2] is an array, or ele_value is an array in the case of a radio button element
     $ele_value = $element->getVar('ele_value');
-    if($element->getVar('ele_type')=='radio') {
+    if(anyRadioElementType($element->getVar('ele_type'))) { // radio based elements (including yn) keep their options in a flat ele_value, not in key 2
         $options = array_keys($ele_value);
     } else {
         $options = array_keys($ele_value[2]);

--- a/modules/formulize/admin/save/form_elements_save.php
+++ b/modules/formulize/admin/save/form_elements_save.php
@@ -120,6 +120,11 @@ foreach($elements as $element) {
 }
 
 // handle any operations
+// NOTE: conversion is deliberately keyed on exact built-in types (no subclass resolution).
+// Each branch below rearranges ele_value and migrates stored data based on the precise
+// structure of the source and target types. A custom type extending one of these may
+// repurpose ele_value or store data differently, so converting it as if it were its parent
+// could corrupt it. If element classes ever grow a conversion API, this should defer to it.
 if($_POST['convertelement']) {
   global $xoopsModuleConfig;
   $element =& $element_handler->get($_POST['convertelement']);

--- a/modules/formulize/class/anonPasscodeElement.php
+++ b/modules/formulize/class/anonPasscodeElement.php
@@ -108,14 +108,14 @@ class formulizeAnonPasscodeElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-    // You can return {WRITEASNULL} to cause a null value to be saved in the database
+    // You can return null to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
 		// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
     // $subformBlankCounter is the instance of a blank subform entry we are saving. Multiple blank subform values can be saved on a given pageload and the counter differentiates the set of data belonging to each one prior to them being saved and getting an entry id of their own.
     function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
         if($value) {
-            return isset($_SESSION['formulize_passCode_'.$value]) ? $_SESSION['formulize_passCode_'.$value] : "{WRITEASNULL}";
+            return isset($_SESSION['formulize_passCode_'.$value]) ? $_SESSION['formulize_passCode_'.$value] : null;
         }
     }
 

--- a/modules/formulize/class/autocompleteElement.php
+++ b/modules/formulize/class/autocompleteElement.php
@@ -43,6 +43,9 @@ class formulizeAutocompleteElement extends formulizeSelectElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'autocomplete'; // rendered as an autocomplete, rather than a dropdown or a listbox
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
+		$this->adminCanAllowNewValues = true; // the webmaster chooses whether users can save values that are not among the options
 		$this->hasMultipleOptions = true;
 		$this->isLinked = false; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/autocompleteLinkedElement.php
+++ b/modules/formulize/class/autocompleteLinkedElement.php
@@ -43,6 +43,9 @@ class formulizeAutocompleteLinkedElement extends formulizeSelectLinkedElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'autocomplete'; // rendered as an autocomplete, rather than a dropdown or a listbox
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
+		$this->adminCanAllowNewValues = true; // the webmaster chooses whether users can save values that are not among the options (a new entry is created in the source form)
 		$this->hasMultipleOptions = true;
 		$this->isLinked = true; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/autocompleteUsersElement.php
+++ b/modules/formulize/class/autocompleteUsersElement.php
@@ -43,6 +43,10 @@ class formulizeAutocompleteUsersElement extends formulizeSelectUsersElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'autocomplete'; // rendered as an autocomplete, rather than a dropdown or a listbox
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
+		$this->adminCanAllowNewValues = false; // new values would mean new user accounts, which this element does not create
+		$this->isUserList = true; // the options are the users of the site
 		$this->hasMultipleOptions = true;
 		$this->isLinked = false; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/checkboxElement.php
+++ b/modules/formulize/class/checkboxElement.php
@@ -636,7 +636,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/checkboxElement.php
+++ b/modules/formulize/class/checkboxElement.php
@@ -363,7 +363,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 		// put the array into another array (clearing all default values)
 		// then we modify our place holder array and then reassign
 
-		$ele_value = $element->getVar('ele_value'); // getVar migrates any legacy ele_value structure to the current one
+		$ele_value = $element->getVar('ele_value');
 
 		$temparray = $ele_value[2];
 
@@ -672,7 +672,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 	// $subformBlankCounter is the instance of a blank subform entry we are saving. Multiple blank subform values can be saved on a given pageload and the counter differentiates the set of data belonging to each one prior to them being saved and getting an entry id of their own.
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
 
-			$ele_value = $element->getVar('ele_value'); // getVar migrates any legacy ele_value structure to the current one
+			$ele_value = $element->getVar('ele_value');
 
 			if(!is_array($ele_value[2]) AND strstr($ele_value[2], "#*=:*")) {
 					$filteredValues = array();

--- a/modules/formulize/class/checkboxElement.php
+++ b/modules/formulize/class/checkboxElement.php
@@ -102,6 +102,30 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
         return new formulizeCheckboxElement();
     }
 
+	/**
+	 * Return the filter options for a checkbox element (and checkboxLinked, which extends this).
+	 * The options live in key 2 of ele_value, once the legacy ele_value structure has been
+	 * brought up to date by backwardsCompatibility().
+	 * @param object $element The element object
+	 * @return array Associative array of filter value => label
+	 */
+	function getFilterOptions($element = null) {
+		if(!$element) {
+			return array();
+		}
+		$ele_value = $this->normalizeEleValue($element->getVar('ele_value'));
+		return isset($ele_value[2]) ? $ele_value[2] : array();
+	}
+
+	/**
+	 * The checkbox element's ele_value structure changed over time, so migrate legacy values.
+	 * @param array $ele_value The raw ele_value from the element object
+	 * @return array The ele_value in the current structure
+	 */
+	function normalizeEleValue($ele_value) {
+		return $this->backwardsCompatibility($ele_value);
+	}
+
 		public function getDefaultEleValue() {
 			$ele_value = array();
 			$ele_value[2] = array(); // an array of options for the select box

--- a/modules/formulize/class/checkboxElement.php
+++ b/modules/formulize/class/checkboxElement.php
@@ -71,6 +71,17 @@ class formulizeCheckboxElement extends formulizeElement {
 		return $descriptionAndExamples;
 	}
 
+	// The checkbox element's ele_value structure changed over time. Present the current structure
+	// to all callers, regardless of what is stored in the database, by migrating legacy values
+	// whenever ele_value is read
+	public function getVar($key, $format = 's') {
+		$value = parent::getVar($key, $format);
+		if($key == 'ele_value' AND is_array($value)) {
+			$value = formulizeCheckboxElementHandler::backwardsCompatibility($value);
+		}
+		return $value;
+	}
+
 	// returns true if the option is one of the values the user can choose from in this element
 	// does not support linked values!!
 	function optionIsValid($option) {
@@ -104,8 +115,8 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 
 	/**
 	 * Return the filter options for a checkbox element (and checkboxLinked, which extends this).
-	 * The options live in key 2 of ele_value, once the legacy ele_value structure has been
-	 * brought up to date by backwardsCompatibility().
+	 * The options live in key 2 of ele_value (the element's getVar migrates any legacy ele_value
+	 * structure to the current one, so key 2 is reliable here).
 	 * @param object $element The element object
 	 * @return array Associative array of filter value => label
 	 */
@@ -113,17 +124,8 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 		if(!$element) {
 			return array();
 		}
-		$ele_value = $this->normalizeEleValue($element->getVar('ele_value'));
+		$ele_value = $element->getVar('ele_value');
 		return isset($ele_value[2]) ? $ele_value[2] : array();
-	}
-
-	/**
-	 * The checkbox element's ele_value structure changed over time, so migrate legacy values.
-	 * @param array $ele_value The raw ele_value from the element object
-	 * @return array The ele_value in the current structure
-	 */
-	function normalizeEleValue($ele_value) {
-		return $this->backwardsCompatibility($ele_value);
 	}
 
 		public function getDefaultEleValue() {
@@ -141,7 +143,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
         $dataToSendToTemplate = array();
 				$dataToSendToTemplate['subformInterfaceAdminUrl'] = "";
         if(is_object($element) AND is_subclass_of($element, 'formulizeElement')) {
-					$ele_value = $this->backwardsCompatibility($element->getVar('ele_value'));
+					$ele_value = $element->getVar('ele_value'); // getVar migrates any legacy ele_value structure to the current one
           if(is_array($ele_value[2])) { // an array will be a set of hard coded options
             $ele_value[2] = formulize_mergeUIText($ele_value[2], $element->getVar('ele_uitext'));
 						$dataToSendToTemplate['islinked'] = 0;
@@ -361,7 +363,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 		// put the array into another array (clearing all default values)
 		// then we modify our place holder array and then reassign
 
-		$ele_value = $this->backwardsCompatibility($element->getVar('ele_value'));
+		$ele_value = $element->getVar('ele_value'); // getVar migrates any legacy ele_value structure to the current one
 
 		$temparray = $ele_value[2];
 
@@ -443,7 +445,10 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 	// $screen is the screen object that is in effect, if any (may be null)
 	function render($ele_value, $caption, $markupName, $isDisabled, $element, $entry_id, $screen=false, $owner=null) {
 
-		$ele_value = $this->backwardsCompatibility($ele_value);
+		// $ele_value normally originates from the element's getVar, which migrates legacy structures,
+		// but it arrives here as a parameter that could have been assembled by other pathways, so
+		// migrate defensively (the migration is idempotent - already-current structures pass through)
+		$ele_value = self::backwardsCompatibility($ele_value);
 
 		// if options are linked...
 		$element_ele_value = $element->getVar('ele_value');
@@ -667,7 +672,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 	// $subformBlankCounter is the instance of a blank subform entry we are saving. Multiple blank subform values can be saved on a given pageload and the counter differentiates the set of data belonging to each one prior to them being saved and getting an entry id of their own.
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
 
-			$ele_value = $this->backwardsCompatibility($element->getVar('ele_value'));
+			$ele_value = $element->getVar('ele_value'); // getVar migrates any legacy ele_value structure to the current one
 
 			if(!is_array($ele_value[2]) AND strstr($ele_value[2], "#*=:*")) {
 					$filteredValues = array();
@@ -756,7 +761,7 @@ class formulizeCheckboxElementHandler extends formulizeBaseClassForListsElementH
 			return parent::formatDataForList($value); // always return the result of formatDataForList through the parent class (where the properties you set here are enforced)
 	}
 
-	function backwardsCompatibility($ele_value) {
+	static function backwardsCompatibility($ele_value) {
 		if(!is_numeric(key($ele_value)) OR (!isset($ele_value[2]) AND (!isset($ele_value[5]) OR (!is_array($ele_value[5]) AND !is_numeric($ele_value[5]))))) {
 			$ele_value = array(2=>$ele_value,5=>array());
 		}

--- a/modules/formulize/class/colorpickElement.php
+++ b/modules/formulize/class/colorpickElement.php
@@ -143,7 +143,7 @@ class formulizeColorpickElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable

--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -1523,7 +1523,9 @@ class formulizeDataHandler {
 		// we need to determine if this element allows multiple values and prepare to handle it
 		$ele_type = $element->getVar('ele_type');
 		$ele_value = $element->getVar('ele_value');
-		$testEleType = anySelectElementType($ele_type) ? "select" : $ele_type;
+		// resolve custom/derived element types to whichever of the types below they are based on,
+		// so that a subclass of the radio element, the checkbox element, etc, is handled correctly
+		$testEleType = formulize_resolveEleType($ele_type, array("radio", "checkbox", "checkboxLinked", "select"));
 		switch($testEleType) {
 			case "radio":
 				$oldValues = array_keys($ele_value);
@@ -1538,7 +1540,7 @@ class formulizeDataHandler {
 				$oldValues = array_keys($ele_value[2]);
 				break;
 		}
-		$prefix = ($ele_type == "checkbox" OR $ele_type == "checkboxLinked" OR (anySelectElementType($ele_type) AND $ele_value[1])) ? "*=+*:" : ""; // multiple selection possible? if so, setup prefix
+		$prefix = (anyCheckboxElementType($ele_type) OR (anySelectElementType($ele_type) AND $ele_value[1])) ? "*=+*:" : ""; // multiple selection possible? if so, setup prefix
 		$newValues = array_keys($newValues);
 		global $xoopsDB;
     $form_handler = xoops_getmodulehandler('forms', 'formulize');

--- a/modules/formulize/class/data.php
+++ b/modules/formulize/class/data.php
@@ -1205,7 +1205,7 @@ class formulizeDataHandler {
 		foreach($element_values as $evHandle=>$thisElementValue) {
 			$thisElementValue = correctStringIntFloatTypes($thisElementValue);
 			$clean_element_values[$evHandle] = $thisElementValue; // set the clean values to reflect any changes we made to the values for comparison purposes
-			$thisElementValue = $thisElementValue === "{WRITEASNULL}" ? NULL : $thisElementValue;
+			$thisElementValue = $thisElementValue === "{WRITEASNULL}" ? null : $thisElementValue; // on before save could have introduced legacy term for null
 			if(array_key_exists($evHandle, $existing_values) AND $existing_values[$evHandle] === $thisElementValue) {
 				unset($element_values[$evHandle]);
 			}

--- a/modules/formulize/class/dateElement.php
+++ b/modules/formulize/class/dateElement.php
@@ -258,7 +258,7 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable
@@ -267,7 +267,7 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 		if ($value != _DATE_DEFAULT AND $value != "" AND $timestamp !== false) { // $timestamp !== false should catch everything by itself? under some circumstance not yet figured out, the other checks could be useful?
 			$value = date("Y-m-d", $timestamp);
 		} else {
-			$value = "{WRITEASNULL}"; // forget about this date element and go on to the next element in the form
+			$value = null; // forget about this date element and go on to the next element in the form
 		}
 		return $value;
 	}

--- a/modules/formulize/class/derivedElement.php
+++ b/modules/formulize/class/derivedElement.php
@@ -321,7 +321,7 @@ class formulizeDerivedElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable

--- a/modules/formulize/class/durationElement.php
+++ b/modules/formulize/class/durationElement.php
@@ -135,7 +135,7 @@ class formulizeDurationElementHandler extends formulizeElementsHandler
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/eagGroupTypeElement.php
+++ b/modules/formulize/class/eagGroupTypeElement.php
@@ -43,9 +43,10 @@ class formulizeEagGroupTypeElementHandler extends formulizeVirtualElementHandler
 	/**
 	 * Return the available filter options for this element type.
 	 *
+	 * @param object $element The element object (not needed - the options are fixed)
 	 * @return array Associative array of option value => display label
 	 */
-	function getFilterOptions() {
+	function getFilterOptions($element = null) {
 		return array('Regular' => 'Regular', 'Form-based' => 'Form-based');
 	}
 

--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -261,6 +261,8 @@ class formulizeElementRenderer{
 	}
 
 	function formulize_disableElement($element, $type) {
+		// resolve custom/derived element types to date or colorpick if they're based on those, so subclasses are disabled the same way
+		$type = formulize_resolveEleType($type, array("date", "colorpick"));
 		if($type == "date" OR $type == "colorpick") {
 			switch($type) {
 				case 'date':
@@ -347,6 +349,7 @@ class formulizeElementRenderer{
 		// element (textarea, number) are prefilled the same way the text element is.
 		$simpleValueType = formulize_resolveEleType($type, array("text", "date"));
 		$prevElement_ele_value = array();
+		$javascript = ""; // stays empty for element types that the previous entry UI does not support
 		// setup the javascript based on the type of question, and setup other data that is required
 		if($isRadioType) {
 			// need to get the options of the question so we know what to match

--- a/modules/formulize/class/elementrenderer.php
+++ b/modules/formulize/class/elementrenderer.php
@@ -336,22 +336,30 @@ class formulizeElementRenderer{
 		if(!$previousElementHandle) { return ""; }
 		$elementName = $de ? "de_".$fid."_".$entry_id."_".$element_id : "ele_".$element_id;
 		$previousElementId = formulize_getIdFromElementHandle($previousElementHandle); // function is in extract.php
+		// Radio buttons and everything that extends them (yn, and any custom radio-based type)
+		// are all set by checking the option at a given position, so they are handled together.
+		// Which position a given value corresponds to differs between them though - a plain
+		// radio matches on the option text, while a yes/no element stores codes - so that part
+		// is delegated to the element type, via previousEntryOptionKey().
+		$isRadioType = anyRadioElementType($type);
+		$typeHandler = $isRadioType ? xoops_getmodulehandler($type."Element", "formulize") : null;
+		// types that are simply given the previous value. Resolving means subclasses of the text
+		// element (textarea, number) are prefilled the same way the text element is.
+		$simpleValueType = formulize_resolveEleType($type, array("text", "date"));
+		$prevElement_ele_value = array();
 		// setup the javascript based on the type of question, and setup other data that is required
-		switch($type) {
-			case "text":
-			case "date":
-				$javascript = "onchange='javascript:this.form.".$elementName.".value=this.form.prev_".$element_id.".value;'";
-				break;
-			case "radio":
-				// need to get the options of the question so we know what to match
-				$prevElementMetaData = formulize_getElementMetaData($previousElementId); // use this function in extract instead of the get element method in handler, since this is guaranteed to be already be cached in memory
-				$prevElement_ele_value = unserialize($prevElementMetaData['ele_value']);
-				$prevElementOptions = array_keys($prevElement_ele_value);
-				$javascript = "onchange='javascript:if(this.form.prev_".$element_id.".value !== \"\") { this.form.".$elementName."[this.form.prev_".$element_id.".value].checked=true; }'";
-				break;
-			case "yn":
-				$javascript = "onchange='javascript:if(this.form.prev_".$element_id.".value !== \"\") { this.form.".$elementName."[this.form.prev_".$element_id.".value].checked=true; }'";
-				break;
+		if($isRadioType) {
+			// need to get the options of the question so we know what to match
+			$prevElementMetaData = formulize_getElementMetaData($previousElementId); // use this function in extract instead of the get element method in handler, since this is guaranteed to be already be cached in memory
+			$prevElement_ele_value = unserialize($prevElementMetaData['ele_value']);
+			$javascript = "onchange='javascript:if(this.form.prev_".$element_id.".value !== \"\") { this.form.".$elementName."[this.form.prev_".$element_id.".value].checked=true; }'";
+		} else {
+			switch($simpleValueType) {
+				case "text":
+				case "date":
+					$javascript = "onchange='javascript:this.form.".$elementName.".value=this.form.prev_".$element_id.".value;'";
+					break;
+			}
 		}
 		$previousOptions = array();
 		$prevOptionsExist = false;
@@ -362,25 +370,19 @@ class formulizeElementRenderer{
 			}
 			if(trim($value) === "" OR trim($value) == "0000-00-00") { continue; }
 			$prevOptionsExist = true;
-			switch($type) {
-				case "text":
-				case "date":
-					$previousOptions[$value] = $value;
-					break;
-				case "radio":
-					$prevElementPosition = array_search($value, $prevElementOptions); // need to figure out which option matches the text of the value
-					if($prevElementPosition !== false) {
-						$previousOptions[$prevElementPosition] = $value; // for radio buttons, we need to pass the position of the option
-					}
-					break;
-				case "yn":
-					if($value == _formulize_TEMP_QYES) {
-						$previousOptions[0] = $value;
-					} elseif($value == _formulize_TEMP_QNO) {
-						$previousOptions[1] = $value;
-					}
-					break;
-
+			if($isRadioType) {
+				// for radio buttons, we need to pass the position of the option, not the value
+				$prevElementPosition = $typeHandler->previousEntryOptionKey($value, $prevElement_ele_value);
+				if($prevElementPosition !== false) {
+					$previousOptions[$prevElementPosition] = $value;
+				}
+			} else {
+				switch($simpleValueType) {
+					case "text":
+					case "date":
+						$previousOptions[$value] = $value;
+						break;
+				}
 			}
 		}
 		if(!$prevOptionsExist) { return ""; }

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -49,7 +49,10 @@ class formulizeElement extends FormulizeObject {
 	var $name;
 	var $adminCanMakeRequired;
 	var $alwaysValidateInputs;
-	var $canHaveMultipleValues;
+	var $canHaveMultipleValues; // whether the element is CURRENTLY configured to hold more than one value at a time. For some types this is fixed (checkboxes always can, radio buttons never can) and for others it depends on the element's settings, in which case the class implements setCanHaveMultipleValues (see _setElementProperties)
+	var $adminCanAllowMultipleValues = false; // whether the webmaster can CHOOSE if this type holds more than one value at a time (listbox and autocomplete style lists can, dropdowns and radio buttons and checkboxes cannot - their multiplicity is inherent to the type). Not the same question as canHaveMultipleValues, which is the current state, not the capability
+	var $adminCanAllowNewValues = false; // whether the webmaster can choose to let users save values that are not among the element's options (autocomplete style lists)
+	var $isUserList = false; // whether the options for this element are the users of the site, instead of a list of options the webmaster defines
 	var $hasMultipleOptions;
 	var $isSystemElement; // only set to true in custom element class, if you want an element to exist in the form but be primarily managed by the system
 	var $readOnly = false; // set to true in element classes whose values should never be written back — treated as $isDisabled throughout the rendering pipeline

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -1204,6 +1204,43 @@ class formulizeElementsHandler {
 		}
 	}
 
+	/**
+	 * Return the options that users can choose from when filtering/searching on this element.
+	 *
+	 * The KEYS of the returned array are the values that get submitted by the filter UI and
+	 * matched against the data (they are passed through the handler's prepareLiteralTextForDB()
+	 * before hitting the database, so an element whose stored values are codes can return
+	 * human readable keys here and translate them there - the yn element does exactly that).
+	 * The array values are only used as labels when the caller sets its $useValue flag, which
+	 * it does for linked elements and user lists.
+	 *
+	 * Element types whose options cannot be enumerated should return an empty array; the
+	 * caller then falls back to finding the distinct values present in the data.
+	 *
+	 * A string may be returned for linked elements, whose ele_value[2] is a "fid#*=:*handle"
+	 * specification that the caller resolves against the source form.
+	 *
+	 * @param object $element The element object to return the filter options for
+	 * @return array|string Associative array of filter value => label, or a linked element spec
+	 */
+	function getFilterOptions($element = null) {
+		return array();
+	}
+
+	/**
+	 * Bring an element's raw ele_value up to the current structure for this element type.
+	 *
+	 * Most element types have always stored ele_value in its current shape, so this is a
+	 * no-op for them. Types that changed their ele_value structure over time (the checkbox
+	 * element, notably) override this to migrate legacy values on read.
+	 *
+	 * @param array $ele_value The raw ele_value from the element object
+	 * @return array The ele_value in the structure this element type expects
+	 */
+	function normalizeEleValue($ele_value) {
+		return $ele_value;
+	}
+
 	// this method is used by custom elements, to do final output from the "local" formatDataForList method, so the custom element developer can simply set booleans there, and they will be enforced here
 	function formatDataForList($value, $handle="", $entry_id=0, $textWidth=100) {
 		global $myts;
@@ -1341,28 +1378,186 @@ function optionIsValidForElement($option, $elementHandleOrId) {
  * @return bool
  */
 function anySelectElementType($type) {
-	static $cachedTypes = array();
-	if(isset($cachedTypes[$type])) {
-		return $cachedTypes[$type];
+	// A "select type" is the select element itself, or any element whose class extends it -
+	// selectLinked, selectUsers, autocomplete/autocompleteLinked/autocompleteUsers,
+	// listbox/listboxLinked/listboxUsers, and any custom subclass of those. They are all
+	// subclasses of formulizeSelectElement, so this reduces to the generic parent test.
+	return ($type === "select") ? true : elementTypeHasOtherTypeAsParent($type, "select");
+}
+
+/**
+ * Determine whether an element type is a subclass of another element type: i.e. its element
+ * class descends from (but is not) the parent type's element class.
+ *
+ * This is the general form of the pattern that anySelectElementType() used to hardcode.
+ * Throughout the codebase there are switch/case and if statements keyed on literal ele_type
+ * strings (e.g. case "radio":). Those miss custom element types that extend a built-in type.
+ * Instead of naming every subclass in every switch, code can ask
+ * elementTypeHasOtherTypeAsParent($type, 'select') and get a true answer for every descendant
+ * of formulizeSelectElement.
+ *
+ * Note: this is a strict subclass test (like is_subclass_of), so it returns FALSE when $type
+ * IS $parentType. Callers that want "is this type X or a subclass of X" should OR in an exact
+ * match, as anySelectElementType() does.
+ *
+ * The element-class naming convention is relied upon: type "radio" -> class formulizeRadioElement,
+ * type "checkboxLinked" -> class formulizeCheckboxLinkedElement, etc. ("formulize" . ucfirst(type)
+ * . "Element").
+ *
+ * @param string|object $type The ele_type string to test, or an element object
+ * @param string $parentType The candidate parent ele_type, e.g. 'select', 'radio'
+ * @return bool True if $type's element class is a subclass of the parent type's element class
+ */
+function elementTypeHasOtherTypeAsParent($type, $parentType) {
+	if(is_object($type)) {
+		$type = $type->getVar('ele_type');
 	}
-	$baseTypes = array("select","autocomplete","listbox");
-	$subTypes = array("","Linked","Users");
-	foreach($baseTypes as $base) {
-		foreach($subTypes as $sub) {
-			if ($type == $base.$sub) {
-				$cachedTypes[$type] = true;
-				return true;
+	if($type === $parentType) {
+		return false; // a type is not a subclass of itself
+	}
+	// the ancestry is cached per type, so this is just an in_array over a very short array
+	return in_array($parentType, formulize_eleTypeAncestry($type), true);
+}
+
+/**
+ * Return the ancestry of an element type: the ele_types of every element class it extends, with
+ * the nearest ancestor first. The walk stops at formulizeElement, which every element extends and
+ * which therefore tells us nothing.
+ *
+ * For example: "listboxLinked" -> array("selectLinked", "select")
+ *              "pointsRedemptionRadio" -> array("radio")
+ *              "text" -> array()
+ *
+ * This is THE ONLY place that pays the cost of inspecting the class hierarchy, and it is cached
+ * per element type - one entry per type, computed at most once per request. Every type check in
+ * this file (anySelectElementType, anyRadioElementType, anyCheckboxElementType,
+ * elementTypeHasOtherTypeAsParent, formulize_resolveEleType) then reduces to an in_array over an
+ * array that is typically empty or one or two entries long. That matters because these checks
+ * replaced straight string comparisons in hot loops (importing a file walks every column of every
+ * row), so they must not do any real work on the repeat calls.
+ *
+ * @param string $type The ele_type whose ancestry we want
+ * @return array The ele_types this type descends from, nearest ancestor first (empty if none)
+ */
+function formulize_eleTypeAncestry($type) {
+	static $cachedAncestry = array();
+	if(isset($cachedAncestry[$type])) {
+		return $cachedAncestry[$type];
+	}
+	$ancestry = array();
+	if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$type."Element.php")) {
+		if($customTypeHandler = xoops_getmodulehandler($type."Element", 'formulize')) {
+			$className = get_class($customTypeHandler->create());
+			while($className = get_parent_class($className)) {
+				$ancestorType = formulize_eleTypeForClassName($className);
+				if($ancestorType === '') {
+					break; // reached formulizeElement (or something unconventionally named), so there is nothing more to learn
+				}
+				$ancestry[] = $ancestorType;
 			}
 		}
 	}
-	if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$type."Element.php")) {
-		$customTypeHandler = xoops_getmodulehandler($type."Element", 'formulize');
-		$element = $customTypeHandler->create();
-		$cachedTypes[$type] = is_a($element, 'formulizeSelectElement');
-		return $cachedTypes[$type];
-	}
-	return false;
+	$cachedAncestry[$type] = $ancestry; // cache the misses too, so a type with no class file is not looked up on disk again
+	return $ancestry;
 }
+
+/**
+ * Take a type string and return true if it is any type of element based on the Radio type
+ *
+ * This covers the radio element itself, the yes/no element, and any custom element type that
+ * extends the radio element. Where the behaviour of those types genuinely differs (the option
+ * labels of a yes/no element, for instance) the difference is handled by the element classes
+ * themselves - see formulizeRadioElementHandler::getOptionLabel(), getFilterOptions() and
+ * previousEntryOptionKey(), and the yn overrides of them - so generic code can safely treat
+ * every one of these as a radio.
+ *
+ * @param string $type
+ * @return bool
+ */
+function anyRadioElementType($type) {
+	return ($type === "radio") ? true : elementTypeHasOtherTypeAsParent($type, "radio");
+}
+
+/**
+ * Take a type string and return true if it is any type of element based on the Checkbox type
+ *
+ * This covers the checkbox element, the checkboxLinked element (which extends it), and any
+ * custom element type that extends either. Checkbox based elements can hold multiple values,
+ * which is what most callers are really asking about.
+ *
+ * @param string $type
+ * @return bool
+ */
+function anyCheckboxElementType($type) {
+	return ($type === "checkbox") ? true : elementTypeHasOtherTypeAsParent($type, "checkbox");
+}
+
+/**
+ * Convert an element class name back into its ele_type, relying on the naming convention
+ * (type "checkboxLinked" <-> class formulizeCheckboxLinkedElement).
+ *
+ * @param string $className The element class name
+ * @return string The ele_type, or an empty string if the class is not a conventionally named
+ *                element class (formulizeElement itself resolves to an empty string, which is
+ *                what stops the hierarchy walk in formulize_resolveEleType)
+ */
+function formulize_eleTypeForClassName($className) {
+	if(substr($className, 0, 9) !== 'formulize' OR substr($className, -7) !== 'Element') {
+		return '';
+	}
+	return lcfirst(substr($className, 9, strlen($className) - 16)); // strip the "formulize" prefix (9 chars) and the "Element" suffix (7 chars)
+}
+
+/**
+ * Resolve an element type to the nearest type that the caller actually knows how to handle.
+ *
+ * This is the general answer to a problem that recurs everywhere the codebase switches on
+ * ele_type: a custom element type that extends a built-in type (a subclass of the radio
+ * element, or of the checkbox element, or of anything else) will not match any case in the
+ * switch, and so silently falls through to the default - even though it should behave exactly
+ * like the type it extends.
+ *
+ * Rather than needing a central registry of "canonical" element types (which cannot be derived
+ * reliably, since custom types are just files in the class folder), each caller passes the set
+ * of types IT handles - which is simply the list of its own case labels. This function then
+ * walks up the element's class hierarchy and returns the first ancestor type that appears in
+ * that set.
+ *
+ * Exact matches always win, which is what keeps subclasses that need to stay distinct working:
+ * the yn element extends the radio element, so a switch that lists both "yn" and "radio" still
+ * gets "yn" for a yes/no element, while a switch that only lists "radio" gets "radio" for it.
+ *
+ * If no ancestor is known to the caller, the type is returned unchanged, so the caller's
+ * default case applies exactly as it does today.
+ *
+ * Example:
+ *   $switchEleType = formulize_resolveEleType($ele_type, array('select', 'checkbox', 'radio'));
+ *   switch($switchEleType) { case 'radio': ... }
+ *   // "pointsRedemptionRadio" and "yn" both resolve to "radio"
+ *   // "listboxLinked" and "autocomplete" both resolve to "select"
+ *   // a custom subclass of the checkbox element resolves to "checkbox"
+ *
+ * @param string $type The ele_type to resolve
+ * @param array $knownTypes The ele_types the caller handles (ie: the case labels of its switch)
+ * @return string The nearest type in $knownTypes, or $type unchanged if none of its ancestors are known
+ */
+function formulize_resolveEleType($type, $knownTypes) {
+	// An exact match always wins, so types that need to stay distinct do. This is also the fast
+	// path: for the built in types that these switches are written around, it is the only work done.
+	if(in_array($type, $knownTypes, true)) {
+		return $type;
+	}
+	// Otherwise walk the (cached) ancestry, nearest ancestor first, and take the first one the
+	// caller knows about. No caching is needed here beyond the ancestry itself - this is a couple
+	// of in_array calls over arrays that are only ever a few entries long.
+	foreach(formulize_eleTypeAncestry($type) as $ancestorType) {
+		if(in_array($ancestorType, $knownTypes, true)) {
+			return $ancestorType;
+		}
+	}
+	return $type; // no ancestor is known to the caller, so its default case applies, as it does today
+}
+
 
 /**
  * Extract the form id and element handle from the ele_value of a linked element

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -1359,16 +1359,72 @@ function optionIsValidForElement($option, $elementHandleOrId) {
 }
 
 /**
- * Take a type string and return true if it is any type of element based on the Select type
- * @param string $type
+ * Take a type string or an element object and return true if it is any type of element based on the Select type
+ *
+ * A "select type" is the select element itself, or any element whose class extends it -
+ * selectLinked, selectUsers, autocomplete/autocompleteLinked/autocompleteUsers,
+ * listbox/listboxLinked/listboxUsers, and any custom subclass of those. They are all
+ * subclasses of formulizeSelectElement, so this reduces to the generic is-or-extends test.
+ *
+ * @param string|object $type The ele_type string to test, or an element object
  * @return bool
  */
 function anySelectElementType($type) {
-	// A "select type" is the select element itself, or any element whose class extends it -
-	// selectLinked, selectUsers, autocomplete/autocompleteLinked/autocompleteUsers,
-	// listbox/listboxLinked/listboxUsers, and any custom subclass of those. They are all
-	// subclasses of formulizeSelectElement, so this reduces to the generic parent test.
-	return ($type === "select") ? true : elementTypeHasOtherTypeAsParent($type, "select");
+	return elementTypeIsOrExtends($type, "select");
+}
+
+/**
+ * Take a type string and return true if it is any type of element based on the Radio type
+ *
+ * This covers the radio element itself, the yes/no element, and any custom element type that
+ * extends the radio element. Where the behaviour of those types genuinely differs (the option
+ * labels of a yes/no element, for instance) the difference is handled by the element classes
+ * themselves - see formulizeRadioElementHandler::getFilterOptions() and
+ * previousEntryOptionKey(), and the yn overrides of them - so generic code can safely treat
+ * every one of these as a radio.
+ *
+ * NOTE: code gated by this function calls radio-family methods (previousEntryOptionKey) on
+ * the type's handler. This function tests the ELEMENT class hierarchy, so a custom radio-based
+ * element must have a handler that extends formulizeRadioElementHandler (or another radio-family
+ * handler) - the two hierarchies must be parallel, which is a requirement when writing any custom
+ * element class.
+ *
+ * @param string|object $type The ele_type string to test, or an element object
+ * @return bool
+ */
+function anyRadioElementType($type) {
+	return elementTypeIsOrExtends($type, "radio");
+}
+
+/**
+ * Take a type string and return true if it is any type of element based on the Checkbox type
+ *
+ * This covers the checkbox element, the checkboxLinked element (which extends it), and any
+ * custom element type that extends either. Checkbox based elements can hold multiple values,
+ * which is what most callers are really asking about.
+ *
+ * @param string|object $type The ele_type string to test, or an element object
+ * @return bool
+ */
+function anyCheckboxElementType($type) {
+	return elementTypeIsOrExtends($type, "checkbox");
+}
+
+/**
+ * Determine whether an element type IS another element type, or descends from it. This is the
+ * "family" test that most code wants: treat this element like an X, whether it is an X itself
+ * or a custom type that extends X. The anySelectElementType/anyRadioElementType/
+ * anyCheckboxElementType functions are just readable shorthands for the common families.
+ *
+ * @param string|object $type The ele_type string to test, or an element object
+ * @param string $parentType The ele_type of the family, e.g. 'select', 'radio', 'yn'
+ * @return bool True if $type is $parentType or a descendant of it
+ */
+function elementTypeIsOrExtends($type, $parentType) {
+	if(is_object($type)) {
+		$type = $type->getVar('ele_type');
+	}
+	return ($type === $parentType) ? true : elementTypeHasOtherTypeAsParent($type, $parentType);
 }
 
 /**
@@ -1383,8 +1439,8 @@ function anySelectElementType($type) {
  * of formulizeSelectElement.
  *
  * Note: this is a strict subclass test (like is_subclass_of), so it returns FALSE when $type
- * IS $parentType. Callers that want "is this type X or a subclass of X" should OR in an exact
- * match, as anySelectElementType() does.
+ * IS $parentType. Callers that want "is this type X or a subclass of X" should use
+ * elementTypeIsOrExtends() instead, which is what the anyXElementType functions do.
  *
  * The element-class naming convention is relied upon: type "radio" -> class formulizeRadioElement,
  * type "checkboxLinked" -> class formulizeCheckboxLinkedElement, etc. ("formulize" . ucfirst(type)
@@ -1432,7 +1488,10 @@ function formulize_eleTypeAncestry($type) {
 	}
 	$ancestry = array();
 	if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/class/".$type."Element.php")) {
-		if($customTypeHandler = xoops_getmodulehandler($type."Element", 'formulize')) {
+		// the true flag makes the handler optional: if the class file exists but does not define a
+		// conventionally named handler class, we get false back instead of a fatal error, and the
+		// type is simply treated as having no ancestry
+		if($customTypeHandler = xoops_getmodulehandler($type."Element", 'formulize', true)) {
 			$className = get_class($customTypeHandler->create());
 			while($className = get_parent_class($className)) {
 				$ancestorType = formulize_eleTypeForClassName($className);
@@ -1448,34 +1507,24 @@ function formulize_eleTypeAncestry($type) {
 }
 
 /**
- * Take a type string and return true if it is any type of element based on the Radio type
+ * Find the admin UI template for an element type, falling back up the element class ancestry.
  *
- * This covers the radio element itself, the yes/no element, and any custom element type that
- * extends the radio element. Where the behaviour of those types genuinely differs (the option
- * labels of a yes/no element, for instance) the difference is handled by the element classes
- * themselves - see formulizeRadioElementHandler::getOptionLabel(), getFilterOptions() and
- * previousEntryOptionKey(), and the yn overrides of them - so generic code can safely treat
- * every one of these as a radio.
+ * Custom element types that extend a built-in type usually have no admin template of their own -
+ * they inherit the parent type's adminPrepare/adminSave methods, so they should inherit the
+ * admin template those methods are written for, too. This looks for a template belonging to the
+ * type itself first, then to each ancestor type in turn.
  *
- * @param string $type
- * @return bool
+ * @param string $ele_type The element type
+ * @param string $suffix Optional suffix on the template name: "_advanced" for the Advanced tab template
+ * @return string The db: template reference for the nearest type that has one, or an empty string if none found
  */
-function anyRadioElementType($type) {
-	return ($type === "radio") ? true : elementTypeHasOtherTypeAsParent($type, "radio");
-}
-
-/**
- * Take a type string and return true if it is any type of element based on the Checkbox type
- *
- * This covers the checkbox element, the checkboxLinked element (which extends it), and any
- * custom element type that extends either. Checkbox based elements can hold multiple values,
- * which is what most callers are really asking about.
- *
- * @param string $type
- * @return bool
- */
-function anyCheckboxElementType($type) {
-	return ($type === "checkbox") ? true : elementTypeHasOtherTypeAsParent($type, "checkbox");
+function formulize_elementTypeAdminTemplate($ele_type, $suffix = "") {
+	foreach(array_merge(array($ele_type), formulize_eleTypeAncestry($ele_type)) as $candidateType) {
+		if(file_exists(XOOPS_ROOT_PATH."/modules/formulize/templates/admin/element_type_".$candidateType.$suffix.".html")) {
+			return "db:admin/element_type_".$candidateType.$suffix.".html";
+		}
+	}
+	return "";
 }
 
 /**

--- a/modules/formulize/class/elements.php
+++ b/modules/formulize/class/elements.php
@@ -1227,20 +1227,6 @@ class formulizeElementsHandler {
 		return array();
 	}
 
-	/**
-	 * Bring an element's raw ele_value up to the current structure for this element type.
-	 *
-	 * Most element types have always stored ele_value in its current shape, so this is a
-	 * no-op for them. Types that changed their ele_value structure over time (the checkbox
-	 * element, notably) override this to migrate legacy values on read.
-	 *
-	 * @param array $ele_value The raw ele_value from the element object
-	 * @return array The ele_value in the structure this element type expects
-	 */
-	function normalizeEleValue($ele_value) {
-		return $ele_value;
-	}
-
 	// this method is used by custom elements, to do final output from the "local" formatDataForList method, so the custom element developer can simply set booleans there, and they will be enforced here
 	function formatDataForList($value, $handle="", $entry_id=0, $textWidth=100) {
 		global $myts;

--- a/modules/formulize/class/emailElement.php
+++ b/modules/formulize/class/emailElement.php
@@ -177,7 +177,7 @@ class formulizeEmailElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-    // You can return {WRITEASNULL} to cause a null value to be saved in the database
+    // You can return null to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/fileUploadElement.php
+++ b/modules/formulize/class/fileUploadElement.php
@@ -229,7 +229,7 @@ class formulizeFileUploadElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
@@ -335,7 +335,7 @@ class formulizeFileUploadElementHandler extends formulizeElementsHandler {
             print "<script>alert(\"".str_replace('"','\"',$value)."\");</script>";
         }
         if(!is_array($value)) {
-            return "{WRITEASNULL}";
+            return null;
         }
         return serialize($value);
     }

--- a/modules/formulize/class/googleAddressElement.php
+++ b/modules/formulize/class/googleAddressElement.php
@@ -225,7 +225,7 @@ $js.='
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-    // You can return {WRITEASNULL} to cause a null value to be saved in the database
+    // You can return null to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/googleFilePickerElement.php
+++ b/modules/formulize/class/googleFilePickerElement.php
@@ -411,7 +411,7 @@ class formulizeGoogleFilePickerElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-    // You can return {WRITEASNULL} to cause a null value to be saved in the database
+    // You can return null to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/gridElement.php
+++ b/modules/formulize/class/gridElement.php
@@ -312,7 +312,7 @@ class formulizeGridElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/listboxElement.php
+++ b/modules/formulize/class/listboxElement.php
@@ -43,6 +43,8 @@ class formulizeListboxElement extends formulizeSelectElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'listbox'; // rendered as a listbox, rather than a dropdown or an autocomplete
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
 		$this->hasMultipleOptions = true;
 		$this->isLinked = false; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/listboxLinkedElement.php
+++ b/modules/formulize/class/listboxLinkedElement.php
@@ -43,6 +43,8 @@ class formulizeListboxLinkedElement extends formulizeSelectLinkedElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'listbox'; // rendered as a listbox, rather than a dropdown or an autocomplete
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
 		$this->hasMultipleOptions = true;
 		$this->isLinked = true; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/listboxUsersElement.php
+++ b/modules/formulize/class/listboxUsersElement.php
@@ -43,6 +43,9 @@ class formulizeListboxUsersElement extends formulizeSelectUsersElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		// $this->canHaveMultipleValues = false; // set by setCanHaveMultipleValues method in the parent class, which is called as part of 'get' operation (in _setElementProperties method in elements.php)
+		$this->listStyle = 'listbox'; // rendered as a listbox, rather than a dropdown or an autocomplete
+		$this->adminCanAllowMultipleValues = true; // the webmaster chooses whether users can select more than one option
+		$this->isUserList = true; // the options are the users of the site
 		$this->hasMultipleOptions = true;
 		$this->isLinked = false; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/numberElement.php
+++ b/modules/formulize/class/numberElement.php
@@ -291,14 +291,14 @@ class formulizeNumberElementHandler extends formulizeTextElementHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
 		$value = preg_replace ('/[^0-9.-]+/', '', trim($value));
-		$value = (!is_numeric($value) AND $value == "") ? "{WRITEASNULL}" : $value;
+		$value = (!is_numeric($value) AND $value == "") ? null : $value;
 		return $value;
 	}
 

--- a/modules/formulize/class/phoneElement.php
+++ b/modules/formulize/class/phoneElement.php
@@ -181,7 +181,7 @@ class formulizePhoneElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-    // You can return {WRITEASNULL} to cause a null value to be saved in the database
+    // You can return null to cause a null value to be saved in the database
     // $value is what the user submitted
     // $element is the element object
 		// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/provinceListElement.php
+++ b/modules/formulize/class/provinceListElement.php
@@ -67,7 +67,9 @@ class formulizeProvinceListElementHandler extends formulizeElementsHandler {
 
 	/**
 	 * Return the filter options for a province element (and provinceRadio, which extends this).
-	 * The province names are what is stored in the data, so they need to be the array keys.
+	 * The database stores numeric codes, but the filter options are keyed on the province names,
+	 * because filter values are passed through prepareLiteralTextForDB() before they hit the
+	 * database, and that method converts a province name into its code.
 	 * @param object $element The element object
 	 * @return array Associative array of filter value => label
 	 */

--- a/modules/formulize/class/provinceListElement.php
+++ b/modules/formulize/class/provinceListElement.php
@@ -171,14 +171,14 @@ class formulizeProvinceListElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
 		if($value == "none") {
-			$value = "{WRITEASNULL}";
+			$value = null;
 		}
         return formulize_db_escape($value); // strictly speaking, formulize will already escape all values it writes to the database, but it's always a good habit to never trust what the user is sending you!
     }

--- a/modules/formulize/class/provinceListElement.php
+++ b/modules/formulize/class/provinceListElement.php
@@ -65,6 +65,23 @@ class formulizeProvinceListElementHandler extends formulizeElementsHandler {
         return new formulizeProvinceListElement();
     }
 
+	/**
+	 * Return the filter options for a province element (and provinceRadio, which extends this).
+	 * The province names are what is stored in the data, so they need to be the array keys.
+	 * @param object $element The element object
+	 * @return array Associative array of filter value => label
+	 */
+	function getFilterOptions($element = null) {
+
+		$provinceList = $this->getProvinceList();
+		$ele_value = $element ? $element->getVar('ele_value') : null;
+		if (is_array($ele_value) AND isset($ele_value[2]) AND $ele_value[2] != 1) {
+			// Sort provinces alphabetically
+			asort($provinceList);
+		}
+		return array_flip($provinceList);
+	}
+
     // this method would gather any data that we need to pass to the template, besides the ele_value and other properties that are already part of the basic element class
     // it receives the element object and returns an array of data that will go to the admin UI template
     // when dealing with new elements, $element might be FALSE

--- a/modules/formulize/class/radioElement.php
+++ b/modules/formulize/class/radioElement.php
@@ -127,6 +127,42 @@ class formulizeRadioElementHandler extends formulizeBaseClassForListsElementHand
 		return $ele_value;
 	}
 
+	/**
+	 * Return the filter options for a radio element: its ele_value is a flat array of
+	 * option text => default flag, and the option text is what is stored in the database,
+	 * so the ele_value keys are exactly the values the filter needs to match on.
+	 * @param object $element The element object
+	 * @return array Associative array of filter value => label
+	 */
+	function getFilterOptions($element = null) {
+		return $element ? $element->getVar('ele_value') : array();
+	}
+
+	/**
+	 * Given a value from a previous entry, work out which option position it corresponds to, so
+	 * the "copy from previous entry" UI can check the right radio button. For a plain radio the
+	 * value stored in the database is the option text itself, so we find its position among the
+	 * options. Element types that store codes rather than the option text (yn) override this.
+	 * @param string $value The value from the previous entry (as prepared for a dataset)
+	 * @param array $prevEleValue The ele_value of the element in the previous form
+	 * @return int|bool The zero-based position of the matching option, or false if there is no match
+	 */
+	function previousEntryOptionKey($value, $prevEleValue) {
+		return array_search($value, array_keys((array) $prevEleValue));
+	}
+
+	/**
+	 * Convert one of this element's ele_value keys into the label to show beside the radio button.
+	 * For a plain radio the option key IS the label, so this is a passthrough. Element types whose
+	 * option keys are sentinel tokens rather than display text (yn) override this.
+	 * @param string $optionKey One of the keys of the element's ele_value
+	 * @param object $element The element object
+	 * @return string The label to display for this option
+	 */
+	function getOptionLabel($optionKey, $element) {
+		return $optionKey;
+	}
+
 	// this method would gather any data that we need to pass to the template, besides the ele_value and other properties that are already part of the basic element class
 	// it receives the element object and returns an array of data that will go to the admin UI template
 	// when dealing with new elements, $element might be FALSE
@@ -254,14 +290,7 @@ class formulizeRadioElementHandler extends formulizeBaseClassForListsElementHand
 		$opt_count = 1;
 		global $myts;
     foreach($ele_value as $iKey=>$iValue) {
-			// yn are translated at runtime since webmaster and user might be in different languages
-			if($element->getVar('ele_type')	== 'yn') {
-				if($iKey == "_YES") {
-					$iKey = _YES;
-				} elseif($iKey == "_NO") {
-					$iKey = _NO;
-				}
-			}
+			$iKey = $this->getOptionLabel($iKey, $element);
 		  $options[$opt_count] = $myts->displayTarea($iKey, 1); // 1 means allow HTML through
 			if( $iValue > 0 ){
 				$selected = $opt_count;

--- a/modules/formulize/class/radioElement.php
+++ b/modules/formulize/class/radioElement.php
@@ -384,7 +384,7 @@ class formulizeRadioElementHandler extends formulizeBaseClassForListsElementHand
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/radioElement.php
+++ b/modules/formulize/class/radioElement.php
@@ -69,6 +69,15 @@ class formulizeRadioElement extends formulizeElement {
 		return $descriptionAndExamples;
 	}
 
+	// return the set of options for this element, as an array of option text => selected flag. The option text is what is stored in the database.
+	// If a state array is passed in (an ele_value as prepared by loadValue, reflecting the current entry), the returned options carry that
+	// state's selection flags - and any out-of-range pseudo-options that loadValue appended - otherwise the configured defaults are returned.
+	// For a plain radio, the state array is already keyed by option text, so it can be returned as is. Subclasses whose ele_value keys are
+	// not display text (yn keys its ele_value by the database codes) override this to convert the keys.
+	function getListOptions($ele_value = null) {
+		return is_array($ele_value) ? $ele_value : $this->getVar('ele_value');
+	}
+
 	// returns true if the option is one of the values the user can choose from in this element
   // returns false if the element does not have options
 	function optionIsValid($option) {
@@ -143,24 +152,18 @@ class formulizeRadioElementHandler extends formulizeBaseClassForListsElementHand
 	 * the "copy from previous entry" UI can check the right radio button. For a plain radio the
 	 * value stored in the database is the option text itself, so we find its position among the
 	 * options. Element types that store codes rather than the option text (yn) override this.
+	 *
+	 * NOTE: generic code calls this method on the handler of ANY element
+	 * type whose element class extends formulizeRadioElement. So if you write a custom
+	 * radio-based element, your handler class must extend formulizeRadioElementHandler (or the
+	 * handler of whichever radio-family class your element extends), so this method exists on
+	 * your handler. The element class hierarchy and the handler class hierarchy must be parallel.
 	 * @param string $value The value from the previous entry (as prepared for a dataset)
 	 * @param array $prevEleValue The ele_value of the element in the previous form
 	 * @return int|bool The zero-based position of the matching option, or false if there is no match
 	 */
 	function previousEntryOptionKey($value, $prevEleValue) {
 		return array_search($value, array_keys((array) $prevEleValue));
-	}
-
-	/**
-	 * Convert one of this element's ele_value keys into the label to show beside the radio button.
-	 * For a plain radio the option key IS the label, so this is a passthrough. Element types whose
-	 * option keys are sentinel tokens rather than display text (yn) override this.
-	 * @param string $optionKey One of the keys of the element's ele_value
-	 * @param object $element The element object
-	 * @return string The label to display for this option
-	 */
-	function getOptionLabel($optionKey, $element) {
-		return $optionKey;
 	}
 
 	// this method would gather any data that we need to pass to the template, besides the ele_value and other properties that are already part of the basic element class
@@ -289,10 +292,12 @@ class formulizeRadioElementHandler extends formulizeBaseClassForListsElementHand
 		$options = array();
 		$opt_count = 1;
 		global $myts;
-    foreach($ele_value as $iKey=>$iValue) {
-			$iKey = $this->getOptionLabel($iKey, $element);
+		// getListOptions converts the passed-in state into displayable options carrying the state's
+		// selection flags (necessary because some subclasses, like yn, key their state by database
+		// codes rather than display text)
+		foreach($element->getListOptions($ele_value) as $iKey=>$iValue) {
 		  $options[$opt_count] = $myts->displayTarea($iKey, 1); // 1 means allow HTML through
-			if( $iValue > 0 ){
+			if( $iValue > 0 ) {
 				$selected = $opt_count;
 			}
 			$opt_count++;

--- a/modules/formulize/class/selectElement.php
+++ b/modules/formulize/class/selectElement.php
@@ -484,6 +484,13 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 		// so for the other styles (dropdowns) there is nothing posted, and multiple is always off
 		$ele_value[ELE_VALUE_SELECT_MULTIPLE] = $elementProperties->adminCanAllowMultipleValues ? $postedMultipleValue : 0;
 
+		// the chooser for the default option is drawn as radio buttons or as checkboxes depending on whether the element
+		// can hold more than one value (see element_optionlist.html), so when the webmaster changes that setting, the
+		// options tab has to be redrawn, or it would go on showing the chooser for the multiplicity we just moved away from
+		if($elementProperties->canHaveMultipleValues != (bool) $ele_value[ELE_VALUE_SELECT_MULTIPLE]) {
+			$_POST['reload_option_page'] = true;
+		}
+
 		switch($elementProperties->listStyle) {
 			case 'listbox':
 				$ele_value[ELE_VALUE_SELECT_AUTOCOMPLETE] = 0;

--- a/modules/formulize/class/selectElement.php
+++ b/modules/formulize/class/selectElement.php
@@ -1410,7 +1410,7 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
@@ -1423,7 +1423,7 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 		$originalValue = $value;
 
 		if ($ele_value[ELE_VALUE_SELECT_NUMROWS] == 1 AND $value == "none") { // none is the flag for the "Choose an option" default value
-			return "{WRITEASNULL}"; // this flag is used to terminate processing of this value
+			return null; // this flag is used to terminate processing of this value
 		}
 
 		$checkForNewValues = !is_array($value) ? array($value) : $value;

--- a/modules/formulize/class/selectElement.php
+++ b/modules/formulize/class/selectElement.php
@@ -159,6 +159,22 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 		return new formulizeSelectElement();
 	}
 
+	/**
+	 * Return the filter options for a select-type element (select, listbox, autocomplete, and
+	 * their Linked/Users variants). By convention these elements keep their options in key 2
+	 * of ele_value. For linked elements that is not a list of options but a "fid#*=:*handle"
+	 * specification string, which the caller resolves against the source form.
+	 * @param object $element The element object
+	 * @return array|string Associative array of filter value => label, or a linked element spec
+	 */
+	function getFilterOptions($element = null) {
+		if(!$element) {
+			return array();
+		}
+		$ele_value = $element->getVar('ele_value');
+		return isset($ele_value[2]) ? $ele_value[2] : array();
+	}
+
 	public function getDefaultEleValue() {
 		$ele_value = array();
 		$ele_value[ELE_VALUE_SELECT_NUMROWS] = 1; // number of rows in list box, set 1 when multiple is disabled or when autocomplete

--- a/modules/formulize/class/selectElement.php
+++ b/modules/formulize/class/selectElement.php
@@ -61,6 +61,11 @@ define('ELE_VALUE_SELECT_LINK_SOURCEMAPPINGS', 'linkedSourceMappings'); // mappi
 class formulizeSelectElement extends formulizeElement {
 
 	var $defaultValueKey;
+	// how this list is rendered for users: 'select' (a dropdown), 'listbox' or 'autocomplete'. The three styles are
+	// stored in the same ele_value keys (NUMROWS and AUTOCOMPLETE), so the class has to say which style it is, rather
+	// than the ele_type being parsed to figure it out - a custom type that extends the listbox is still a listbox, and
+	// the linked/users variants of a style extend selectLinked/selectUsers rather than the style's own class
+	var $listStyle = 'select';
 	public static $category = "lists";
 
 	function __construct() {
@@ -104,7 +109,6 @@ class formulizeSelectElement extends formulizeElement {
 	 */
 	public function getDefaultDataType($defaultType = 'text') {
 		$ele_value = $this->getVar('ele_value');
-		$selectTypeName = strtolower(str_ireplace(['formulize', 'element', 'linked', 'users'], "", static::class));
 		if ($ele_value[ELE_VALUE_SELECT_MULTIPLE] == 0 AND $this->isLinked) {
 			if($ele_value[ELE_VALUE_SELECT_LINK_SNAPSHOT]) {
 				$dataType = 'text';
@@ -331,7 +335,7 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 			$options['multiple'] = 0;
 			$ele_value[ELE_VALUE_SELECT_NUMROWS] = 1;
 			$options['islinked'] = 0;
-			$options['usernameslist'] = substr($_GET['type'], -5) == 'users' ? true : false;
+			$options['usernameslist'] = $this->create()->isUserList; // ask the class, since a custom user list type will not have a type name we could test for
 			$options['formlink_scope'] = array(0=>'all');
 			$ele_value = array();
 			$ele_uitext = array();
@@ -465,32 +469,35 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 
 		$postedMultipleValue = isset($_POST['elements_multiple']) ? intval($_POST['elements_multiple']) : 0;
 
-		// for username lists, enforce the ancient convention of using {USERNAMES} as the only option
-		$elementTypeName = strtolower(str_ireplace(['formulize', 'elementhandler'], "", static::class));
-		$userNameList = strstr($elementTypeName, 'users') ? true : false; // is this a user list?
-		if($userNameList) {
+		// the element class is what says which kind of list this is, and what the webmaster is allowed to configure.
+		// Do not go by the class name or the ele_type: a custom element type that extends one of the list types is
+		// that kind of list too, and its name will match none of the names we could test for
+		$elementProperties = (is_object($element) AND is_a($element, 'formulizeElement')) ? $element : $this->create();
+
+		// for user lists, enforce the ancient convention of using {USERNAMES} as the only option
+		if($elementProperties->isUserList) {
 			unset($ele_value[ELE_VALUE_SELECT_OPTIONS]);
 			$ele_value[ELE_VALUE_SELECT_OPTIONS] = array('{USERNAMES}' => 0);
 		}
 
-		$selectTypeName = strtolower(str_ireplace(['formulize', 'elementhandler', 'linked', 'users'], "", static::class));
-		switch($selectTypeName) {
+		// multiple selections are only possible for the list styles where the webmaster is offered the choice,
+		// so for the other styles (dropdowns) there is nothing posted, and multiple is always off
+		$ele_value[ELE_VALUE_SELECT_MULTIPLE] = $elementProperties->adminCanAllowMultipleValues ? $postedMultipleValue : 0;
+
+		switch($elementProperties->listStyle) {
 			case 'listbox':
 				$ele_value[ELE_VALUE_SELECT_AUTOCOMPLETE] = 0;
-				$ele_value[ELE_VALUE_SELECT_NUMROWS] = ($userNameList OR $element->isLinked) ? 10 : (count((array)$_POST['ele_value']) < 10 ? count($_POST['ele_value']) : 10);
+				$ele_value[ELE_VALUE_SELECT_NUMROWS] = ($elementProperties->isUserList OR $elementProperties->isLinked) ? 10 : (count((array)$_POST['ele_value']) < 10 ? count($_POST['ele_value']) : 10);
 				$ele_value[ELE_VALUE_SELECT_NUMROWS] = $ele_value[ELE_VALUE_SELECT_NUMROWS] < 1 ? 1 : $ele_value[ELE_VALUE_SELECT_NUMROWS]; // min of 1
-				$ele_value[ELE_VALUE_SELECT_MULTIPLE] = $postedMultipleValue;
 				break;
 			case 'autocomplete':
 				$ele_value[ELE_VALUE_SELECT_NUMROWS] = 1; // rows is 1
 				$ele_value[ELE_VALUE_SELECT_AUTOCOMPLETE] = 1; // is autocomplete
-				$ele_value[ELE_VALUE_SELECT_MULTIPLE] = $postedMultipleValue;
 				break;
 			case 'select':
 			default:
 				$ele_value[ELE_VALUE_SELECT_AUTOCOMPLETE] = 0;
 				$ele_value[ELE_VALUE_SELECT_NUMROWS] = 1;
-				$ele_value[ELE_VALUE_SELECT_MULTIPLE] = 0; // multiple selections not allowed for drop down lists
 				break;
 		}
 
@@ -538,12 +545,14 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 				list($_POST['ele_value'], $ele_uitext) = formulize_extractUIText($_POST['ele_value']);
 				foreach($_POST['ele_value'] as $id=>$text) {
 					if($text !== "") {
-						// For select elements, defaultoption is a single value (radio button)
-						// For other elements (listbox, autocomplete), it's an array (checkboxes)
-						if($selectTypeName == 'select') {
-							$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = (isset($_POST['defaultoption']) && $_POST['defaultoption'] == $id) ? 1 : 0;
-						} else {
+						// the default option chooser is rendered as radio buttons when the element can only hold one value,
+						// and as checkboxes when it can hold several (see element_optionlist.html), so a single value comes
+						// back in the first case and an array in the second. Read what was actually posted, so that this
+						// cannot fall out of step with the markup that produced it
+						if(is_array($_POST['defaultoption'])) {
 							$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = isset($_POST['defaultoption'][$id]) ? 1 : 0;
+						} else {
+							$ele_value[ELE_VALUE_SELECT_OPTIONS][$text] = (isset($_POST['defaultoption']) AND $_POST['defaultoption'] == $id) ? 1 : 0;
 						}
 					}
 				}
@@ -1719,9 +1728,10 @@ class formulizeSelectElementHandler extends formulizeBaseClassForListsElementHan
 	function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
 
 		// if this is a user list, we may need to convert from string to uid
-		$elementTypeName = strtolower(str_ireplace(['formulize', 'elementhandler'], "", static::class));
-		$userNameList = strstr($elementTypeName, 'users') ? true : false; // is this a user list?
-		if($userNameList) {
+		// the element class is what knows if its options are users - a custom type that extends one of the user
+		// list types is a user list too, and its class name will not contain anything we could test for
+		$elementProperties = (is_object($element) AND is_a($element, 'formulizeElement')) ? $element : $this->create();
+		if($elementProperties->isUserList) {
 			// if $value is not numeric, search the users table for a match on uname, taking $partialMatch into account
 			if(!is_numeric($value) AND $value !== '') {
 				global $xoopsDB;

--- a/modules/formulize/class/selectUsersElement.php
+++ b/modules/formulize/class/selectUsersElement.php
@@ -45,6 +45,7 @@ class formulizeSelectUsersElement extends formulizeSelectElement {
 		$this->adminCanMakeRequired = true; // set to true if the webmaster should be able to toggle this element as required/not required
 		$this->alwaysValidateInputs = false; // set to true if you want your custom validation function to always be run.  This will override any required setting that the webmaster might have set, so the recommendation is to set adminCanMakeRequired to false when this is set to true.
 		$this->canHaveMultipleValues = false;
+		$this->isUserList = true; // the options are the users of the site
 		$this->hasMultipleOptions = true;
 		$this->isLinked = false; // set to true if this element can have linked values
 	}

--- a/modules/formulize/class/sliderElement.php
+++ b/modules/formulize/class/sliderElement.php
@@ -332,7 +332,7 @@ class formulizeSliderElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
@@ -341,7 +341,7 @@ class formulizeSliderElementHandler extends formulizeElementsHandler {
         $ele_value = $element->getVar('ele_value');
         $configuredDefault = isset($ele_value[3]) ? $ele_value[3] : null;
         if ($configuredDefault === "" && ($value === "" || $value === null)) {
-            return '{WRITEASNULL}'; // empty-default mode: untouched slider → store NULL
+            return null; // empty-default mode: untouched slider → store NULL
         }
         return formulize_db_escape($value);
     }

--- a/modules/formulize/class/subformListingsElement.php
+++ b/modules/formulize/class/subformListingsElement.php
@@ -569,7 +569,7 @@ class formulizeSubformListingsElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
@@ -807,7 +807,7 @@ function drawSubLinks($subform_id, $sub_entries, $uid, $groups, $frid, $mid, $fi
             // need to also write the joining value to the main form!!
             // add that entry to the list of sub entries
             $valuesToWrite[$optionElementObject->getVar('ele_handle')] = prepDataForWrite($optionElementObject, $optionKey); // keys are what the form sends back for processing
-            if($valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "" AND $valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "{WRITEASNULL}") {
+            if($valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "" AND $valuesToWrite[$optionElementObject->getVar('ele_handle')] !== "{WRITEASNULL}" AND $valuesToWrite[$optionElementObject->getVar('ele_handle')] !== null) {
                 $proxyUser = $overrideOwnerOfNewEntries ? $mainFormOwner : false;
                 if($writtenEntryId = formulize_writeEntry($valuesToWrite, 'new', 'replace', $proxyUser, true)) { // last true forces writing even when not using POST method on page request. Necessary for prepop in modal drawing.
                     secondPassWritingSubformEntryDefaults($subform_id,$writtenEntryId,array_keys($valuesToWrite));

--- a/modules/formulize/class/textElement.php
+++ b/modules/formulize/class/textElement.php
@@ -370,7 +370,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
@@ -391,7 +391,7 @@ class formulizeTextElementHandler extends formulizeElementsHandler {
 		}
 		global $myts;
 		$value = $myts->htmlSpecialChars($value);
-		$value = (!is_numeric($value) AND $value == "") ? "{WRITEASNULL}" : $value;
+		$value = (!is_numeric($value) AND $value == "") ? null : $value;
 		return $value;
 	}
 

--- a/modules/formulize/class/textareaElement.php
+++ b/modules/formulize/class/textareaElement.php
@@ -272,7 +272,7 @@ class formulizeTextareaElementHandler extends formulizeTextElementHandler {
 		$counterType   = isset($ele_value[ELE_VALUE_TEXTAREA_COUNTER_TYPE])   ? $ele_value[ELE_VALUE_TEXTAREA_COUNTER_TYPE]   : 'none';
 		$limitNumber = isset($ele_value[ELE_VALUE_TEXTAREA_LIMIT_NUMBER]) ? intval($ele_value[ELE_VALUE_TEXTAREA_LIMIT_NUMBER]) : 0;
 		$isRichText  = isset($ele_value[ELE_VALUE_TEXTAREA_RICHTEXT]) && $ele_value[ELE_VALUE_TEXTAREA_RICHTEXT];
-		if (!$isRichText && $counterType && $counterType !== 'none' && $limitNumber > 0 && $value !== '' && $value !== '{WRITEASNULL}') {
+		if (!$isRichText && $counterType && $counterType !== 'none' && $limitNumber > 0 && $value !== '' && $value !== null && $value !== '{WRITEASNULL}') {
 			if ($counterType === 'characters') {
 				if (mb_strlen($value) > $limitNumber) {
 					$value = mb_substr($value, 0, $limitNumber);

--- a/modules/formulize/class/timeElement.php
+++ b/modules/formulize/class/timeElement.php
@@ -198,14 +198,14 @@ class formulizeTimeElementHandler extends formulizeElementsHandler {
     }
 
     // this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
         // have to convert this to a 24 hour time for saving
-        if($value == "") { $value = "{WRITEASNULL}"; }
+        if($value == "") { $value = null; }
         return $value;
     }
 

--- a/modules/formulize/class/userAccountElement.php
+++ b/modules/formulize/class/userAccountElement.php
@@ -246,7 +246,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
     /**
      * Prepare a submitted value for insertion into the form's data table (base: pass-through).
      *
-     * Return {WRITEASNULL} to save a SQL NULL. $entry_id may be "new" for new entries or null
+     * Return null to save a SQL NULL. $entry_id may be "new" for new entries or null
      * for subform-blank entries.
      *
      * @param mixed     $value              The submitted value
@@ -462,7 +462,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				$old2faMethod = $context['old2faMethod'];
 				$old2faPhone = $context['old2faPhone'];
 				$oldEmail = $context['oldEmail'];
-				
+
 				// Collect all pending changes from form submission
 				$changes = self::collectPendingUserVars($formId, $entryId, $userObject, $profile, $entryUserId, $old2faMethod);
 				$pendingUserVars = $changes['pendingUserVars'];
@@ -470,7 +470,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				$rawSubmitted2faMethod = $changes['rawSubmitted2faMethod'];
 				$passwordChanged = $changes['passwordChanged'];
 				$cleanupAppSecret = $changes['cleanupAppSecret'];
-				
+
 				// Validate 2FA transition if user is editing their own account
 				if(!self::validateOwnAccount2faTransition(
 					$entryUserId, $userObject, $profile, $pendingUserVars, $pendingProfileVars,
@@ -478,11 +478,11 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				)) {
 					return self::setTfaValidationError($results[$cacheKey]);
 				}
-				
+
 				// Apply all pending changes now that validation has passed
 				foreach($pendingProfileVars as $k => $v) { $profile->setVar($k, $v); }
 				foreach($pendingUserVars as $k => $v) { $userObject->setVar($k, $v); }
-				
+
 				// Persist to database
 				$userId = self::persistUserAndProfile($userObject, $profile, $entryUserId);
 				if($userId) {
@@ -552,7 +552,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 		$member_handler = xoops_gethandler('member');
 		$profile_handler = xoops_getmodulehandler('profile', 'profile');
 		$entryUserId = $formObject->getSystemUserIdFromEntry($entryId);
-		
+
 		if($entryUserId) {
 			$userObject = $member_handler->getUser($entryUserId);
 			if (!$userObject) {
@@ -583,7 +583,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			$old2faPhone = '';
 			$oldEmail = '';
 		}
-		
+
 		return array(
 			'userObject' => $userObject,
 			'profile' => $profile,
@@ -601,7 +601,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 	private static function collectPendingUserVars($formId, $entryId, $userObject, $profile, $entryUserId, $old2faMethod) {
 		$form_handler = xoops_getmodulehandler('forms', 'formulize');
 		$element_handler = xoops_getmodulehandler('elements', 'formulize');
-		
+
 		$pendingProfileVars = array();
 		$pendingUserVars = array();
 		$rawSubmitted2faMethod = null;
@@ -615,10 +615,10 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			if(!$accountElement) {
 				continue;
 			}
-			
+
 			$elementId = $accountElement->getVar('ele_id');
 			$userProperty = $accountElement->userProperty;
-			
+
 			if($accountElement->readOnly) {
 				continue; // system-managed property
 			}
@@ -628,9 +628,9 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			if(!isset($_POST['decue_'.$formId.'_'.$entryId.'_'.$elementId])) {
 				continue; // element not on this form/page
 			}
-			
+
 			$value = isset($_POST['de_'.$formId.'_'.$entryId.'_'.$elementId]) ? $_POST['de_'.$formId.'_'.$entryId.'_'.$elementId] : '';
-			
+
 			// Handle password encryption
 			if($userProperty == 'pass') {
 				if($value === '') {
@@ -645,7 +645,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				$pendingUserVars['salt'] = $salt;
 				$pendingUserVars['enc_type'] = $enc_type;
 			}
-			
+
 			// Handle profile properties
 			if(substr($userProperty, 0, 8) == 'profile:') {
 				$property = substr($userProperty, 8);
@@ -680,7 +680,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				$pendingUserVars[$userProperty] = $value;
 			}
 		}
-		
+
 		return array(
 			'pendingUserVars' => $pendingUserVars,
 			'pendingProfileVars' => $pendingProfileVars,
@@ -700,7 +700,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 		$criteria_2fagroups = new Criteria('conf_name', 'auth_2fa_groups');
 		$auth_2fa_groups_cfg = icms::handler('icms_config')->getConfigs($criteria_2fagroups);
 		$auth_2fa_groups = ($auth_2fa_groups_cfg) ? $auth_2fa_groups_cfg[0]->getConfValueForOutput() : array();
-		
+
 		// Get submitted phone to check SMS-without-phone case
 		$phoneEleForCheck = $element_handler->get('formulize_user_account_phone_'.$formId);
 		$submittedPhoneForCheck = '';
@@ -708,12 +708,12 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			$phoneEleIdForCheck = $phoneEleForCheck->getVar('ele_id');
 			$submittedPhoneForCheck = preg_replace('/[^0-9]/', '', isset($_POST['de_'.$formId.'_'.$entryId.'_'.$phoneEleIdForCheck]) ? $_POST['de_'.$formId.'_'.$entryId.'_'.$phoneEleIdForCheck] : '');
 		}
-		
+
 		if(($value == TFA_OFF && array_intersect($edituserGroups, (array)$auth_2fa_groups))
 		   || ($value == TFA_SMS && !$submittedPhoneForCheck)) {
 			return TFA_EMAIL;
 		}
-		
+
 		return $value;
 	}
 
@@ -726,7 +726,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 		if(!$entryUserId || !$xoopsUser || intval($entryUserId) != intval($xoopsUser->getVar('uid'))) {
 			return true; // Not editing own account
 		}
-		
+
 		$criteria_2fa_sv = new Criteria('conf_name', 'auth_2fa');
 		$is2faOn = false;
 		if($auth_2fa_sv = icms::handler('icms_config')->getConfigs($criteria_2fa_sv)) {
@@ -735,24 +735,24 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 		if(!$is2faOn) {
 			return true; // 2FA not enabled
 		}
-		
+
 		include_once XOOPS_ROOT_PATH . '/include/2fa/manage.php';
 		self::$submittedValues = $_POST;
 		$newEmail  = isset($pendingUserVars['email']) ? $pendingUserVars['email'] : $userObject->getVar('email');
 		$newPhone  = isset($pendingProfileVars['2faphone']) ? $pendingProfileVars['2faphone'] : $profile->getVar('2faphone');
 		$effectiveNewMethod = $rawSubmitted2faMethod !== null ? $rawSubmitted2faMethod : $old2faMethod;
-		
+
 		$needsValidation = (
 			($effectiveNewMethod != $old2faMethod) ||
 			(($old2faMethod == TFA_SMS || $effectiveNewMethod == TFA_SMS) && $newPhone != $old2faPhone) ||
 			(($old2faMethod == TFA_EMAIL || $old2faMethod == TFA_OFF || $effectiveNewMethod == TFA_EMAIL || $effectiveNewMethod == TFA_OFF) && $oldEmail && $newEmail != $oldEmail) ||
 			$passwordChanged
 		);
-		
+
 		if(!$needsValidation) {
 			return true;
 		}
-		
+
 		// Two-phase (verify the OLD contact, then the NEW contact) is required in three cases:
 		// 1. Staying on email, email is changing. Email is the default 2FA contact when no method
 		//    is set, so TFA_OFF is treated as email-ish here: changing your email while 2FA is off
@@ -766,7 +766,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			($old2faMethod == TFA_SMS && $effectiveNewMethod == TFA_SMS && $old2faPhone && $newPhone != $old2faPhone) ||
 			($rawSubmitted2faMethod !== null && $old2faMethod != TFA_OFF && $rawSubmitted2faMethod != TFA_OFF && $rawSubmitted2faMethod != $old2faMethod)
 		);
-		
+
 		if($contactChanging) {
 			$step1Token = isset($_POST['formulize_tfa_step1token']) ? trim($_POST['formulize_tfa_step1token']) : '';
 			if($rawSubmitted2faMethod == TFA_APP) {
@@ -796,19 +796,19 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 				return false;
 			}
 		}
-		
+
 		$submittedCode = isset($_POST['formulize_tfa_code']) ? trim($_POST['formulize_tfa_code']) : '';
 		if(!validateCode($submittedCode, intval($entryUserId))) {
 			return false;
 		}
-		
+
 		// Validation passed -- now safe to delete the app secret if switching away from app
 		if($cleanupAppSecret) {
 			global $xoopsDB;
 			$sql = 'DELETE FROM '.$xoopsDB->prefix('tfa_codes').' WHERE uid = '.intval($userObject->getVar('uid')).' AND method = '.TFA_APP;
 			$xoopsDB->queryF($sql);
 		}
-		
+
 		return true;
 	}
 
@@ -825,10 +825,10 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			}
 			$userObject->setVar('login_name', $altLoginName);
 		}
-		
+
 		$member_handler = xoops_gethandler('member');
 		$profile_handler = xoops_getmodulehandler('profile', 'profile');
-		
+
 		if($member_handler->insertUser($userObject)) {
 			$userId = $userObject->getVar('uid');
 			if(!$entryUserId) {
@@ -837,7 +837,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			$profile_handler->insert($profile);
 			return $userId;
 		}
-		
+
 		return false;
 	}
 
@@ -881,14 +881,14 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			trigger_error("Invalid profile column name: $column", E_USER_WARNING);
 			return "1=0"; // Return a clause that will never match
 		}
-		
+
 		// Validate operator against whitelist
 		$validOperators = array('=', '!=', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE');
 		if(!in_array($operator, $validOperators, true)) {
 			trigger_error("Invalid operator: $operator", E_USER_WARNING);
 			return "1=0";
 		}
-		
+
 		$safeTermClause = $operator . $quotes . $likebits . formulize_db_escape($term) . $likebits . $quotes;
 		return "EXISTS("
 			. "SELECT 1 FROM " . $xoopsDB->prefix('profile_profile') . " AS pp"
@@ -913,7 +913,7 @@ class formulizeUserAccountElementHandler extends formulizeElementsHandler {
 			trigger_error("Invalid user table column name: $column", E_USER_WARNING);
 			return "1=0"; // Return a clause that will never match
 		}
-		
+
 		// Validate operator against whitelist
 		$validOperators = array('=', '!=', '<', '>', '<=', '>=', 'LIKE', 'NOT LIKE');
 		if(!in_array($operator, $validOperators, true)) {

--- a/modules/formulize/class/userEauTypeElement.php
+++ b/modules/formulize/class/userEauTypeElement.php
@@ -47,9 +47,10 @@ class formulizeUserEauTypeElementHandler extends formulizeVirtualElementHandler 
 	 *
 	 * Returns "Regular" plus one entry per EAU form (singular name, or form_title as fallback).
 	 *
+	 * @param object $element The element object (not needed - the options come from the EAU forms)
 	 * @return array Associative array of option value => display label
 	 */
-	function getFilterOptions() {
+	function getFilterOptions($element = null) {
 		global $xoopsDB;
 		$options    = array('Regular' => 'Regular');
 		$formsTable = $xoopsDB->prefix('formulize_id');

--- a/modules/formulize/class/usersGroupsPerms.php
+++ b/modules/formulize/class/usersGroupsPerms.php
@@ -642,7 +642,7 @@ class formulizePermHandler {
 		}
 
 		// Sync ele_value['formlink_scope'] for checkbox elements
-		if (($ele_type == "checkbox" || $ele_type == "checkboxLinked") && isset($ele_value['formlink_scope'])) {
+		if (anyCheckboxElementType($ele_type) && isset($ele_value['formlink_scope'])) {
 			list($newScope, $scopeChanged) = $syncCommaSeparated($ele_value['formlink_scope']);
 			if ($scopeChanged) {
 				$ele_value['formlink_scope'] = $newScope;

--- a/modules/formulize/class/ynElement.php
+++ b/modules/formulize/class/ynElement.php
@@ -102,6 +102,57 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 		);
 	}
 
+	/**
+	 * Return the filter options for a yes/no element.
+	 *
+	 * Unlike a plain radio element, this element's ele_value keys are the _YES/_NO sentinel
+	 * tokens, and the values stored in the database are the codes 1 (yes) and 2 (no). So the
+	 * filter options must be keyed on the translated Yes/No text that users actually see and
+	 * type - prepareLiteralTextForDB() below converts that text back into the 1/2 codes when
+	 * the filter is applied to the database.
+	 * @param object $element The element object
+	 * @return array Associative array of filter value => label
+	 */
+	function getFilterOptions($element = null) {
+		return array(_YES => 1, _NO => 2);
+	}
+
+	/**
+	 * A yes/no element's ele_value keys are the _YES/_NO sentinel tokens, and the value coming
+	 * from a previous entry has already been converted to the translated Yes/No text by
+	 * prepareDataForDataset(). So the option text match that the radio element does would never
+	 * succeed here - map the translated text onto the fixed option positions instead (Yes is
+	 * always the first option, No always the second).
+	 * @param string $value The value from the previous entry (as prepared for a dataset)
+	 * @param array $prevEleValue The ele_value of the element in the previous form (not needed)
+	 * @return int|bool The zero-based position of the matching option, or false if there is no match
+	 */
+	function previousEntryOptionKey($value, $prevEleValue) {
+		if($value == _formulize_TEMP_QYES) {
+			return 0;
+		} elseif($value == _formulize_TEMP_QNO) {
+			return 1;
+		}
+		return false;
+	}
+
+	/**
+	 * This element's ele_value keys are the _YES/_NO sentinel tokens, not display text, so swap
+	 * them for the Yes/No language constants. This is done at runtime rather than being baked
+	 * into ele_value, since the webmaster and the user might be in different languages.
+	 * @param string $optionKey One of the keys of the element's ele_value
+	 * @param object $element The element object
+	 * @return string The label to display for this option
+	 */
+	function getOptionLabel($optionKey, $element) {
+		if($optionKey == "_YES") {
+			return _YES;
+		} elseif($optionKey == "_NO") {
+			return _NO;
+		}
+		return $optionKey;
+	}
+
 	// this method would gather any data that we need to pass to the template, besides the ele_value and other properties that are already part of the basic element class
 	// it receives the element object and returns an array of data that will go to the admin UI template
 	// when dealing with new elements, $element might be FALSE

--- a/modules/formulize/class/ynElement.php
+++ b/modules/formulize/class/ynElement.php
@@ -181,7 +181,7 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	}
 
 	// this method will read what the user submitted, and package it up however we want for insertion into the form's datatable
-	// You can return {WRITEASNULL} to cause a null value to be saved in the database
+	// You can return null to cause a null value to be saved in the database
 	// $value is what the user submitted
 	// $element is the element object
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.

--- a/modules/formulize/class/ynElement.php
+++ b/modules/formulize/class/ynElement.php
@@ -32,7 +32,29 @@ require_once XOOPS_ROOT_PATH . "/modules/formulize/class/elements.php"; // you n
 require_once XOOPS_ROOT_PATH . "/modules/formulize/include/functions.php";
 require_once XOOPS_ROOT_PATH . "/modules/formulize/class/radioElement.php";
 
+/**
+ * The Yes/No element speaks two vocabularies, and it is important to know which one any given
+ * value belongs to:
+ *
+ * 1. THE DATABASE CODES: YES_DB_VALUE (1) and NO_DB_VALUE (2). These language-independent codes
+ *    are what is stored in the data tables, and they are the keys of ele_value (following the
+ *    radio-family convention that ele_value keys are the values stored in the database). The
+ *    positions submitted by the rendered radio buttons also happen to coincide with the codes:
+ *    Yes is always the first option (position 1) and No the second (position 2).
+ *
+ * 2. THE TRANSLATED TEXT: the _YES and _NO language constants ("Yes"/"No", "Oui"/"Non", etc,
+ *    according to the active language). This is what users see and type, everywhere: rendered
+ *    options (getListOptions), dataset values (prepareDataForDataset), and filter options
+ *    (getFilterOptions). Text is converted back into the codes by prepareLiteralTextForDB.
+ *
+ * Conversions between the two vocabularies happen only in this file. Note that ele_value was
+ * historically keyed by the sentinel strings '_YES' and '_NO' instead of the codes - the getVar
+ * override below migrates that legacy structure whenever ele_value is read.
+ */
 class formulizeYnElement extends formulizeRadioElement {
+
+	const YES_DB_VALUE = 1; // the language-independent code stored in the database when Yes is selected
+	const NO_DB_VALUE = 2; // the language-independent code stored in the database when No is selected
 
 	var $defaultValueKey;
 	public static $category = "lists";
@@ -42,6 +64,18 @@ class formulizeYnElement extends formulizeRadioElement {
 		$this->name = "Yes/No Radio Buttons";
 		$this->needsDataType = false; // set to false if you're going force a specific datatype for this element using the overrideDataType
 		$this->overrideDataType = "tinyint"; // use this to set a datatype for the database if you need the element to always have one (like 'date').  set needsDataType to false if you use this.
+	}
+
+	// This element's ele_value structure changed over time (it used to be keyed by the sentinel
+	// strings '_YES'/'_NO' rather than the database codes). Present the current structure to all
+	// callers, regardless of what is stored in the database, by migrating legacy values whenever
+	// ele_value is read
+	public function getVar($key, $format = 's') {
+		$value = parent::getVar($key, $format);
+		if($key == 'ele_value' AND is_array($value)) {
+			$value = formulizeYnElementHandler::backwardsCompatibility($value);
+		}
+		return $value;
 	}
 
 	/**
@@ -63,12 +97,46 @@ class formulizeYnElement extends formulizeRadioElement {
 - A Yes/No radio button that defaults to Yes: { defaultvalue: 1 }";
 	}
 
+	// return the set of options for this element, as an array of translated Yes/No text => selected flag.
+	// If a state array is passed in (an ele_value as prepared by loadValue, reflecting the current entry),
+	// the returned options carry that state's selection flags; otherwise the configured defaults are returned.
+	function getListOptions($ele_value = null) {
+		$ele_value = is_array($ele_value) ? formulizeYnElementHandler::backwardsCompatibility($ele_value) : $this->getVar('ele_value');
+		$options = [_YES => 0, _NO => 0];
+		foreach($ele_value as $optionKey=>$selected) {
+			if($optionKey == self::YES_DB_VALUE) {
+				$options[_YES] = $selected;
+			} elseif($optionKey == self::NO_DB_VALUE) {
+				$options[_NO] = $selected;
+			}
+		}
+		return $options;
+	}
+
 }
 #[AllowDynamicProperties]
 class formulizeYnElementHandler extends formulizeRadioElementHandler {
 
 	function create() {
 		return new formulizeYnElement();
+	}
+
+	/**
+	 * Migrate a legacy ele_value structure to the current one. Historically, ele_value was keyed
+	 * by the sentinel strings '_YES' and '_NO'. The current structure is keyed by the database
+	 * codes (YES_DB_VALUE and NO_DB_VALUE), matching the radio-family convention that ele_value
+	 * keys are the values stored in the database. Idempotent - current structures pass through.
+	 * @param array $ele_value The raw ele_value
+	 * @return array The ele_value in the current structure
+	 */
+	static function backwardsCompatibility($ele_value) {
+		if(isset($ele_value['_YES']) OR isset($ele_value['_NO'])) {
+			$ele_value = array(
+				formulizeYnElement::YES_DB_VALUE => isset($ele_value['_YES']) ? $ele_value['_YES'] : 0,
+				formulizeYnElement::NO_DB_VALUE => isset($ele_value['_NO']) ? $ele_value['_NO'] : 0
+			);
+		}
+		return $ele_value;
 	}
 
 	/**
@@ -81,13 +149,14 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	 * @return array An array of properties ready for the object. Usually just ele_value but could be others too.
 	 */
 	public function validateEleValuePublicAPIProperties($properties, $ele_value = [], $elementIdentifier = null) {
+		$ele_value = self::backwardsCompatibility($ele_value); // make sure anything we write back out is in the current structure
 		if(isset($properties['defaultvalue'])) {
 			if($properties['defaultvalue']) {
-				$ele_value['_YES'] = 1;
-				$ele_value['_NO'] = 0;
+				$ele_value[formulizeYnElement::YES_DB_VALUE] = 1;
+				$ele_value[formulizeYnElement::NO_DB_VALUE] = 0;
 			} elseif(!$properties['defaultvalue']) {
-				$ele_value['_YES'] = 0;
-				$ele_value['_NO'] = 1;
+				$ele_value[formulizeYnElement::YES_DB_VALUE] = 0;
+				$ele_value[formulizeYnElement::NO_DB_VALUE] = 1;
 			}
 		}
 		return [
@@ -97,29 +166,28 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 
 	public function getDefaultEleValue() {
 		return array(
-			'_YES' => 0, // a 1/0 indicating if Yes is the default
-			'_NO' => 0 // a 1/0 indicating if No is the default
+			formulizeYnElement::YES_DB_VALUE => 0, // a 1/0 indicating if Yes is the default
+			formulizeYnElement::NO_DB_VALUE => 0 // a 1/0 indicating if No is the default
 		);
 	}
 
 	/**
 	 * Return the filter options for a yes/no element.
 	 *
-	 * Unlike a plain radio element, this element's ele_value keys are the _YES/_NO sentinel
-	 * tokens, and the values stored in the database are the codes 1 (yes) and 2 (no). So the
-	 * filter options must be keyed on the translated Yes/No text that users actually see and
-	 * type - prepareLiteralTextForDB() below converts that text back into the 1/2 codes when
-	 * the filter is applied to the database.
+	 * The values stored in the database are the language-independent codes, but users see and
+	 * type the translated Yes/No text, so the filter options are keyed on that text -
+	 * prepareLiteralTextForDB() below converts the text back into the codes when the filter is
+	 * applied to the database.
 	 * @param object $element The element object
 	 * @return array Associative array of filter value => label
 	 */
 	function getFilterOptions($element = null) {
-		return array(_YES => 1, _NO => 2);
+		return array(_YES => formulizeYnElement::YES_DB_VALUE, _NO => formulizeYnElement::NO_DB_VALUE);
 	}
 
 	/**
-	 * A yes/no element's ele_value keys are the _YES/_NO sentinel tokens, and the value coming
-	 * from a previous entry has already been converted to the translated Yes/No text by
+	 * A yes/no element's ele_value keys are the database codes, and the value coming from a
+	 * previous entry has already been converted to the translated Yes/No text by
 	 * prepareDataForDataset(). So the option text match that the radio element does would never
 	 * succeed here - map the translated text onto the fixed option positions instead (Yes is
 	 * always the first option, No always the second).
@@ -128,29 +196,12 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	 * @return int|bool The zero-based position of the matching option, or false if there is no match
 	 */
 	function previousEntryOptionKey($value, $prevEleValue) {
-		if($value == _formulize_TEMP_QYES) {
+		if($value == _YES) {
 			return 0;
-		} elseif($value == _formulize_TEMP_QNO) {
+		} elseif($value == _NO) {
 			return 1;
 		}
 		return false;
-	}
-
-	/**
-	 * This element's ele_value keys are the _YES/_NO sentinel tokens, not display text, so swap
-	 * them for the Yes/No language constants. This is done at runtime rather than being baked
-	 * into ele_value, since the webmaster and the user might be in different languages.
-	 * @param string $optionKey One of the keys of the element's ele_value
-	 * @param object $element The element object
-	 * @return string The label to display for this option
-	 */
-	function getOptionLabel($optionKey, $element) {
-		if($optionKey == "_YES") {
-			return _YES;
-		} elseif($optionKey == "_NO") {
-			return _NO;
-		}
-		return $optionKey;
 	}
 
 	// this method would gather any data that we need to pass to the template, besides the ele_value and other properties that are already part of the basic element class
@@ -159,10 +210,13 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	// can organize template data into two top level keys, advanced-tab-values and options-tab-values, if there are some options for the element type that appear on the Advanced tab in the admin UI. This requires an additional template file with _advanced.html as the end of the name. Text elements have an example.
 	function adminPrepare($element) {
 		$dataToSendToTemplate = array();
+		// send the database codes to the template, so the radio buttons there can submit them back to adminSave
+		$dataToSendToTemplate['yes_db_value'] = formulizeYnElement::YES_DB_VALUE;
+		$dataToSendToTemplate['no_db_value'] = formulizeYnElement::NO_DB_VALUE;
 		if($element != false) {
 			$ele_value = $element->getVar('ele_value');
-			$dataToSendToTemplate['ele_value_yes'] = $ele_value['_YES'];
-    	$dataToSendToTemplate['ele_value_no'] = $ele_value['_NO'];
+			$dataToSendToTemplate['ele_value_yes'] = $ele_value[formulizeYnElement::YES_DB_VALUE];
+    	$dataToSendToTemplate['ele_value_no'] = $ele_value[formulizeYnElement::NO_DB_VALUE];
 		}
 		return $dataToSendToTemplate;
 	}
@@ -177,15 +231,15 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 		$changed = false;
 		if(is_object($element) AND is_subclass_of($element, 'formulizeElement')) {
 			$ele_value = array();
-			if($_POST['elements_ele_value'] == "_YES") {
-				$ele_value['_YES'] = 1;
-				$ele_value['_NO'] = 0;
-			} elseif($_POST['elements_ele_value'] == "_NO") {
-				$ele_value['_YES'] = 0;
-				$ele_value['_NO'] = 1;
+			if($_POST['elements_ele_value'] == formulizeYnElement::YES_DB_VALUE) {
+				$ele_value[formulizeYnElement::YES_DB_VALUE] = 1;
+				$ele_value[formulizeYnElement::NO_DB_VALUE] = 0;
+			} elseif($_POST['elements_ele_value'] == formulizeYnElement::NO_DB_VALUE) {
+				$ele_value[formulizeYnElement::YES_DB_VALUE] = 0;
+				$ele_value[formulizeYnElement::NO_DB_VALUE] = 1;
 			} else {
-				$ele_value['_YES'] = 0;
-				$ele_value['_NO'] = 0;
+				$ele_value[formulizeYnElement::YES_DB_VALUE] = 0;
+				$ele_value[formulizeYnElement::NO_DB_VALUE] = 0;
 			}
 			$element->setVar('ele_value', $ele_value);
 		}
@@ -202,10 +256,10 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	function getDefaultValue($element, $entry_id = 'new') {
 		$ele_value = $element->getVar('ele_value');
 		$default = null; // no default configured (neither Yes nor No flagged)
-    if($ele_value["_YES"] == 1) {
-      $default = 1;
-    } elseif($ele_value["_NO"] == 1) {
-      $default = 2;
+    if($ele_value[formulizeYnElement::YES_DB_VALUE] == 1) {
+      $default = formulizeYnElement::YES_DB_VALUE;
+    } elseif($ele_value[formulizeYnElement::NO_DB_VALUE] == 1) {
+      $default = formulizeYnElement::NO_DB_VALUE;
     }
 		return $default;
 	}
@@ -216,17 +270,12 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	// $value is the value that was retrieved from the database for this element in the active entry.  It is a raw value, no processing has been applied, it is exactly what is in the database (as prepared in the prepareDataForSaving method and then written to the DB)
 	// $entry_id is the ID of the entry being loaded
 	function loadValue($element, $value, $entry_id) {
-		if($value == 1)
-		{
-			$ele_value = array('_YES'=>1, '_NO'=>0);
-		}
-		elseif($value == 2)
-		{
-			$ele_value = array('_YES'=>0, '_NO'=>1);
-		}
-		else
-		{
-			$ele_value = array('_YES'=>0, '_NO'=>0);
+		if($value == formulizeYnElement::YES_DB_VALUE) {
+			$ele_value = array(formulizeYnElement::YES_DB_VALUE=>1, formulizeYnElement::NO_DB_VALUE=>0);
+		} elseif($value == formulizeYnElement::NO_DB_VALUE) {
+			$ele_value = array(formulizeYnElement::YES_DB_VALUE=>0, formulizeYnElement::NO_DB_VALUE=>1);
+		} else {
+			$ele_value = array(formulizeYnElement::YES_DB_VALUE=>0, formulizeYnElement::NO_DB_VALUE=>0);
 		}
 		return $ele_value;
 	}
@@ -238,6 +287,10 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	// $entry_id is the ID number of the entry that this data is being saved into. Can be "new", or null in the event of a subformblank entry being saved.
 	// $subformBlankCounter is the counter for the subform blank entries, if applicable
 	function prepareDataForSaving($value, $element, $entry_id=null, $subformBlankCounter=null) {
+		// the rendered radio buttons submit the position of the chosen option (see the radio
+		// element's render method), and the positions happen to coincide with the database codes:
+		// Yes is always the first option (position 1 = YES_DB_VALUE) and No the second
+		// (position 2 = NO_DB_VALUE), so the submitted value can be stored as is
 		return $value;
 	}
 
@@ -256,10 +309,10 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	// $handle is the element handle for the field that we're retrieving this for
 	// $entry_id is the entry id of the entry in the form that we're retrieving this for
 	function prepareDataForDataset($value, $handle, $entry_id) {
-		if ($value == "1") {
-			$value = _formulize_TEMP_QYES;
-		} elseif ($value == "2") {
-			$value = _formulize_TEMP_QNO;
+		if ($value == formulizeYnElement::YES_DB_VALUE) {
+			$value = _YES;
+		} elseif ($value == formulizeYnElement::NO_DB_VALUE) {
+			$value = _NO;
 		} else {
 			$value = "";
 		}
@@ -275,10 +328,10 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 	// LINKED ELEMENTS AND UITEXT ARE RESOLVED PRIOR TO THIS METHOD BEING CALLED
 	function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
 		// since we're matching based on even a single character match between the query and the yes/no language constants, if the current language has the same letters or letter combinations in yes and no, then sometimes only Yes may be searched for
-		if (($value AND strstr(strtoupper(_formulize_TEMP_QYES), strtoupper($value))) OR strtoupper($value) == "YES") {
-			$value = 1;
-		} elseif (($value AND strstr(strtoupper(_formulize_TEMP_QNO), strtoupper($value))) OR strtoupper($value) == "NO") {
-			$value = 2;
+		if (($value AND strstr(strtoupper(_YES), strtoupper($value))) OR strtoupper($value) == "YES") {
+			$value = formulizeYnElement::YES_DB_VALUE;
+		} elseif (($value AND strstr(strtoupper(_NO), strtoupper($value))) OR strtoupper($value) == "NO") {
+			$value = formulizeYnElement::NO_DB_VALUE;
 		} elseif(!is_numeric($value)) {
 			$value = "";
 		}

--- a/modules/formulize/class/ynElement.php
+++ b/modules/formulize/class/ynElement.php
@@ -332,9 +332,15 @@ class formulizeYnElementHandler extends formulizeRadioElementHandler {
 			$value = formulizeYnElement::YES_DB_VALUE;
 		} elseif (($value AND strstr(strtoupper(_NO), strtoupper($value))) OR strtoupper($value) == "NO") {
 			$value = formulizeYnElement::NO_DB_VALUE;
-		} elseif(!is_numeric($value)) {
-			$value = "";
+		} elseif (
+			$value !== ""
+			AND $value !== null
+      AND $value != formulizeYnElement::YES_DB_VALUE
+      AND $value != formulizeYnElement::NO_DB_VALUE
+		) {
+			$value = false; // not a valid code, so there is no match
 		}
+
 		return $value;
 	}
 

--- a/modules/formulize/formulize_xhr_responder.php
+++ b/modules/formulize/formulize_xhr_responder.php
@@ -319,7 +319,7 @@ switch($op) {
         $databaseReadyValue = 'new';
       } else {
         $databaseReadyValue = prepDataForWrite($passedElementObject, $v, $entryId);
-        $databaseReadyValue = $databaseReadyValue === "{WRITEASNULL}" ? NULL : $databaseReadyValue;
+        $databaseReadyValue = $databaseReadyValue === "{WRITEASNULL}" ? null : $databaseReadyValue;
       }
       $GLOBALS['formulize_asynchronousFormDataInDatabaseReadyFormat'][$passedEntryId][$handle] = $databaseReadyValue;
       $apiFormatValue = prepvalues($databaseReadyValue, $handle, $passedEntryId); // will be an array

--- a/modules/formulize/include/common.php
+++ b/modules/formulize/include/common.php
@@ -39,6 +39,7 @@ include_once XOOPS_ROOT_PATH . '/class/xoopsformloader.php';
 require_once XOOPS_ROOT_PATH . '/modules/system/constants.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/formulize.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/frameworks.php';
+include_once XOOPS_ROOT_PATH . '/modules/formulize/class/elements.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/elementrenderer.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/constants.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/functions.php';

--- a/modules/formulize/include/common.php
+++ b/modules/formulize/include/common.php
@@ -41,6 +41,10 @@ include_once XOOPS_ROOT_PATH . '/modules/formulize/class/formulize.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/frameworks.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/elements.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/class/elementrenderer.php';
+include_once XOOPS_ROOT_PATH . '/modules/formulize/class/usersGroupsPerms.php';
+include_once XOOPS_ROOT_PATH . '/modules/formulize/class/data.php';
+include_once XOOPS_ROOT_PATH . '/modules/formulize/class/screen.php';
+include_once XOOPS_ROOT_PATH . "/modules/formulize/class/ynElement.php"; // for the yn database value constants used in the yn mapping
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/constants.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/functions.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/configsettings.php';
@@ -54,9 +58,6 @@ include_once XOOPS_ROOT_PATH . "/modules/formulize/include/mapdisplay.php";
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/extract.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/usersAndGroups.php';
 include_once XOOPS_ROOT_PATH . '/modules/formulize/include/customCodeForApplications.php';
-include_once XOOPS_ROOT_PATH . '/modules/formulize/class/usersGroupsPerms.php';
-include_once XOOPS_ROOT_PATH . '/modules/formulize/class/data.php';
-include_once XOOPS_ROOT_PATH . '/modules/formulize/class/screen.php';
 
 // look up the form id and title of every form and create constants of the format {FORM_HANDLE}_FORM_ID with spaces converted to underscores
 global $xoopsDB;

--- a/modules/formulize/include/elementdisplay.php
+++ b/modules/formulize/include/elementdisplay.php
@@ -239,7 +239,7 @@ EOF;
 										if($js = $form_ele->renderValidationJS()) {
 											$GLOBALS['formulize_renderedElementsValidationJS'][strval($GLOBALS['formulize_thisRendering'])][$renderedElementMarkupName] = $js;
 										}
-				          } elseif($element->getVar('ele_required') AND ($element->getVar('ele_type') == "text" OR $element->getVar('ele_type') == "textarea") AND !$isDisabled) {
+				          } elseif($element->getVar('ele_required') AND elementTypeIsOrExtends($element, "text") AND !$isDisabled) { // text elements and everything based on them (textarea, number, and any custom subclass) get the generic non-empty check
 				            $eltname    = $form_ele->getName();
 				            $eltcaption = $form_ele->getCaption();
 				            $eltmsg = empty($eltcaption) ? sprintf( _FORM_ENTER, $eltname ) : sprintf( _FORM_ENTER, $eltcaption );

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -4567,6 +4567,8 @@ function processClickedCustomButton($clickedElements, $clickedValues, $clickedAc
 		$config_handler = xoops_gethandler('config');
 		$formulizeConfig = $config_handler->getConfigsByCat(0, getFormulizeModId());
 		$useOldCustomButtonEffectWriting = $formulizeConfig['useOldCustomButtonEffectWriting'];
+		$newEntriesToNotifyAbout = array();
+		$updatedEntriesToNotifyAbout = array();
 		foreach($caEntries as $id=>$thisEntry) { // loop through all the entries this button click applies to
 			$maxIdReq = 0;
 			$needToSetOwner = false;
@@ -4585,7 +4587,13 @@ function processClickedCustomButton($clickedElements, $clickedValues, $clickedAc
 				}
 			}
 			if(count($valuesToWrite)>0) {
-				$maxIdReq = $data_handler->writeEntry($thisEntry, $valuesToWrite);
+				if($maxIdReq = $data_handler->writeEntry($thisEntry, $valuesToWrite)) {
+					if($thisEntry == "new") {
+						$newEntriesToNotifyAbout[] = $maxIdReq;
+					} else {
+						$updatedEntriesToNotifyAbout[] = $maxIdReq;
+					}
+				}
 			}
 			if($maxIdReq) {
                 // NOTE: if there are derived values involving something other than the fid of the updated form, and the frid of the screen, then they won't be updated when this custom button is clicked!!
@@ -4596,6 +4604,12 @@ function processClickedCustomButton($clickedElements, $clickedValues, $clickedAc
         			$data_handler->setEntryOwnerGroups($newOwner, $maxIdReq);
 				}
             }
+		}
+		if(!empty($newEntriesToNotifyAbout)) {
+			sendNotifications($formId, 'new_entry', $newEntriesToNotifyAbout);
+		}
+		if(!empty($updatedEntriesToNotifyAbout)) {
+			sendNotifications($formId, 'update_entry', $updatedEntriesToNotifyAbout);
 		}
 	}
 	return $clickedMessageText;

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -3198,14 +3198,11 @@ function calcValuePlusText($value, $handle, $col, $calc, $groupingValue) {
   $uitexts = $element->getVar('ele_uitext');
   $value = formulize_handleRandomAndDateText(formulize_swapUIText($value, $uitexts));
   if(substr($value, 0, 6)=="{OTHER") { $value = _formulize_OPT_OTHER; }
-  if($element->getVar('ele_type')=='yn') {
-	if($value == "1") {
-			$value = _formulize_TEMP_QYES;
-		} elseif($value == "2") {
-			$value = _formulize_TEMP_QNO;
-		} else {
-			$value = "";
-		}
+  // yn elements (and any custom types based on them) store 1/2 codes, so let the element class
+  // convert the stored code into the Yes/No text users should see, via prepareDataForDataset
+  if(elementTypeIsOrExtends($element, 'yn')) {
+		$ynTypeHandler = xoops_getmodulehandler($element->getVar('ele_type')."Element", "formulize");
+		$value = $ynTypeHandler->prepareDataForDataset($value, $handle, 0);
   }
   return $value;
 }

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -1502,10 +1502,6 @@ function makeJoinTextIfFormLinksToIntermediary($ele_value, $linkSideElementHandl
  */
 function multipleValuesAllowedForElement($elementHandleOrId) {
 	$element_handler = xoops_getmodulehandler('elements', 'formulize');
-	// canHaveMultipleValues is computed once per element, when it is loaded (see _setElementProperties
-	// in elements.php), and is correct for every element type - checkbox-family types set it true in
-	// their constructor, select-family types compute it from their multiple-selections setting via
-	// setCanHaveMultipleValues(), and any custom type gets whichever of those it inherits, or false
 	$element = $element_handler->get($elementHandleOrId);
 	return $element ? $element->canHaveMultipleValues : false;
 }
@@ -2334,7 +2330,15 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 							$queryElementMetaData = formulize_getElementMetaData($ifParts[0], true);
 							$ele_value = unserialize($queryElementMetaData['ele_value']);
 							$cleanSearchTerm = convertStringToUseSpecialCharsToMatchDB($ifParts[1]);
-							if (elementTypeIsOrExtends($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], 'checkboxLinked') or (($ele_value[0] > 1 or $ele_value[8]) and $ele_value[1])) { // if checkbox (or any type based on checkboxLinked), or a selectbox where the element supports multiple selections [1], and number of rows is greater than 1 [0], or it is an autocomplete element [8]
+							// if any linked checkbox
+							// or if any select type (which will necessarily be only linked ones since we're in a linked if statement from above), that supports multiple selections [1], and (number of rows is greater than 1 [0] or it is an autocomplete element [8])
+							if (elementTypeIsOrExtends($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], 'checkboxLinked')
+								OR (
+									elementTypeIsOrExtends($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], 'select')
+									AND ($ele_value[0] > 1 OR $ele_value[8])
+									AND $ele_value[1]
+								)
+							) {
 								if (is_numeric($ifParts[1])) {
 									$operator = "=";
 									$quotes = "";

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -1504,7 +1504,7 @@ function makeJoinTextIfFormLinksToIntermediary($ele_value, $linkSideElementHandl
 function multipleValuesAllowedForElement($elementHandleOrId) {
 	$metaData = formulize_getElementMetaData($elementHandleOrId, !is_numeric($elementHandleOrId));
 	$ele_value = unserialize($metaData['ele_value']);
-	if ($metaData['ele_type'] == 'checkbox' OR $metaData['ele_type'] == 'checkboxLinked' OR (is_array($ele_value) AND isset($ele_value[1]) AND $ele_value[1])) {
+	if (anyCheckboxElementType($metaData['ele_type']) OR (is_array($ele_value) AND isset($ele_value[1]) AND $ele_value[1])) {
 		return true;
 	}
 	return false;
@@ -2604,7 +2604,7 @@ function formulize_mapFormFieldFilter($element_id, $formFieldFilterMap)
 			$formFieldFilterMap[$array['id_form']][$element_id]['islinked'] = false;
 		}
 		$formFieldFilterMap[$array['id_form']][$element_id]['isyn'] = $array['ele_type'] == "yn" ? true : false;
-		if (($array['ele_type'] == "radio" OR $array['ele_type'] == "checkbox" OR anySelectElementType($array['ele_type'])) AND strstr($array['ele_value'], "{OTHER|")) {
+		if ((anyRadioElementType($array['ele_type']) OR anyCheckboxElementType($array['ele_type']) OR anySelectElementType($array['ele_type'])) AND strstr($array['ele_value'], "{OTHER|")) {
 			$formFieldFilterMap[$array['id_form']][$element_id]['hasother'] = true;
 		} else {
 			$formFieldFilterMap[$array['id_form']][$element_id]['hasother'] = false;
@@ -2669,7 +2669,7 @@ function formulize_elementAllowsMultipleSelections($elementOrHandle, $isHandle =
 	static $cachedElements = array();
 	if (!isset($cachedElements[$elementOrHandle])) {
 		$evqRow = formulize_getElementMetaData($elementOrHandle, $isHandle);
-		if ($evqRow['ele_type'] == 'checkbox' OR $evqRow['ele_type'] == 'checkboxLinked') {
+		if (anyCheckboxElementType($evqRow['ele_type'])) {
 			$cachedElements[$elementOrHandle] = true;
 		} elseif (anySelectElementType($evqRow['ele_type'])) {
 			$ele_value = unserialize($evqRow['ele_value']);

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -1497,17 +1497,17 @@ function makeJoinTextIfFormLinksToIntermediary($ele_value, $linkSideElementHandl
 
 /**
  * Determine if multiple values are allowed for an element
- * Crude! Only meant for use in the arcane parts of the extraction layer where things are heavily optimized to use cached metadata under controlled circumstances
  * @param string|int $elementHandleOrId The handle or id of the element to check
  * @return bool True if multiple values are allowed, false otherwise
  */
 function multipleValuesAllowedForElement($elementHandleOrId) {
-	$metaData = formulize_getElementMetaData($elementHandleOrId, !is_numeric($elementHandleOrId));
-	$ele_value = unserialize($metaData['ele_value']);
-	if (anyCheckboxElementType($metaData['ele_type']) OR (is_array($ele_value) AND isset($ele_value[1]) AND $ele_value[1])) {
-		return true;
-	}
-	return false;
+	$element_handler = xoops_getmodulehandler('elements', 'formulize');
+	// canHaveMultipleValues is computed once per element, when it is loaded (see _setElementProperties
+	// in elements.php), and is correct for every element type - checkbox-family types set it true in
+	// their constructor, select-family types compute it from their multiple-selections setting via
+	// setCanHaveMultipleValues(), and any custom type gets whichever of those it inherits, or false
+	$element = $element_handler->get($elementHandleOrId);
+	return $element ? $element->canHaveMultipleValues : false;
 }
 
 function entryHasChildrenInRecursiveRelationship($entry_id, $linkedElementId) {
@@ -2248,17 +2248,6 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 
 				list($ifParts[0], $formFieldFilterMap, $mappedForm, $element_id, $elementPrefix, $queryElement) = prepareElementMetaData($frid, $fid, $linkfids, $ifParts[0], $formFieldFilterMap);
 
-				// set query term for yes/no questions
-				if ($formFieldFilterMap[$mappedForm][$element_id]['isyn'] and $ifParts[1] !== "") {
-					if (strstr(strtoupper(_formulize_TEMP_QYES), strtoupper($ifParts[1])) or strtoupper($ifParts[1]) == "YES") { // since we're matching based on even a single character match between the query and the yes/no language constants, if the current language has the same letters or letter combinations in yes and no, then sometimes only Yes may be searched for
-						$ifParts[1] = 1;
-					} elseif (strstr(strtoupper(_formulize_TEMP_QNO), strtoupper($ifParts[1])) or strtoupper($ifParts[1]) == "NO") {
-						$ifParts[1] = 2;
-					} else {
-						continue; // search term is not valid for the yes/no column
-					}
-				}
-
 				// build the where clause....
 
 				// HANDLE 'OTHER' BOXES
@@ -2345,7 +2334,7 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 							$queryElementMetaData = formulize_getElementMetaData($ifParts[0], true);
 							$ele_value = unserialize($queryElementMetaData['ele_value']);
 							$cleanSearchTerm = convertStringToUseSpecialCharsToMatchDB($ifParts[1]);
-							if ($formFieldFilterMap[$mappedForm][$element_id]['ele_type'] == 'checkboxLinked' or (($ele_value[0] > 1 or $ele_value[8]) and $ele_value[1])) { // if checkbox, or a selectbox where the element supports multiple selections [1], and number of rows is greater than 1 [0], or it is an autocomplete element [8]
+							if (elementTypeIsOrExtends($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], 'checkboxLinked') or (($ele_value[0] > 1 or $ele_value[8]) and $ele_value[1])) { // if checkbox (or any type based on checkboxLinked), or a selectbox where the element supports multiple selections [1], and number of rows is greater than 1 [0], or it is an autocomplete element [8]
 								if (is_numeric($ifParts[1])) {
 									$operator = "=";
 									$quotes = "";
@@ -2603,7 +2592,6 @@ function formulize_mapFormFieldFilter($element_id, $formFieldFilterMap)
 		} else {
 			$formFieldFilterMap[$array['id_form']][$element_id]['islinked'] = false;
 		}
-		$formFieldFilterMap[$array['id_form']][$element_id]['isyn'] = $array['ele_type'] == "yn" ? true : false;
 		if ((anyRadioElementType($array['ele_type']) OR anyCheckboxElementType($array['ele_type']) OR anySelectElementType($array['ele_type'])) AND strstr($array['ele_value'], "{OTHER|")) {
 			$formFieldFilterMap[$array['id_form']][$element_id]['hasother'] = true;
 		} else {

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -2797,8 +2797,9 @@ function formulize_calcDerivedColumns($entry, $metadata, $relationship_id, $form
 						$derivedValue = $functionName($entry, $form_id, $primary_entry_id, $relationship_id);
 						// if the new value is the same as the previous one, then skip updating and saving
 						if ($derivedValue !== $entry[$formHandle][$primary_entry_id][$thisMetaData['handle']]) {
+							$derivedValue = $derivedValue === '{WRITEASNULL}' ? null : $derivedValue; // legacy derived values might use old term
 							$dataToWrite[$thisMetaData['handle']] = $derivedValue;
-							$entry[$formHandle][$primary_entry_id][$thisMetaData['handle']] = $derivedValue === '{WRITEASNULL}' ? NULL : $derivedValue;
+							$entry[$formHandle][$primary_entry_id][$thisMetaData['handle']] = $derivedValue;
 						}
 					}
 					if (count((array) $dataToWrite) > 0) {
@@ -2806,7 +2807,7 @@ function formulize_calcDerivedColumns($entry, $metadata, $relationship_id, $form
 							if (isset($GLOBALS['formulize_cachedGetDataResults'][$staleCacheKey])) {
 								foreach (array_keys($masterIndexes) as $staleMasterIndex) {
 									foreach ($dataToWrite as $handle => $value) {
-										$GLOBALS['formulize_cachedGetDataResults'][$staleCacheKey][$staleMasterIndex][$formHandle][$primary_entry_id][$handle] = ($value === '{WRITEASNULL}') ? null : $value;
+										$GLOBALS['formulize_cachedGetDataResults'][$staleCacheKey][$staleMasterIndex][$formHandle][$primary_entry_id][$handle] = $value;
 									}
 								}
 							}

--- a/modules/formulize/include/formdisplay.php
+++ b/modules/formulize/include/formdisplay.php
@@ -3392,7 +3392,7 @@ function _compileGoverningElements($entries, $elementObject, $renderedMarkupName
 	$type = $elementObject->getVar('ele_type');
 	$ele_value = $elementObject->getVar('ele_value');
 	// This determination does not always (or usually?) end up being used in the keys for the elements! But we have compensated for this by gathering the right stuff at the time the JS is generated from all the gathered metadata. See markupNameAttr function and its use.
-	if($type == "checkbox" OR $type == "checkboxLinked" OR (anySelectElementType($type) AND $ele_value[1])) {
+	if(anyCheckboxElementType($type) OR (anySelectElementType($type) AND $ele_value[1])) {
 		$additionalNameParts = "[]"; // set things up with the right [] for multiple value elements
 	} else {
 		$additionalNameParts = "";

--- a/modules/formulize/include/formulizeConfigSyncElementValueProcessor.php
+++ b/modules/formulize/include/formulizeConfigSyncElementValueProcessor.php
@@ -93,8 +93,8 @@ class FormulizeConfigSyncElementValueProcessor
 		'associated_element_id' => 3,
 	];
 	private $ynradioMapping = [
-		'yes' => '_YES',
-		'no' => '_NO',
+		'yes' => formulizeYnElement::YES_DB_VALUE,
+		'no' => formulizeYnElement::NO_DB_VALUE,
 	];
 	private $dateMapping = [
 		'default' => 0

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -5245,8 +5245,11 @@ function buildFilter($id, $element_identifier, $defaultText="", $formDOMId="", $
 					// the ele_type string here. That way custom element types that extend a built-in
 					// type inherit the right behaviour automatically, and types whose stored values are
 					// codes (yn) can return the human readable options they want users to search on.
-					$optionsHandler = xoops_getmodulehandler($elementObject->getVar('ele_type').'Element', 'formulize');
-					$ele_value = $optionsHandler ? $optionsHandler->normalizeEleValue($elementObject->getVar('ele_value')) : $elementObject->getVar('ele_value');
+					// the true flag makes the handler optional: if the element type has no class file (a custom
+					// type that was removed, for instance) we get false back instead of a fatal error, and the
+					// fallbacks below apply
+					$optionsHandler = xoops_getmodulehandler($elementObject->getVar('ele_type').'Element', 'formulize', true);
+					$ele_value = $elementObject->getVar('ele_value'); // element classes present ele_value in its current structure, migrating legacy stored structures if necessary (see the checkbox element's getVar)
 					$ele_uitext = $elementObject->getVar('ele_uitext');
 					$options = $optionsHandler ? $optionsHandler->getFilterOptions($elementObject) : array();
 					if(is_array($options)) {

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -3408,7 +3408,7 @@ function _findLinkedEntries($targetFormKeySelf, $targetFormFid, $valuesToLookFor
         if($entries_to_return !== false) {
             $totalEntriesToReturn = array_unique(array_merge($entries_to_return, $totalEntriesToReturn));
         }
-        if($selfEleValue[1] OR $selfElement->getVar('ele_type') == 'checkbox' OR $selfElement->getVar('ele_type') == 'checkboxLinked') {
+        if($selfEleValue[1] OR anyCheckboxElementType($selfElement->getVar('ele_type'))) {
             if($selfElement->isLinked AND $selfEleValue['snapshot'] == false) {
                 $entries_to_return = $data_handler_target->findAllEntriesWithValue($targetFormKeySelf, '%,'.$valueToLookFor.',%', $all_users, $all_groups, 'LIKE');
                 if($entries_to_return !== false) {
@@ -4498,7 +4498,9 @@ function writeElementValue($formframe, $elementIdentifier, $entry, $value, $appe
             }
         } elseif ($append=="append") {
             $prevValue = q("SELECT `".$element->getVar('ele_handle')."` FROM ".$xoopsDB->prefix("formulize_".$elementFormObject->getVar('form_handle'))." WHERE entry_id=".intval($entry));
-						$switchEleType = anySelectElementType($element->getVar('ele_type')) ? "select" : $element->getVar('ele_type');
+						// resolve custom/derived element types to whichever of the types below they are based on,
+						// so that a subclass of the radio element, the text element, etc, is handled correctly
+						$switchEleType = formulize_resolveEleType($element->getVar('ele_type'), array("checkbox", "checkboxLinked", "select", "date", "radio", "text", "textarea"));
             switch ($switchEleType) {
                 case "checkbox":
 								case "checkboxLinked":
@@ -4513,9 +4515,8 @@ function writeElementValue($formframe, $elementIdentifier, $entry, $value, $appe
                     }
                     break;
 
-                case "yn": // cannot append to yn
                 case "date": // cannot append to date
-                case "radio": // cannot append to radios
+                case "radio": // cannot append to radios (and yn, and any other radio-based type)
                     $valueToWrite = $value;
                     break;
 
@@ -5240,48 +5241,18 @@ function buildFilter($id, $element_identifier, $defaultText="", $formDOMId="", $
         	$ele_uitext = array();
         	list($options, $useValue) = formulize_getMetadataFilterOptions($element_identifier, $metadataFid);
         } else {
-					$ele_value = $elementObject->getVar('ele_value');
+					// Ask the element type itself what its filter options are, rather than switching on
+					// the ele_type string here. That way custom element types that extend a built-in
+					// type inherit the right behaviour automatically, and types whose stored values are
+					// codes (yn) can return the human readable options they want users to search on.
+					$optionsHandler = xoops_getmodulehandler($elementObject->getVar('ele_type').'Element', 'formulize');
+					$ele_value = $optionsHandler ? $optionsHandler->normalizeEleValue($elementObject->getVar('ele_value')) : $elementObject->getVar('ele_value');
 					$ele_uitext = $elementObject->getVar('ele_uitext');
-					$switchEleType = anySelectElementType($elementObject->getVar('ele_type')) ? "select" : $elementObject->getVar('ele_type');
-					switch ($switchEleType) {
-							case "select":
-									$options = $ele_value[2];
-									break;
-							case "checkbox":
-							case "checkboxLinked":
-									$checkboxHandler = xoops_getmodulehandler("checkboxElement", "formulize");
-									$ele_value = $checkboxHandler->backwardsCompatibility($ele_value);
-									$options = $ele_value[2];
-									break;
-							case "radio":
-									$options = $ele_value;
-									break;
-							case "provinceList":
-							case "provinceRadio":
-									$provinceListHandler = xoops_getmodulehandler("provinceListElement", "formulize");
-									$options = array_flip($provinceListHandler->getProvinceList()); // values we want in the filter need to be the array keys!
-									break;
-							case "yn":
-									$options = array(_YES=>1, _NO=>2);
-									break;
-							default:
-									$options = array();
-					}
+					$options = $optionsHandler ? $optionsHandler->getFilterOptions($elementObject) : array();
 					if(is_array($options)) {
 						foreach($options as $checkThisKey=>$checkThisValue) {
 							if(strstr($checkThisKey, "{OTHER|")) {
 								unset($options[$checkThisKey]);
-							}
-						}
-					}
-					if (empty($options)) {
-						$eleTypeForOpts  = $elementObject->getVar('ele_type');
-						$classFileForOpts = XOOPS_ROOT_PATH . '/modules/formulize/class/' . $eleTypeForOpts . 'Element.php';
-						if (file_exists($classFileForOpts)) {
-							require_once $classFileForOpts;
-							$optsHandler = xoops_getmodulehandler($eleTypeForOpts . 'Element', 'formulize');
-							if ($optsHandler && method_exists($optsHandler, 'getFilterOptions')) {
-								$options = $optsHandler->getFilterOptions();
 							}
 						}
 					}
@@ -8677,7 +8648,7 @@ function formulize_parseSearchesIntoFilter($searches) {
 					if ($ele_value[1]) {
 						$allowsMulti = true;
 					}
-				} elseif ($ele_type == "checkbox" OR $ele_type == "checkboxLinked") {
+				} elseif (anyCheckboxElementType($ele_type)) {
 					$allowsMulti = true;
 				}
 				if ($allowsMulti) {

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -4378,20 +4378,21 @@ function writeElementValue($formframe, $elementIdentifier, $entry, $value, $appe
 		$element_id = $element->getVar('ele_id');
     $ele_value = $element->getVar('ele_value');
 
+    // yn elements (and any custom types based on them) store 1/2 codes, so let the element class
+    // convert Yes/No text into the codes, via its prepareLiteralTextForDB method
+    $ynTypeHandler = elementTypeIsOrExtends($element, "yn") ? xoops_getmodulehandler($element->getVar('ele_type')."Element", "formulize") : null;
     if (!is_array($value)) { // value can be an array of multiple values -- initially that only worked for linked selectboxes
-        if ($element->getVar('ele_type') == "yn") {
-            $value = strtoupper($value) == strtoupper(_formulize_TEMP_QYES) ? 1 : $value;
-            $value = strtoupper($value) == strtoupper(_formulize_TEMP_QNO) ? 2 : $value;
+        if ($ynTypeHandler) {
+            $value = $ynTypeHandler->prepareLiteralTextForDB($value, $element);
         } else {
             $value = $myts->htmlSpecialChars($value);
         }
     } else {
         foreach ($value as $id=>$thisValue) {
-            if ($element->getVar('ele_type') == "yn") {
-                $value[$id] = strtoupper($value[$id]) == strtoupper(_formulize_TEMP_QYES) ? 1 : $value[$id];
-                $value[$id] = strtoupper($value[$id]) == strtoupper(_formulize_TEMP_QNO) ? 2 : $value[$id];
+            if ($ynTypeHandler) {
+                $value[$id] = $ynTypeHandler->prepareLiteralTextForDB($thisValue, $element);
             } else {
-                $value[$id] = $myts->htmlSpecialChars($value[$id]);
+                $value[$id] = $myts->htmlSpecialChars($thisValue);
             }
         }
     }
@@ -10955,8 +10956,7 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
 	$evaluationCondition = "";
 
 	// convert the internal database representation to the displayed value, if this element has uitext that we're supposed to use
-	// translate yes/no choices for yes/no elements if French is active language
-	global $xoopsConfig;
+	// and normalize yes/no terms into the translated text that datasets contain, since the conditions are evaluated against dataset values
 	$element_handler = xoops_getmodulehandler('elements', 'formulize');
 
 	foreach ($filterElements as $key => $element) {
@@ -10971,9 +10971,17 @@ function buildEvaluationCondition($match,$indexes,$filterElements,$filterOps,$fi
 			if($element_metadata['ele_uitextshow'] AND isset($element_metadata['ele_uitext'])) {
 				$filterTerms[$key] = formulize_swapUIText($filterTerms[$key], unserialize($element_metadata['ele_uitext']));
 			}
-			if($element_metadata['ele_type'] == 'yn' AND ($filterTerms[$key] == 'Yes' OR $filterTerms[$key] == 'No') AND $xoopsConfig['language'] == 'french') {
-				$filterTerms[$key] = $filterTerms[$key] == 'Yes' ? 'Oui' : $filterTerms[$key];
-				$filterTerms[$key] = $filterTerms[$key] == 'No' ? 'Non' : $filterTerms[$key];
+			// yn elements (and their subclasses) store codes but their dataset values are translated
+			// Yes/No text, so convert whatever the user typed into the standard readable value
+			// that datasets contain in the active language. Leave the term alone if it doesn't
+			// convert to anything, so an invalid term fails to match, rather than matching blanks.
+			if(elementTypeIsOrExtends($element_metadata['ele_type'], 'yn') AND $filterTerms[$key] !== '') {
+				$ynTypeHandler = xoops_getmodulehandler($element_metadata['ele_type']."Element", "formulize");
+				$dbValue = $ynTypeHandler->prepareLiteralTextForDB($filterTerms[$key], $filterElementObject);
+				$convertedTerm = $ynTypeHandler->prepareDataForDataset($dbValue, $filterElementObject->getVar('ele_handle'), 0);
+				if($convertedTerm !== "") {
+					$filterTerms[$key] = $convertedTerm;
+				}
 			}
 		}
 	}

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -3560,6 +3560,8 @@ function cloneEntry($entryOrFilter, $frid, $fid, $copies=1, $callback = null, $t
  */
 function sendNotifications($fid, $event, $entries) {
 
+		$entries = array_unique($entries);
+
     // don't send a notification twice, so we store what we have processed already and don't process again
     static $processedNotifications = array();
     $serializedEntries = serialize($entries);

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -3560,15 +3560,19 @@ function cloneEntry($entryOrFilter, $frid, $fid, $copies=1, $callback = null, $t
  */
 function sendNotifications($fid, $event, $entries) {
 
-		$entries = array_unique($entries);
-
     // don't send a notification twice, so we store what we have processed already and don't process again
+		$entries = array_unique($entries);
     static $processedNotifications = array();
-    $serializedEntries = serialize($entries);
-    if (isset($processedNotifications[$fid][$event][$serializedEntries])) {
-        return;
-    }
-    $processedNotifications[$fid][$event][$serializedEntries] = true;
+		foreach($entries as $i => $entry_id) {
+			if (isset($processedNotifications[$fid][$event][$entry_id])) {
+				unset($entries[$i]);
+			} else {
+				$processedNotifications[$fid][$event][$entry_id] = true;
+			}
+		}
+		if(empty($entries)) {
+			return;
+		}
 
 		global $xoopsDB, $xoopsUser, $xoopsConfig, $renderedFormulizeScreen;
 
@@ -5252,7 +5256,7 @@ function buildFilter($id, $element_identifier, $defaultText="", $formDOMId="", $
 					$optionsHandler = xoops_getmodulehandler($elementObject->getVar('ele_type').'Element', 'formulize', true);
 					$ele_value = $elementObject->getVar('ele_value'); // element classes present ele_value in its current structure, migrating legacy stored structures if necessary (see the checkbox element's getVar)
 					$ele_uitext = $elementObject->getVar('ele_uitext');
-					$options = $optionsHandler ? $optionsHandler->getFilterOptions($elementObject) : array();
+					$options = ($optionsHandler AND method_exists($optionsHandler, 'getFilterOptions')) ? $optionsHandler->getFilterOptions($elementObject) : array();
 					if(is_array($options)) {
 						foreach($options as $checkThisKey=>$checkThisValue) {
 							if(strstr($checkThisKey, "{OTHER|")) {

--- a/modules/formulize/include/import_functions.php
+++ b/modules/formulize/include/import_functions.php
@@ -613,22 +613,22 @@ function importCsvValidate(&$importSet, $regfid, $validateOverride=false) {
 
 
                             case "yn":
+                            xoops_getmodulehandler('ynElement', 'formulize'); // make sure the yn class is loaded, so its constants are available
                             if (is_numeric($cell_value)) {
-                                if (!($cell_value == 1 || $cell_value == 2)) {
+                                if (!($cell_value == formulizeYnElement::YES_DB_VALUE || $cell_value == formulizeYnElement::NO_DB_VALUE)) {
                                     $errors[] = "<li>line " . $rowCount .
                                         ", column " . $importSet[3][$link] .
                                         ",<br> <b>found</b>: " . $cell_value .
-                                        ", <b>was expecting</b>: { 1, 2, " . _formulize_TEMP_QYES . ", " . _formulize_TEMP_QNO . " }</li>";
+                                        ", <b>was expecting</b>: { " . formulizeYnElement::YES_DB_VALUE . ", " . formulizeYnElement::NO_DB_VALUE . ", " . _YES . ", " . _NO . " }</li>";
                                 }
                             } else {
                                 $yn_value = strtoupper($cell_value);
 
-                                if (!($yn_value == strtoupper(_formulize_TEMP_QYES) || $yn_value == strtoupper(_formulize_TEMP_QNO))) {
-                                    // changed to use language constants, June 29, 2006 {
+                                if (!($yn_value == strtoupper(_YES) || $yn_value == strtoupper(_NO))) {
                                     $errors[] = "<li>line " . $rowCount .
                                         ", column " . $importSet[3][$link] .
                                         ",<br> <b>found</b>: " . $cell_value .
-                                        ", <b>was expecting</b>: { 1, 2, " . _formulize_TEMP_QYES . ", " . _formulize_TEMP_QNO . " }</li>";
+                                        ", <b>was expecting</b>: { " . formulizeYnElement::YES_DB_VALUE . ", " . formulizeYnElement::NO_DB_VALUE . ", " . _YES . ", " . _NO . " }</li>";
                                 }
                             }
                             break;
@@ -1093,12 +1093,9 @@ function importCsvProcess(& $importSet, $regfid, $validateOverride, $pkColumn=fa
 
                             case "yn":
                             if (!is_numeric($row_value)) {
-                                $yn_value = strtoupper($row_value);
-
-                                if ($yn_value == "YES")
-                                    $row_value = 1;
-                                else if ($yn_value == "NO")
-                                    $row_value = 2;
+                                // convert Yes/No text (in the active language, or English) into the database codes
+                                $ynElementHandler = xoops_getmodulehandler('ynElement', 'formulize');
+                                $row_value = $ynElementHandler->prepareLiteralTextForDB($row_value, null);
                             }
                             break;
 

--- a/modules/formulize/include/import_functions.php
+++ b/modules/formulize/include/import_functions.php
@@ -167,7 +167,7 @@ function importCsvSetup(&$importSet, $pkColumn=false) {
                         $mapIndex = $element;
 
                         // links?
-												$switchEleType = anySelectElementType($form_elementsq[$element]["ele_type"]) ? "select" : $form_elementsq[$element]["ele_type"];
+												$switchEleType = formulize_resolveEleType($form_elementsq[$element]["ele_type"], array("select", "checkbox", "checkboxLinked"));
         								switch ($switchEleType) {
                             case "select":
 														case "checkbox":
@@ -335,7 +335,7 @@ function importCsvValidate(&$importSet, $regfid, $validateOverride=false) {
 												}
 
                         // check columns from form
-                        $switchEleType = anySelectElementType($element["ele_type"]) ? "select" : $element["ele_type"];
+                        $switchEleType = formulize_resolveEleType($element["ele_type"], array("select", "checkbox", "checkboxLinked", "date", "provinceList", "provinceRadio", "radio", "yn"));
         								switch ($switchEleType) {
                             case "select":
                                 $ele_value = unserialize($element["ele_value"]);
@@ -808,7 +808,7 @@ function importCsvProcess(& $importSet, $regfid, $validateOverride, $pkColumn=fa
                     }
 
                     if ($row_value != "") {
-                        $switchEleType = anySelectElementType($element["ele_type"]) ? "select" : $element["ele_type"];
+                        $switchEleType = formulize_resolveEleType($element["ele_type"], array("select", "checkbox", "checkboxLinked", "date", "derived", "provinceList", "provinceRadio", "radio", "text", "textarea", "yn"));
         								switch ($switchEleType) {
 
                             case "derived":
@@ -1336,7 +1336,7 @@ function importCsvDebug(& $importSet) {
                 $element["ele_type"];
             $output .= "<td>";
 
-            $switchEleType = anySelectElementType($element["ele_type"]) ? "select" : $element["ele_type"];
+            $switchEleType = formulize_resolveEleType($element["ele_type"], array("select", "checkbox", "checkboxLinked", "radio"));
         		switch ($switchEleType) {
                 case "select":
                     $ele_value = unserialize($element["ele_value"]);

--- a/modules/formulize/include/moreinfo.php
+++ b/modules/formulize/include/moreinfo.php
@@ -60,12 +60,16 @@ print "<table width=100%><tr><td width=5%></td><td width=90%>";
   <?php
   $ele_value=unserialize($elementMetaData['ele_value']);
   $ele_uitext=unserialize($elementMetaData['ele_uitext']);
-  switch($elementMetaData['ele_type']) {
-    case "radio":
+  // radio buttons and everything that extends them (yn, and custom radio-based types) have a
+  // list of options we can show. Ask the element type for each option's label, since some types
+  // store sentinel tokens rather than display text in their ele_value keys (yn stores _YES/_NO).
+  if(anyRadioElementType($elementMetaData['ele_type'])) {
+      $moreInfoHandler = xoops_getmodulehandler($elementMetaData['ele_type']."Element", "formulize");
       print "<tr><td class=\"odd\"><p><b>"._formulize_DE_MOREINFO_OPTIONS."</b></p>\n";
       print "<ul>\n";
       foreach($ele_value as $option=>$selected) {
-        $optionText = isset($ele_uitext[$option]) ? trans($option) ." &mdash; ".trans($ele_uitext[$option]) : trans($option);
+        $optionLabel = $moreInfoHandler ? $moreInfoHandler->getOptionLabel($option, null) : $option;
+        $optionText = isset($ele_uitext[$option]) ? trans($optionLabel) ." &mdash; ".trans($ele_uitext[$option]) : trans($optionLabel);
         print "<li>$optionText</li>\n";
       }
       print "</ul></td></tr>\n";

--- a/modules/formulize/include/moreinfo.php
+++ b/modules/formulize/include/moreinfo.php
@@ -61,14 +61,13 @@ print "<table width=100%><tr><td width=5%></td><td width=90%>";
   <?php print _formulize_DE_MOREINFO_QUESTION."<br>".trans($elementObject->getVar('ele_caption')); ?>
   </p><center></td></tr>
   <?php
-  $ele_value=$elementObject->getVar('ele_value'); // ele_value and ele_uitext are array properties, unserialized by getVar
-  $ele_uitext=$elementObject->getVar('ele_uitext');
   // radio buttons and everything that extends them (yn, and custom radio-based types) have a
   // list of options we can show. getListOptions returns them keyed by display-ready text, since
   // some types store codes rather than display text in their ele_value keys (yn stores 1/2).
   if(anyRadioElementType($elementObject)) {
       print "<tr><td class=\"odd\"><p><b>"._formulize_DE_MOREINFO_OPTIONS."</b></p>\n";
       print "<ul>\n";
+			$ele_uitext=$elementObject->getVar('ele_uitext');
       foreach($elementObject->getListOptions() as $optionLabel=>$selected) {
         $optionText = isset($ele_uitext[$optionLabel]) ? trans($optionLabel) ." &mdash; ".trans($ele_uitext[$optionLabel]) : trans($optionLabel);
         print "<li>$optionText</li>\n";

--- a/modules/formulize/include/moreinfo.php
+++ b/modules/formulize/include/moreinfo.php
@@ -38,9 +38,12 @@ include_once XOOPS_ROOT_PATH . "/modules/formulize/include/extract.php";
 include_once XOOPS_ROOT_PATH."/modules/formulize/language/english/main.php";
 if ( file_exists(XOOPS_ROOT_PATH."/modules/formulize/language/".$xoopsConfig['language']."/main.php") ) {
   include_once XOOPS_ROOT_PATH."/modules/formulize/language/".$xoopsConfig['language']."/main.php";
-} 
+}
 
-$elementMetaData = formulize_getElementMetaData($_GET['col'], true);
+$element_handler = xoops_getmodulehandler('elements', 'formulize');
+if(!$elementObject = $element_handler->get($_GET['col'])) {
+	exit("Element not found");
+}
 
 print "<HTML>";
 print "<head>";
@@ -49,27 +52,25 @@ print "<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"" . XO
 $themecss = xoops_getcss();
 print "<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"$themecss\" />\n";
 print "</head>";
-print "<body style=\"background: white; margin-top:20px;\"><center>"; 
+print "<body style=\"background: white; margin-top:20px;\"><center>";
 print "<table width=100%><tr><td width=5%></td><td width=90%>";
 ?>
 <br><br>
 <table class="outer">
   <tr><td class="head"><center><p>
-  <?php print _formulize_DE_MOREINFO_QUESTION."<br>".trans($elementMetaData['ele_caption']); ?>
+  <?php print _formulize_DE_MOREINFO_QUESTION."<br>".trans($elementObject->getVar('ele_caption')); ?>
   </p><center></td></tr>
   <?php
-  $ele_value=unserialize($elementMetaData['ele_value']);
-  $ele_uitext=unserialize($elementMetaData['ele_uitext']);
+  $ele_value=$elementObject->getVar('ele_value'); // ele_value and ele_uitext are array properties, unserialized by getVar
+  $ele_uitext=$elementObject->getVar('ele_uitext');
   // radio buttons and everything that extends them (yn, and custom radio-based types) have a
-  // list of options we can show. Ask the element type for each option's label, since some types
-  // store sentinel tokens rather than display text in their ele_value keys (yn stores _YES/_NO).
-  if(anyRadioElementType($elementMetaData['ele_type'])) {
-      $moreInfoHandler = xoops_getmodulehandler($elementMetaData['ele_type']."Element", "formulize");
+  // list of options we can show. getListOptions returns them keyed by display-ready text, since
+  // some types store codes rather than display text in their ele_value keys (yn stores 1/2).
+  if(anyRadioElementType($elementObject)) {
       print "<tr><td class=\"odd\"><p><b>"._formulize_DE_MOREINFO_OPTIONS."</b></p>\n";
       print "<ul>\n";
-      foreach($ele_value as $option=>$selected) {
-        $optionLabel = $moreInfoHandler ? $moreInfoHandler->getOptionLabel($option, null) : $option;
-        $optionText = isset($ele_uitext[$option]) ? trans($optionLabel) ." &mdash; ".trans($ele_uitext[$option]) : trans($optionLabel);
+      foreach($elementObject->getListOptions() as $optionLabel=>$selected) {
+        $optionText = isset($ele_uitext[$optionLabel]) ? trans($optionLabel) ." &mdash; ".trans($ele_uitext[$optionLabel]) : trans($optionLabel);
         print "<li>$optionText</li>\n";
       }
       print "</ul></td></tr>\n";

--- a/modules/formulize/include/readelements.php
+++ b/modules/formulize/include/readelements.php
@@ -134,7 +134,7 @@ foreach($_POST as $k=>$v) {
 		$blankSubformCounter = $subformMetaDataParts[0];
 		$blankSubformElementId = $subformMetaDataParts[1];
     $v = prepDataForWrite($elementObject, $v, "new", $blankSubformCounter);
-		if(($v === "" OR $v === "{WRITEASNULL}") AND $elementMetaData[2] == "new") { continue; } // don't store blank values for new entries, we don't want to write those (if desubform is used only for blank defaults, then it will always be "new" but we'll keep this as is for now, can't hurt)
+		if(($v === "" OR $v === "{WRITEASNULL}" OR $v === null) AND $elementMetaData[2] == "new") { continue; } // don't store blank values for new entries, we don't want to write those (if desubform is used only for blank defaults, then it will always be "new" but we'll keep this as is for now, can't hurt)
 		$formulize_elementData[$elementMetaData[1]][$elementMetaData[2].$blankSubformCounter."x".$blankSubformElementId][$elementMetaData[3]] = $v;
 		if(!isset($formulize_subformBlankCues[$elementMetaData[1]])) {
 			$formulize_subformBlankCues[$elementMetaData[1]] = $elementMetaData[1]; // we will watch for entries being written to this form, and store the resulting entries in global space so we can synch them later
@@ -174,7 +174,7 @@ foreach($_POST as $k=>$v) {
 				$v = prepDataForWrite($elementObject, $_POST["de_".$elementMetaData[1]."_".$elementMetaData[2]."_".$elementMetaData[3]], $elementMetaData[2]);
 				$formulize_elementData[$elementMetaData[1]][$elementMetaData[2]][$elementMetaData[3]] = $v;
 			} elseif(is_numeric($elementMetaData[1]) AND $elementObject->isSystemElement == false) {
-				$formulize_elementData[$elementMetaData[1]][$elementMetaData[2]][$elementMetaData[3]] = "{WRITEASNULL}"; // no value returned for this element that was included (cue was found) so we write it as blank to the db
+				$formulize_elementData[$elementMetaData[1]][$elementMetaData[2]][$elementMetaData[3]] = null; // no value returned for this element that was included (cue was found) so we write it as blank to the db
 			}
 		}
 

--- a/modules/formulize/include/synccompare.php
+++ b/modules/formulize/include/synccompare.php
@@ -414,7 +414,7 @@ class SyncCompareCatalog {
                         $usRecord[3] = $this->stripGroupsFromCommaList($usRecord[3]);
                         /*print $usRecord[3];
                         print "<br>";*/
-                    } elseif(isset($data['ele_type']) AND ($data['ele_type'] == 'checkbox' OR $data['ele_type'] == 'checkboxLinked') AND isset($usRecord['formlink_scope']) AND is_string($usRecord['formlink_scope']) AND preg_replace("/[^,0-9]/", "", $usRecord['formlink_scope']) === $usRecord['formlink_scope']) {
+                    } elseif(isset($data['ele_type']) AND anyCheckboxElementType($data['ele_type']) AND isset($usRecord['formlink_scope']) AND is_string($usRecord['formlink_scope']) AND preg_replace("/[^,0-9]/", "", $usRecord['formlink_scope']) === $usRecord['formlink_scope']) {
                         /*print "checkbox $groupFieldName switch: ";
                         print $usRecord['formlink_scope'];
                         print "<br>";*/

--- a/modules/formulize/language/english/main.php
+++ b/modules/formulize/language/english/main.php
@@ -187,6 +187,7 @@ define("_formulize_TEMP_ENTEREDBY", "Entered by: ");
 define("_formulize_TEMP_ENTEREDBYSINGLE", "Entered ");
 define("_formulize_TEMP_ON", "on");
 define("_formulize_TEMP_AT", "at");
+// The two _formulize_TEMP_Q constants below are DEPRECATED as of 2026 and no longer used by Formulize itself. The core _YES and _NO constants are used instead. These remain defined only in case custom code in templates or derived value formulas refers to them.
 define("_formulize_TEMP_QYES", "Yes");
 define("_formulize_TEMP_QNO", "No");
 define("_formulize_REPORT_ON", "Turn Report Writing Mode ON");

--- a/modules/formulize/language/french/main.php
+++ b/modules/formulize/language/french/main.php
@@ -616,6 +616,7 @@ define("_formulize_TEMP_ENTEREDBY", "Saisie par : ");
 define("_formulize_TEMP_ENTEREDBYSINGLE", "Saisie ");
 define("_formulize_TEMP_NOENTRIES", "Aucune entrée.");
 define("_formulize_TEMP_ON", "sur");
+// The two _formulize_TEMP_Q constants below are DEPRECATED as of 2026 and no longer used by Formulize itself. The core _YES and _NO constants are used instead. These remain defined only in case custom code in templates or derived value formulas refers to them.
 define("_formulize_TEMP_QNO", "Non");
 define("_formulize_TEMP_QYES", "Oui");
 define("_formulize_TEMP_SELENTTITLE", "Votre entrée dans '");

--- a/modules/formulize/language/german/main.php
+++ b/modules/formulize/language/german/main.php
@@ -178,6 +178,7 @@ define("_formulize_TEMP_ENTEREDBY", "Entered by: ");
 define("_formulize_TEMP_ENTEREDBYSINGLE", "Entered ");
 define("_formulize_TEMP_ON", "on");
 define("_formulize_TEMP_AT", "at");
+// The two _formulize_TEMP_Q constants below are DEPRECATED as of 2026 and no longer used by Formulize itself. The core _YES and _NO constants are used instead. These remain defined only in case custom code in templates or derived value formulas refers to them.
 define("_formulize_TEMP_QYES", "Yes");
 define("_formulize_TEMP_QNO", "No");
 define("_formulize_REPORT_ON", "Turn Report Writing Mode ON");

--- a/modules/formulize/language/italian/main.php
+++ b/modules/formulize/language/italian/main.php
@@ -63,6 +63,7 @@ define("_FORM_GROUPSCOPE","Users can view entries made by everyone in their grou
 define("_formulize_TEMP_SELENTTITLE_GS", "All entries in '");
 define("_formulize_TEMP_NOENTRIES", "No entries yet.");
 define("_formulize_TEMP_ENTEREDBY", "Entered by: ");
+// The two _formulize_TEMP_Q constants below are DEPRECATED as of 2026 and no longer used by Formulize itself. The core _YES and _NO constants are used instead. These remain defined only in case custom code in templates or derived value formulas refers to them.
 define("_formulize_TEMP_QYES", "YES");
 define("_formulize_TEMP_QNO", "NO");
 

--- a/modules/formulize/language/portuguesebr/main.php
+++ b/modules/formulize/language/portuguesebr/main.php
@@ -186,6 +186,7 @@ define("_formulize_TEMP_ENTEREDBY", "Entrada por: ");
 define("_formulize_TEMP_ENTEREDBYSINGLE", "Entrada ");
 define("_formulize_TEMP_ON", "em");
 define("_formulize_TEMP_AT", "em"); //GibaPhp 3.0
+// The two _formulize_TEMP_Q constants below are DEPRECATED as of 2026 and no longer used by Formulize itself. The core _YES and _NO constants are used instead. These remain defined only in case custom code in templates or derived value formulas refers to them.
 define("_formulize_TEMP_QYES", "Sim");
 define("_formulize_TEMP_QNO", "Não");
 define("_formulize_REPORT_ON", "Ativar Modo de Escrita de Relatório");

--- a/modules/formulize/templates/admin/element_linkedandusernames_scopefilter.html
+++ b/modules/formulize/templates/admin/element_linkedandusernames_scopefilter.html
@@ -1,9 +1,10 @@
-<{if $content.type == "selectLinked" OR $content.type == "selectUsers" OR $content.type == "autocompleteLinked" OR $content.type == "autocompleteUsers" OR $content.type == "listboxLinked" OR $content.type == "listboxUsers"}>
+<{* the select family and the checkbox family store these two settings under different ele_value keys *}>
+<{if $content.typeIsSelect}>
 	<{assign var="ele_value_scopelimit_DOM" value="elements-ele_value[4]"}>
 	<{assign var="ele_value_scopelimit_SMARTY" value=$content.ele_value[4]}>
 	<{assign var="ele_value_anyorall_DOM" value="elements-ele_value[6]"}>
 	<{assign var="ele_value_anyorall_SMARTY" value=$content.ele_value[6]}>
-<{elseif $content.type == "checkbox" OR $content.type == "checkboxLinked"}>
+<{elseif $content.typeIsCheckbox}>
 	<{assign var="ele_value_scopelimit_DOM" value="elements-ele_value[checkbox_scopelimit]"}>
 	<{assign var="ele_value_scopelimit_SMARTY" value=$content.ele_value.checkbox_scopelimit}>
 	<{assign var="ele_value_anyorall_DOM" value="elements-ele_value[checkbox_formlink_anyorall]"}>

--- a/modules/formulize/templates/admin/element_linkedfilter.html
+++ b/modules/formulize/templates/admin/element_linkedfilter.html
@@ -9,7 +9,8 @@
 			<{$smarty.const._AM_ELE_FORMLINK_SCOPEFILTER_DESC}>
 		</div>
 
-		<{if $content.type == 'selectLinked' OR $content.type == 'listboxLinked' OR $content.type == 'autocompleteLinked'}>
+		<{* limiting the options by the value of an element in another form is a select family feature, and only makes sense when the options come from another form *}>
+		<{if $content.typeIsSelect AND $content.isLinkedType}>
 		<div class="form-select" id="optionsLimitByElementFilterDiv">
 			<p>Limit based on the values selected in this other element: <{$content.optionsLimitByElement}></p><br />
 			<{if isset($content.optionsLimitByElementFilter) AND $content.optionsLimitByElementFilter}>

--- a/modules/formulize/templates/admin/element_linkedoptionlist.html
+++ b/modules/formulize/templates/admin/element_linkedoptionlist.html
@@ -4,14 +4,14 @@
 		<div id="linkedSourceOptions">
 			<{$content.linkedoptions}>
 
-			<{if $content.type == "listbox" OR $content.type == "listboxLinked" OR $content.type == "listboxUsers" OR $content.type == "autocomplete" OR $content.type == "autocompleteLinked" OR $content.type == "autocompleteUsers"}>
+			<{if $content.canAllowMultipleValues}>
 				<br>
 				<br>
 				Are multiple selections allowed?<br>
 				<{include file="db:admin/element_multiple_onoff.html"}>
 			<{/if}>
 
-			<{if $content.type == "autocomplete" OR $content.type == "autocompleteLinked"}>
+			<{if $content.canAllowNewValues}>
 				<br>
 				<{include file="db:admin/element_autocomplete_allownew.html"}>
 			<{/if}>
@@ -30,7 +30,7 @@
 					<p>For example, imagine an Activity Log that contains a linked list of all the activities in the log. When you're editing an entry, should the list contain the activity you're editing or not?</p>
 				</div>
 			</div>
-			<{if $content.type == "selectLinked" OR $content.type == "listboxLinked" OR $content.type == "autocompleteLinked" OR $content.type == "checkboxLinked"}>
+			<{if $content.isLinkedType}>
 				<div class="form-radios">
 				<{if $content.subformInterfaceAdminUrl}>
 					<p><a href="<{$content.subformInterfaceAdminUrl}>" target="_blank">Open the Configuration page for the Subform interface</a></p>

--- a/modules/formulize/templates/admin/element_linkedoptionlist.html
+++ b/modules/formulize/templates/admin/element_linkedoptionlist.html
@@ -4,14 +4,14 @@
 		<div id="linkedSourceOptions">
 			<{$content.linkedoptions}>
 
-			<{if $content.canAllowMultipleValues}>
+			<{if $content.adminCanAllowMultipleValues}>
 				<br>
 				<br>
 				Are multiple selections allowed?<br>
 				<{include file="db:admin/element_multiple_onoff.html"}>
 			<{/if}>
 
-			<{if $content.canAllowNewValues}>
+			<{if $content.adminCanAllowNewValues}>
 				<br>
 				<{include file="db:admin/element_autocomplete_allownew.html"}>
 			<{/if}>

--- a/modules/formulize/templates/admin/element_names.html
+++ b/modules/formulize/templates/admin/element_names.html
@@ -51,7 +51,7 @@
 		</fieldset>
 	</div>
 
-<{if $content.type != "grid"}>
+<{if !$content.typeIsGrid}>
 <div class="accordion-box">
 	<div class="form-item">
    	<fieldset>

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -29,12 +29,12 @@
   <p><{$smarty.const._AM_ELE_OPT_UITEXT}></p>
 </div>
 
-<{if $content.canAllowMultipleValues}>
+<{if $content.adminCanAllowMultipleValues}>
 	Are multiple selections allowed?<br>
 	<{include file="db:admin/element_multiple_onoff.html"}>
 <{/if}>
 
-<{if $content.canAllowNewValues}>
+<{if $content.adminCanAllowNewValues}>
 	<br>
 	<{include file="db:admin/element_autocomplete_allownew.html"}>
 <{/if}>

--- a/modules/formulize/templates/admin/element_optionlist.html
+++ b/modules/formulize/templates/admin/element_optionlist.html
@@ -5,36 +5,36 @@
 <{if isset($content.useroptions) AND $content.useroptions|is_array AND $content.useroptions|@count > 0}>
   <{foreach from=$content.useroptions key=text item=checked name=optionsloop}>
     <p class="useroptions" name="<{$smarty.foreach.optionsloop.index}>">
-    <{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
+    <{if $content.canHaveMultipleValues == false}><input type="radio" name="defaultoption" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{else}><input type="checkbox" name="defaultoption[<{$smarty.foreach.optionsloop.index}>]" value=<{$smarty.foreach.optionsloop.index}> <{if $checked}>checked<{/if}>></input>
     <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[<{$smarty.foreach.optionsloop.index}>]" value="<{$text|replace:'"':'&quot;'}>" onchange="checkForNames()"></input> <span class='sorthandle'>&equiv;</span></p>
   <{/foreach}>
 <{else}>
   <p class="useroptions" name="0">
-  <{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value=0></input>
+  <{if $content.canHaveMultipleValues == false}><input type="radio" name="defaultoption" value=0></input>
   <{else}><input type="checkbox" name="defaultoption[0]" value=0></input>
   <{/if}>&nbsp;&nbsp;<input type="text" name="ele_value[0]" onchange="checkForNames()"></input> <span class='sorthandle'>&equiv;</span></p>
 <{/if}>
 </div>
 
-<{if $content.type == "radio" || $content.type == "select"}>
+<{if $content.canHaveMultipleValues == false}>
 <p><input type="button" class="formButton" name="cleardef" value="<{$smarty.const._AM_CLEAR_DEFAULT}>"/></p>
 <{/if}>
 
 
 <div class="description">
-  <{if $content.type == "radio"}><p><{$smarty.const._AM_ELE_OPT_DESC2}></p><p><{$smarty.const._AM_ELE_OTHER}></p><{/if}>
-  <{if $content.type == "checkbox" || $content.type == "checkboxLinked"}><p><{$smarty.const._AM_ELE_OPT_DESC_CHECKBOXES}></p><p><{$smarty.const._AM_ELE_OTHER}></p><{/if}>
+  <{if $content.typeIsRadio}><p><{$smarty.const._AM_ELE_OPT_DESC2}></p><p><{$smarty.const._AM_ELE_OTHER}></p><{/if}>
+  <{if $content.typeIsCheckbox}><p><{$smarty.const._AM_ELE_OPT_DESC_CHECKBOXES}></p><p><{$smarty.const._AM_ELE_OTHER}></p><{/if}>
   <{if $content.typeIsSelect}><p><{$smarty.const._AM_ELE_OPT_DESC}><{$smarty.const._AM_ELE_OPT_DESC1}></p><{/if}>
   <p><{$smarty.const._AM_ELE_OPT_UITEXT}></p>
 </div>
 
-<{if $content.type != "radio" AND $content.type != "checkbox" AND $content.type != "checkboxLinked" AND $content.type != "select" AND $content.type != "selectLinked" AND $content.type != "selectUsers"}>
+<{if $content.canAllowMultipleValues}>
 	Are multiple selections allowed?<br>
 	<{include file="db:admin/element_multiple_onoff.html"}>
 <{/if}>
 
-<{if $content.type == "autocomplete" OR $content.type == "autocompleteLinked"}>
+<{if $content.canAllowNewValues}>
 	<br>
 	<{include file="db:admin/element_autocomplete_allownew.html"}>
 <{/if}>
@@ -64,7 +64,7 @@
   $("[name=addoption]").click(function (){
     number = $(".useroptions:last").attr('name');
     number = parseInt(number) + 1;
-    appendContents1 = '<{if $content.type == "radio" || $content.type == "select"}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
+    appendContents1 = '<{if $content.canHaveMultipleValues == false}><input type="radio" name="defaultoption" value='+number+'></input><{else}><input type="checkbox" name="defaultoption['+number+']" value='+number+'></input><{/if}>';
     appendContents2 = '<input type="text" name="ele_value['+number+']"></input>';
     $(".optionlist").append('<p class="useroptions" name="'+number+'"></p>');
     $(".useroptions:last").append(appendContents1);
@@ -76,7 +76,7 @@
     $("#no").attr('checked',1);
   });
 
-  <{if $content.type == "radio" || $content.type == "select"}>
+  <{if $content.canHaveMultipleValues == false}>
   $("[name=cleardef]").click(function () {
     $("[name=defaultoption]").attr('checked',0);
     $("[name=cleardef]").blur();
@@ -89,10 +89,10 @@
 
   function checkForNames() {
     if ($("[name=ele_value[0]]").val() == "{USERNAMES}" || $("[name=ele_value[0]]").val() == "{FULLNAMES}"){
-      <{if $content.typeIsSelect}>disableForAutocomplete();<{/if}>
+      disableForAutocomplete();
 			$('div#linked-or-usernames-options').show(200);
     }else{
-      <{if $content.typeIsSelect}>enableForAutocomplete();<{/if}>
+      enableForAutocomplete();
 			$('div#linked-or-usernames-options').hide(200);
     }
   }

--- a/modules/formulize/templates/admin/element_type_selectUsers.html
+++ b/modules/formulize/templates/admin/element_type_selectUsers.html
@@ -4,7 +4,7 @@
 			<{include file="db:admin/element_linkedandusernames_scopefilter.html"}>
 		</div>
 
-		<{if $content.type != "select" AND $content.type != "selectLinked" AND $content.type != "selectUsers"}>
+		<{if $content.canAllowMultipleValues}>
 			<div class="form-item">
 				<fieldset>
 					<legend>Are multiple selections allowed?</legend>
@@ -13,7 +13,7 @@
 			</div>
 		<{/if}>
 
-		<{if $content.type == "autocomplete" OR $content.type == "autocompleteLinked"}>
+		<{if $content.canAllowNewValues}>
 			<br>
 			<{include file="db:admin/element_autocomplete_allownew.html"}>
 		<{/if}>

--- a/modules/formulize/templates/admin/element_type_selectUsers.html
+++ b/modules/formulize/templates/admin/element_type_selectUsers.html
@@ -4,7 +4,7 @@
 			<{include file="db:admin/element_linkedandusernames_scopefilter.html"}>
 		</div>
 
-		<{if $content.canAllowMultipleValues}>
+		<{if $content.adminCanAllowMultipleValues}>
 			<div class="form-item">
 				<fieldset>
 					<legend>Are multiple selections allowed?</legend>
@@ -13,7 +13,7 @@
 			</div>
 		<{/if}>
 
-		<{if $content.canAllowNewValues}>
+		<{if $content.adminCanAllowNewValues}>
 			<br>
 			<{include file="db:admin/element_autocomplete_allownew.html"}>
 		<{/if}>

--- a/modules/formulize/templates/admin/element_type_subformListings.html
+++ b/modules/formulize/templates/admin/element_type_subformListings.html
@@ -21,7 +21,7 @@
 	<fieldset>
 		<legend>User interface options</legend>
 
-		<{if $content.type == 'subformFullForm'}>
+		<{if $content.typeIsSubformFullForm}>
 		<div class="form-item">
 		 <div class="form-radios">
 		     <label for="elements-ele_value[8]-form"><input type="radio" id="elements-ele_value[8]-form" name="elements-ele_value[8]" value="form"<{if $content.ele_value[8] eq 'form'}> checked="checked"<{/if}>/><{$content.fullFormOption1}></label>
@@ -41,7 +41,7 @@
 		<{/if}>
 
 		<div class="form-item">
-			<p><{if $content.type == 'subformFullForm'}><{$smarty.const._AM_ELE_SUBFORM_ELEMENT_LIST_FORM}><{else}><{$smarty.const._AM_ELE_SUBFORM_ELEMENT_LIST_ROW}><{/if}></p>
+			<p><{if $content.typeIsSubformFullForm}><{$smarty.const._AM_ELE_SUBFORM_ELEMENT_LIST_FORM}><{else}><{$smarty.const._AM_ELE_SUBFORM_ELEMENT_LIST_ROW}><{/if}></p>
 			<select name="elements_ele_value_1[]" size="10" multiple>
 				<{html_options options=$content.subformelements selected=$content.ele_value[1]}>
 			</select>
@@ -90,7 +90,7 @@
 				<div class="form-item">
 					<br />
 
-				<{if $content.type != 'subformFullForm'}>
+				<{if !$content.typeIsSubformFullForm}>
 
                     <div class="form-item">
                         <p>Show <i>View</i> buttons, and view entries in a <b>dialog box</b></p>
@@ -110,7 +110,7 @@
                     </div>
 										<br />
 
-										<{if $content.type == 'subformEditableRow'}>
+										<{if $content.typeIsSubformEditableRow}>
                     <div class="form-item">
                         <div class="form-radios">
                             <p>Disable these elements in each row:</p>

--- a/modules/formulize/templates/admin/element_type_yn.html
+++ b/modules/formulize/templates/admin/element_type_yn.html
@@ -6,8 +6,8 @@
   	  <div class="form-item">
   		<label for="max"><{$smarty.const._AM_ELE_DEFAULT}></label>
 
-	    <label for="elements-ele_value-yes"><input type="radio" id="elements-ele_value-yes" name="elements_ele_value" value="_YES"<{if $content.ele_value_yes}> checked<{/if}>/><{$smarty.const._YES}></label>
-	    <label for="elements-ele_value-no"><input type="radio" id="elements-ele_value-no" name="elements_ele_value" value="_NO"<{if $content.ele_value_no}> checked<{/if}>/><{$smarty.const._NO}></label>
+	    <label for="elements-ele_value-yes"><input type="radio" id="elements-ele_value-yes" name="elements_ele_value" value="<{$content.yes_db_value}>"<{if $content.ele_value_yes}> checked<{/if}>/><{$smarty.const._YES}></label>
+	    <label for="elements-ele_value-no"><input type="radio" id="elements-ele_value-no" name="elements_ele_value" value="<{$content.no_db_value}>"<{if $content.ele_value_no}> checked<{/if}>/><{$smarty.const._NO}></label>
   		<input type="submit" class="formButton" name="cleardef" value="<{$smarty.const._AM_CLEAR_DEFAULT}>"/>
 	    <div class="description"></div>
 	  </div>


### PR DESCRIPTION
Element classes had a few subtle dependencies outside the core classes. We have removed those so they can all be extended cleanly, and determinations like "is this a radio button" will still work, when you extend the radio button class, for example.