### PR TITLE
EMPTYSET searches and related features

### DIFF
--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -82,6 +82,12 @@ jobs:
     - name: PHP logic tests (T3.1' normalize-then-escape form sinks)
       run: docker exec formulize-web-1 php /var/www/html/tests/normalize_then_escape_test.php
 
+    - name: PHP logic tests (EMPTYSET searches and search term prefixes)
+      run: docker exec formulize-web-1 php /var/www/html/tests/empty_set_search_test.php
+
+    - name: PHP logic tests (partial date searches)
+      run: docker exec formulize-web-1 php /var/www/html/tests/date_search_test.php
+
     - name: Install dependencies
       run: npm ci
       working-directory: tests/e2e

--- a/modules/formulize/class/dateElement.php
+++ b/modules/formulize/class/dateElement.php
@@ -84,7 +84,6 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	var $clickable; // used in formatDataForList
 	var $striphtml; // used in formatDataForList
 	var $length; // used in formatDataForList
-	var $searchPeriod = false; // set by prepareLiteralTextForDB, read by buildSearchWhereClause
 
 	function __construct($db) {
 		$this->db =& $db;
@@ -301,11 +300,6 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	// if literal text that users type can be used as is to interact with the database, simply return the $value
 	// LINKED ELEMENTS AND UITEXT ARE RESOLVED PRIOR TO THIS METHOD BEING CALLED
 	function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
-		// Note whether this term names a whole month or year instead of one day, so buildSearchWhereClause can turn it into
-		// a range. Recorded on every call, including when there is no period, so that one search term's period cannot
-		// linger into the next term's clause. The value itself is still collapsed to a single date below, because every
-		// other caller of this method wants one date and only the search path knows what to do with a range.
-		$this->searchPeriod = formulize_parseDatePeriodSearchTerm($value);
 		$firstChar = substr($value, 0, 1);
 		$operators = array("=", "!", ">", "<");
 		if(!in_array($firstChar, $operators)) {
@@ -321,6 +315,13 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	 * Only partial dates are handled here. Anything else returns false, which sends the term back to the ordinary date
 	 * handling in the extraction layer completely untouched.
 	 *
+	 * $rawTerm carries the period, not $term: by the time prepareLiteralTextForDB has run, "October" is already collapsed
+	 * to a single day (every other caller of that method wants one date, not a range), so the range has to be recovered
+	 * from the original text instead. This is deliberately a parameter rather than something prepareLiteralTextForDB
+	 * records on $this for this method to read back - prepareLiteralTextForDB is called from many places that have
+	 * nothing to do with searching, and a value stashed on the handler instance between two calls would depend on
+	 * nothing else using that same shared instance in between, which is not something this method can guarantee.
+	 *
 	 * @param string $term The search term, already passed through prepareLiteralTextForDB by the caller
 	 * @param string $operator The normalized operator
 	 * @param string $quotes Unused here, the range is quoted as dates regardless
@@ -328,15 +329,17 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	 * @param int $fid The form id
 	 * @param string $tableAlias Unused here, the column reference below is already qualified
 	 * @param string $queryElement The fully qualified column being searched
+	 * @param string $rawTerm The search term as originally typed, before prepareLiteralTextForDB collapsed it to one date
 	 * @return string|false The where clause, or false to leave this term to the ordinary handling
 	 */
-	function buildSearchWhereClause($term, $operator, $quotes, $likebits, $fid, $tableAlias = 'main', $queryElement = '') {
+	function buildSearchWhereClause($term, $operator, $quotes, $likebits, $fid, $tableAlias = 'main', $queryElement = '', $rawTerm = '') {
 
-		if (!$this->searchPeriod OR !$queryElement) {
+		$searchPeriod = formulize_parseDatePeriodSearchTerm($rawTerm);
+		if (!$searchPeriod OR !$queryElement) {
 			return false;
 		}
-		$start = "'" . formulize_db_escape($this->searchPeriod['start']) . "'";
-		$end   = "'" . formulize_db_escape($this->searchPeriod['end']) . "'";
+		$start = "'" . formulize_db_escape($searchPeriod['start']) . "'";
+		$end   = "'" . formulize_db_escape($searchPeriod['end']) . "'";
 
 		// The comparisons people expect when they have named a period rather than a day: after October means after all of
 		// it, before October means before any of it, and a plain search for October means anywhere inside it.

--- a/modules/formulize/class/dateElement.php
+++ b/modules/formulize/class/dateElement.php
@@ -84,6 +84,7 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	var $clickable; // used in formatDataForList
 	var $striphtml; // used in formatDataForList
 	var $length; // used in formatDataForList
+	var $searchPeriod = false; // set by prepareLiteralTextForDB, read by buildSearchWhereClause
 
 	function __construct($db) {
 		$this->db =& $db;
@@ -300,12 +301,63 @@ class formulizeDateElementHandler extends formulizeElementsHandler {
 	// if literal text that users type can be used as is to interact with the database, simply return the $value
 	// LINKED ELEMENTS AND UITEXT ARE RESOLVED PRIOR TO THIS METHOD BEING CALLED
 	function prepareLiteralTextForDB($value, $element, $partialMatch=false) {
+		// Note whether this term names a whole month or year instead of one day, so buildSearchWhereClause can turn it into
+		// a range. Recorded on every call, including when there is no period, so that one search term's period cannot
+		// linger into the next term's clause. The value itself is still collapsed to a single date below, because every
+		// other caller of this method wants one date and only the search path knows what to do with a range.
+		$this->searchPeriod = formulize_parseDatePeriodSearchTerm($value);
 		$firstChar = substr($value, 0, 1);
 		$operators = array("=", "!", ">", "<");
 		if(!in_array($firstChar, $operators)) {
 			$value = date('Y-m-d', strtotime($value));
 		}
 		return $value;
+	}
+
+	/**
+	 * Turn a search for a whole month or year into a range, so that "October" finds every day in October rather than the
+	 * one day strtotime would collapse it to (which is today's date in October - not a reading anybody intends).
+	 *
+	 * Only partial dates are handled here. Anything else returns false, which sends the term back to the ordinary date
+	 * handling in the extraction layer completely untouched.
+	 *
+	 * @param string $term The search term, already passed through prepareLiteralTextForDB by the caller
+	 * @param string $operator The normalized operator
+	 * @param string $quotes Unused here, the range is quoted as dates regardless
+	 * @param string $likebits Unused here, a range is never a substring match
+	 * @param int $fid The form id
+	 * @param string $tableAlias Unused here, the column reference below is already qualified
+	 * @param string $queryElement The fully qualified column being searched
+	 * @return string|false The where clause, or false to leave this term to the ordinary handling
+	 */
+	function buildSearchWhereClause($term, $operator, $quotes, $likebits, $fid, $tableAlias = 'main', $queryElement = '') {
+
+		if (!$this->searchPeriod OR !$queryElement) {
+			return false;
+		}
+		$start = "'" . formulize_db_escape($this->searchPeriod['start']) . "'";
+		$end   = "'" . formulize_db_escape($this->searchPeriod['end']) . "'";
+
+		// The comparisons people expect when they have named a period rather than a day: after October means after all of
+		// it, before October means before any of it, and a plain search for October means anywhere inside it.
+		switch (trim($operator)) {
+			case '>=':
+				return " $queryElement >= $start ";
+			case '>':
+				return " $queryElement > $end ";
+			case '<=':
+				return " $queryElement <= $end ";
+			case '<':
+				return " $queryElement < $start ";
+			case '!=':
+			case '<>':
+			case 'NOT LIKE':
+				return " ( $queryElement < $start OR $queryElement > $end ) ";
+			case '=':
+			case 'LIKE':
+				return " ( $queryElement >= $start AND $queryElement <= $end ) ";
+		}
+		return false;
 	}
 
 	// this method will format a dataset value for display on screen when a list of entries is prepared

--- a/modules/formulize/docs/search_help.html
+++ b/modules/formulize/docs/search_help.html
@@ -273,6 +273,7 @@
 						<a name="Dates"/>
 						Dates
 				</h3>
+				<p class="Standard">Dates don't have to be typed in the YYYY-MM-DD form the database stores them in.  Write one the way you would say it and it will be worked out for you, so “Jan 1 2009”, “last Thursday” and “2009-01-01” are all fine.  The operators in the table below work with any of them.</p>
 				<div style="text-align:left">
 						<table
 								border="0"
@@ -328,39 +329,108 @@
 								</tr>
 								<tr class="Table81">
 										<td style="text-align:left;width:2.4569in; " class="Table8A2">
-												<p class="P14">&lt;2009-01//&gt;2007-12</p>
+												<p class="P14">Jan 1 2009<br>1 January 2009</p>
 										</td>
 										<td style="text-align:left;width:1.8764in; " class="Table8A2">
-												<p class="P14">find dates in the year 2008 (see below for more info on using two terms at once)</p>
+												<p class="P14">the same day, written the way you would say it</p>
 										</td>
 										<td style="text-align:left;width:2.1701in; " class="Table8C2">
-												<p class="P14">Any date starting with 2008</p>
+												<p class="P14">2009-01-01</p>
 										</td>
 								</tr>
 								<tr class="Table81">
 										<td style="text-align:left;width:2.4569in; " class="Table8A2">
-												<p class="P14">&gt;=2008-10-01//&lt;=2008-10-31</p>
+												<p class="P14">July 25<br>25 July</p>
 										</td>
 										<td style="text-align:left;width:1.8764in; " class="Table8A2">
-												<p class="P14">find dates in October 2008 (see below for more info on using two terms at once)</p>
+												<p class="P14">leave the year off and this year is filled in for you</p>
 										</td>
 										<td style="text-align:left;width:2.1701in; " class="Table8C2">
-												<p class="P14">Any date starting with 2008-10</p>
+												<p class="P14">July 25 of the current year</p>
 										</td>
 								</tr>
 								<tr class="Table81">
 										<td style="text-align:left;width:2.4569in; " class="Table8A2">
-												<p class="P14">2008-10</p>
+												<p class="P14">yesterday<br>last Thursday<br>next Monday<br>1 week ago</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">dates described in relation to today</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">the one day each of these works out to.  “last Thursday” is a single date, not everything since then.</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">&gt;=July 1 AND &lt;=July 31</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">find dates in July of this year (see below for more info on using two terms at once)</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">every date in July</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">&gt;=2008-10-01 AND &lt;=2008-10-31</p>
 										</td>
 										<td style="text-align:left;width:1.8764in; " class="Table8A2">
 												<p class="P14">find dates in October 2008</p>
 										</td>
 										<td style="text-align:left;width:2.1701in; " class="Table8C2">
-												<p class="P14">Any date starting with 2008-10 (same as the previous, more complex search)</p>
+												<p class="P14">every date in October 2008</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">between 2008-10-01 and 2008-10-31</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">the same search, said more plainly.  This one only understands dates written as YYYY-MM-DD.</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">every date in October 2008</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">October<br>Oct<br>Octobre</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">find every date in that month of this year</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">every date in October</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">Oct 2008<br>2008-10</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">the same month in a year you name</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">every date in October 2008</p>
+										</td>
+								</tr>
+								<tr class="Table81">
+										<td style="text-align:left;width:2.4569in; " class="Table8A2">
+												<p class="P14">2008</p>
+										</td>
+										<td style="text-align:left;width:1.8764in; " class="Table8A2">
+												<p class="P14">find every date in that year</p>
+										</td>
+										<td style="text-align:left;width:2.1701in; " class="Table8C2">
+												<p class="P14">every date in 2008</p>
 										</td>
 								</tr>
 						</table>
 				</div>
+				<p class="Standard">Naming a month or a year, rather than a day, searches the whole of it.  “October” finds every day in October this year, “Oct 2008” finds all of October 2008, and “2008” finds the whole year.  Months can be written out or shortened, in English or in the language you are reading the page in, so “Octobre” and “oct” work too.</p>
+				<p class="Standard">The operators work on the whole period as well, which is usually what you would expect:  &gt;=October means on or after the 1st, and &gt;October means after the month has finished.</p>
+				<p class="Standard">If what you type isn't a date that can be worked out then that column is left out of the search rather than finding nothing at all.</p>
 				<h3 class="P6">
 					<a name="Duration"/>
 						Duration
@@ -412,7 +482,7 @@
 								</tr>
 								<tr class="Table81">
 										<td style="text-align:left;width:2.4569in; " class="Table8A2">
-												<p class="P14">&lt;5h//&gt;10m</p>
+												<p class="P14">&lt;5h AND &gt;10m</p>
 										</td>
 										<td style="text-align:left;width:1.8764in; " class="Table8A2">
 												<p class="P14">Find a duraction greater than 10 minutes and less than 300 minutes</p>
@@ -427,6 +497,7 @@
 						<a name="More_than_one_search_on_the_same_column"/>
 						More than one search on the same column
 				</h3>
+				<p class="Standard">You can put several search terms in one box, joined by AND or by OR.  Type them in capitals, with a space on either side.</p>
 				<div style="text-align:left">
 						<table
 								border="0"
@@ -452,7 +523,7 @@
 								</tr>
 								<tr class="Table31">
 										<td style="text-align:left;width:2.4556in; " class="Table3A2">
-												<p class="P14">&gt;10//&lt;100</p>
+												<p class="P14">&gt;10 AND &lt;100</p>
 										</td>
 										<td style="text-align:left;width:2.2153in; " class="Table3A2">
 												<p class="P14">find numbers between 11 and 99</p>
@@ -463,7 +534,7 @@
 								</tr>
 								<tr class="Table31">
 										<td style="text-align:left;width:2.4556in; " class="Table3A2">
-												<p class="P14">&gt;10//&lt;10</p>
+												<p class="P14">&gt;10 AND &lt;10</p>
 										</td>
 										<td style="text-align:left;width:2.2153in; " class="Table3A2">
 												<p class="P14">find entries that are both greater than 10 and less than 10</p>
@@ -474,7 +545,7 @@
 								</tr>
 								<tr class="Table31">
 										<td style="text-align:left;width:2.4556in; " class="Table3A2">
-												<p class="P14">santa//!monica</p>
+												<p class="P14">santa AND !monica</p>
 										</td>
 										<td style="text-align:left;width:2.2153in; " class="Table3A2">
 												<p class="P14">find entries that contain “santa” and not “monica”</p>
@@ -491,7 +562,7 @@
 								</tr>
 								<tr class="Table31">
 										<td style="text-align:left;width:2.4556in; " class="Table3A2">
-												<p class="P11">&gt;=2008-10-01//&lt;=2008-10-31</p>
+												<p class="P11">&gt;=2008-10-01 AND &lt;=2008-10-31</p>
 										</td>
 										<td style="text-align:left;width:2.2153in; " class="Table3A2">
 												<p class="P14">find dates within October 2008</p>
@@ -506,7 +577,7 @@
 								</tr>
 								<tr class="Table31">
 										<td style="text-align:left;width:2.4556in; " class="Table3A2">
-												<p class="P11">red//orange//blue</p>
+												<p class="P11">red AND orange AND blue</p>
 										</td>
 										<td style="text-align:left;width:2.2153in; " class="Table3A2">
 												<p class="P15">find those three values.  You can have as many terms as you want in a single column.</p>
@@ -515,8 +586,84 @@
 												<p class="P15">Searches like this will usually only find matches if the field you're searching accepts multiple selections (ie: checkboxes), and red, orange and blue were three of the options.</p>
 										</td>
 								</tr>
+								<tr class="Table31">
+										<td style="text-align:left;width:2.4556in; " class="Table3A2">
+												<p class="P14">red OR blue</p>
+										</td>
+										<td style="text-align:left;width:2.2153in; " class="Table3A2">
+												<p class="P14">find entries that match either one. Terms joined by OR only need one of them to match.</p>
+										</td>
+										<td style="text-align:left;width:1.8306in; " class="Table3C2">
+												<p class="P14">
+														red
+														<br>
+														blue
+												</p>
+										</td>
+								</tr>
 						</table>
 				</div>
+				<p class="Standard">If you use OR in more than one column at a time, all of those terms end up in a single group, so an entry only has to match one of them.  See “OR searches on multiple columns” below for how that works, and how to make more than one separate group.</p>
+				<h3 class="P5">
+						<a name="Using_AND_and_OR_in_the_same_column"/>
+						Using AND and OR in the same column
+				</h3>
+				<p class="Standard">Writing AND and OR between terms in the same box does not work &mdash; there is no way to tell which part of “red OR blue AND green” you meant to group together, so the whole thing is searched for as plain text and finds nothing.</p>
+				<p class="Standard">To do it, join every term with AND, and put OR: on the front of the ones that should only need one match.  The OR: terms become a group of their own, and that group is then one of the things that has to be matched.</p>
+				<div style="text-align:left">
+						<table
+								border="0"
+								cellspacing="0"
+								cellpadding="0"
+								class="Table3"
+						>
+								<colgroup>
+										<col width="273">
+										<col width="246">
+										<col width="203">
+								</colgroup>
+								<tr class="Table31">
+										<td style="text-align:left;width:2.4556in; " class="Table3A1">
+												<p class="P9">This search term:</p>
+										</td>
+										<td style="text-align:left;width:2.2153in; " class="Table3A1">
+												<p class="P9">Means this:</p>
+										</td>
+										<td style="text-align:left;width:1.8306in; " class="Table3C1">
+												<p class="P9">It will find:</p>
+										</td>
+								</tr>
+								<tr class="Table31">
+										<td style="text-align:left;width:2.4556in; " class="Table3A2">
+												<p class="P14">santa AND OR:cruz AND OR:claus</p>
+										</td>
+										<td style="text-align:left;width:2.2153in; " class="Table3A2">
+												<p class="P14">santa has to match, and then either cruz or claus</p>
+										</td>
+										<td style="text-align:left;width:1.8306in; " class="Table3C2">
+												<p class="P14">
+														Santa Cruz
+														<br>
+														Santa Claus
+														<br>
+														(it won't find Santa Fe)
+												</p>
+										</td>
+								</tr>
+								<tr class="Table31">
+										<td style="text-align:left;width:2.4556in; " class="Table3A2">
+												<p class="P14">ORSET1:red AND ORSET1:blue AND ORSET2:small AND ORSET2:large</p>
+										</td>
+										<td style="text-align:left;width:2.2153in; " class="Table3A2">
+												<p class="P14">two separate groups, each needing only one match.  Use this when a plain OR: group isn't enough, the same way it works across columns.</p>
+										</td>
+										<td style="text-align:left;width:1.8306in; " class="Table3C2">
+												<p class="P14">entries that are (red or blue), and that are also (small or large)</p>
+										</td>
+								</tr>
+						</table>
+				</div>
+				<p class="Standard">Remember that plain OR: terms all join one group no matter which column they are in, so if you are already using OR: on another column, use the numbered ORSET form here to keep the two sets of terms apart.</p>
 				<h3 class="P6">
 						<a name="Wildcard_terms__7BTODAY_7D_and__7BUSER_7D"/>
 						Wildcard terms {TODAY}, {USER} and {BLANK}
@@ -568,7 +715,7 @@
 								</tr>
 								<tr class="Table41">
 										<td style="text-align:left;width:1.6618in; " class="Table4A2">
-												<p class="P14">&gt;={TODAY+30}//&lt;={TODAY}</p>
+												<p class="P14">&gt;={TODAY-30} AND &lt;={TODAY}</p>
 										</td>
 										<td style="text-align:left;width:2.6715in; " class="Table4A2">
 												<p class="P14">find dates between 30 days ago and today</p>
@@ -616,6 +763,7 @@
 						<a name="_E2_80_9COR_E2_80_9D_searches_on_multiple_columns"/>
 						“OR” searches on multiple columns
 				</h3>
+				<p class="Standard">The OR you type between two terms only joins terms inside that one box.  To make an OR search that spans two different columns, put OR on the front of the term in each of them instead.</p>
 				<div style="text-align:left">
 						<table
 								border="0"
@@ -644,11 +792,11 @@
 												<p class="P14">
 														<span class="T2">on the fruit column:</span>
 														<br>
-														ORapples
+														OR:apples
 														<br>
 														<span class="T2">and at the same time on the vegetable column:</span>
 														<br>
-														ORcarrots
+														OR:carrots
 												</p>
 										</td>
 										<td style="text-align:left;width:2.1667in; " class="Table5A2">
@@ -695,8 +843,127 @@
 												<p class="P13"></p>
 										</td>
 								</tr>
+								<tr class="Table51">
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">
+														<span class="T2">on the fruit column:</span>
+														<br>
+														ORSET1:apples
+														<br>
+														<span class="T2">on the vegetable column:</span>
+														<br>
+														ORSET1:carrots
+														<br>
+														<span class="T2">on the colour column:</span>
+														<br>
+														ORSET2:red
+														<br>
+														<span class="T2">on the size column:</span>
+														<br>
+														ORSET2:large
+												</p>
+										</td>
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">Make more than one separate “OR” group.  All the plain OR terms join together into a single group, but sometimes you need to ask two independent questions.  Terms with the same number are OR'd together, and then every group has to be matched.</p>
+										</td>
+										<td style="text-align:left;width:2.1681in; " class="Table5C2">
+												<p class="P14">entries that have (apples or carrots), and that also have (red or large)</p>
+										</td>
+								</tr>
 						</table>
 				</div>
+				<h3 class="P6">
+						<a name="Finding_entries_with_nothing_matching_in_a_connected_form"/>
+						Finding entries that have nothing matching in a connected form
+				</h3>
+				<p class="Standard">Some lists show information from more than one form at once. A list of customers might also show each customer's orders, for example. In a list like that, a single customer might have multiple orders showing.</p>
+				<p class="Standard">Searching for what is <i>missing</i> in a list like that needs a special search term. If you search the product column for “!shoes” (not shoes), you will find customers who have at least one order that isn't shoes. That includes customers who have an order for shoes, and an order for socks (because “socks” matches “not shoes”). Usually that isn't the question you meant to ask.</p>
+				<p class="Standard">EMPTYSET: asks it a different way.  Instead of looking at each order (row) on its own, it looks at all of one customer's orders together, and finds the customers where <i>none</i> of them match.</p>
+				<div style="text-align:left">
+						<table
+								border="0"
+								cellspacing="0"
+								cellpadding="0"
+								class="Table5"
+						>
+								<colgroup>
+										<col width="241">
+										<col width="241">
+										<col width="241">
+								</colgroup>
+								<tr class="Table51">
+										<td style="text-align:left;width:2.1667in; " class="Table5A1">
+												<p class="P9">This search term:</p>
+										</td>
+										<td style="text-align:left;width:2.1667in; " class="Table5A1">
+												<p class="P9">Means this:</p>
+										</td>
+										<td style="text-align:left;width:2.1681in; " class="Table5C1">
+												<p class="P9">It will find:</p>
+										</td>
+								</tr>
+								<tr class="Table51">
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">
+														<span class="T2">on the product column:</span>
+														<br>
+														EMPTYSET:shoes
+												</p>
+										</td>
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">Find the customers who have never ordered shoes</p>
+										</td>
+										<td style="text-align:left;width:2.1681in; " class="Table5C2">
+												<p class="P14">Customers with no shoe order at all, including customers who have never ordered anything</p>
+										</td>
+								</tr>
+								<tr class="Table51">
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">
+														<span class="T2">on the product column:</span>
+														<br>
+														EMPTYSET:shoes
+														<br>
+														<span class="T2">and at the same time on the status column:</span>
+														<br>
+														EMPTYSET:cancelled
+												</p>
+										</td>
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">Find the customers who have no cancelled orders for shoes. When you put EMPTYSET: on more than one column, each record is matched against all of those conditions together.</p>
+										</td>
+										<td style="text-align:left;width:2.1681in; " class="Table5C2">
+												<p class="P14">Customers with no cancelled shoe order.  A customer who cancelled a sock order is found. A customer who ordered shoes and kept them, is found.</p>
+										</td>
+								</tr>
+								<tr class="Table51">
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">
+														<span class="T2">on the product column:</span>
+														<br>
+														EMPTYSET1:shoes
+														<br>
+														<span class="T2">and at the same time on the status column:</span>
+														<br>
+														EMPTYSET2:cancelled
+												</p>
+										</td>
+										<td style="text-align:left;width:2.1667in; " class="Table5A2">
+												<p class="P14">Ask two separate questions instead of one.  Adding a number makes a separate group, the same way ORSET does above, so these become two independent conditions rather than a description of one order.</p>
+										</td>
+										<td style="text-align:left;width:2.1681in; " class="Table5C2">
+												<p class="P14">customers who have never ordered shoes, and who have also never cancelled anything</p>
+										</td>
+								</tr>
+						</table>
+				</div>
+				<p class="Standard">A few things to know about EMPTYSET:</p>
+				<ul>
+						<li><p class="Standard">It only works on columns that come from a connected form. In the example above, EMPTYSET: belongs on Order form columns, not on Customer Profile form columns.</p></li>
+						<li><p class="Standard">Entries with nothing connected to them at all are always found. A customer who has never placed an order would be included, regardless of the search term.</p></li>
+						<li><p class="Standard">You can search for anything you would normally type, not just plain words.  EMPTYSET:&gt;100 on an Amount column finds the entries with no connected record with an amount over 100.</p></li>
+						<li><p class="Standard">EMPTYSET terms are always combined with “and”.</p></li>
+				</ul>
 				<h3 class="P6">
 						<a name="Advanced_developer-focused_search_terms"/>
 						Advanced developer-focused search terms
@@ -746,10 +1013,10 @@
 								</tr>
 								<tr class="Table61">
 										<td style="text-align:left;width:1.5792in; " class="Table6A2">
-												<p class="P14">!!monica!//!santa!</p>
+												<p class="P14">!!monica! AND !santa!</p>
 										</td>
 										<td style="text-align:left;width:4.9222in; " class="Table6B2">
-												<p class="P14">When persisting a search that includes multiple terms, put the ! ! at the beginning and end of each term.  Don't get confused by “not” operators (!) that may be part of the terms (as in “not monica” at the beginning of this set of terms).</p>
+												<p class="P14">When persisting a search that includes multiple terms, put the ! ! around each term separately, not around the whole thing.  Don't get confused by “not” operators (!) that may be part of the terms (as in “not monica” at the beginning of this set of terms).</p>
 										</td>
 								</tr>
 						</table>

--- a/modules/formulize/include/entriesdisplay.php
+++ b/modules/formulize/include/entriesdisplay.php
@@ -1173,10 +1173,26 @@ function enforceSearchesAsFundamentalFilters($savedViewIndentifier, $screen) {
 							if(substr($searchTerm, 0, 1) == "!" AND substr($searchTerm, -1) == "!") {
 								$searchTerm = substr($searchTerm, 1, -1);
 							}
+							// Route through the same prefix parser a live search box uses, rather than the old bare substr(term,0,2)=="OR"
+							// check, so a saved search that happens to read as an OR (an all-capitals value like "ORANGE" or "ORDERS")
+							// is read the same way here as it now is everywhere else: as a literal search, not an OR for its tail end.
+							//
+							// CHANGE FROM USER INTENT, DOCUMENTED DELIBERATELY: fundamental_filters (the structure this function feeds)
+							// only has one 'oom' bucket - unlike a live search, there is no way for this structure to keep several
+							// distinct ORSET groups apart, or to represent EMPTYSET's "must match no connected entry" semantics at all
+							// as a plain oom/all row. ORSET1:a and ORSET2:b, meant as two separate OR sets combined with AND ("(a) AND
+							// (b)", each an OR of its own group's terms), collapse into a single combined OR: "(a OR b)". That changes
+							// what the search means, it is not just a compatibility shim. Representing multiple named OR sets (or
+							// EMPTYSET) correctly here would need fundamental_filters itself extended to carry that information - a
+							// larger structural change to the conditions filter system, out of scope for this fix.
+							// EMPTYSET is unaffected by that limitation here: its own prefix is deliberately left in $searchTerm
+							// untouched below (group !== 'or'/'orset'), because formulize_extractEmptySetConditions() downstream
+							// re-parses the raw term for exactly this prefix and already resolves it correctly on its own.
 							$oomAll = 'all';
-							if(substr($searchTerm, 0, 2) == "OR") {
+							$groupPrefix = formulize_extractSearchGroupPrefix($searchTerm);
+							if ($groupPrefix['group'] === 'or' OR $groupPrefix['group'] === 'orset') {
 								$oomAll = 'oom';
-								$searchTerm = substr($searchTerm, 2);
+								$searchTerm = $groupPrefix['term'];
 							}
 							$operator = extractOperatorFromString($searchTerm);
 							$searchTerm = substr($searchTerm, strlen($operator));
@@ -4764,10 +4780,12 @@ function formulize_gatherDataSet($settings, $searches, $sort, $order, $frid, $fi
 	$showcols = explode(",", $settings['oldcols']);
 	if ($settings['global_search']) {
 		foreach($showcols as $column) {
+			// OR: rather than bare OR, since this constructs the OR group syntax programmatically and an all-capitals global
+			// search term (a country code, an acronym) must still be read as an OR search rather than a literal search.
 			if ($searches[$column]) {
-				$searches[$column] .= "//OR" . $settings['global_search'];
+				$searches[$column] .= "//OR:" . $settings['global_search'];
 			} else {
-				$searches[$column] = "OR" . $settings['global_search'];
+				$searches[$column] = "OR:" . $settings['global_search'];
 			}
 		}
 	}

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -797,9 +797,9 @@ function dataExtraction($frame, $form, $filter, $andor, $scope, $limitStart, $li
 							}
 						}
 						// bracket the clauses for this form when there is more than one of them, so the global and/or between forms cannot bind into the middle of the set
-						$existsJoinText .= $existsBoolean . (count($existsClausesForThisForm) > 1
-							? " ( " . implode(" AND ", $existsClausesForThisForm) . " ) "
-							: implode("", $existsClausesForThisForm));
+						if ($existsClausesForThisForm) {
+					    $existsJoinText .= $existsBoolean . " ( " . implode(" AND ", $existsClausesForThisForm) . " ) ";
+						}
 					}
 				}
 			}
@@ -2002,6 +2002,7 @@ function formulize_tryDelegatedSearchWhere($eleType, $term, $operator, $quotes, 
 
 	$typeHandler = xoops_getmodulehandler($eleType . 'Element', 'formulize');
 	if ($typeHandler && method_exists($typeHandler, 'buildSearchWhereClause')) {
+		$rawTerm = $term; // kept aside for handlers (currently just dateElement) that need the term as originally typed, before it is collapsed below
 		$isPartial = ($normalizedOperator === 'LIKE' || $normalizedOperator === 'NOT LIKE');
 		$term = $typeHandler->prepareLiteralTextForDB($term, null, $isPartial);
 
@@ -2023,9 +2024,9 @@ function formulize_tryDelegatedSearchWhere($eleType, $term, $operator, $quotes, 
 			$likebits = '';
 			$quotes = $quotes === '' ? '' : "'";
 		}
-		// $queryElement is the fully qualified column this term is searching, for the element types whose column varies
-		// from form to form. Handlers with a fixed column of their own simply do not declare the parameter.
-		return $typeHandler->buildSearchWhereClause($term, $normalizedOperator, $quotes, $likebits, $fid, $tableAlias, $queryElement);
+		// $queryElement and $rawTerm are only declared by handlers that need them (currently just dateElement, for the
+		// fully qualified column and the pre-collapse term respectively) - every other handler simply ignores the extra args.
+		return $typeHandler->buildSearchWhereClause($term, $normalizedOperator, $quotes, $likebits, $fid, $tableAlias, $queryElement, $rawTerm);
 	}
 	return false;
 }
@@ -2312,11 +2313,15 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 					// key held in one of those alternate columns rather than a reference to this element's own target. Work that out before the
 					// shortcut below, because it decides whether the number is compared to this element or looked up inside the source form.
 					$altColumnFKTargets = formulize_altColumnFKTargetsForSearch($formFieldFilterMap[$mappedForm][$element_id], $ifParts, $operator);
+					// Loaded once here rather than inside the elseif below, so its failure can also be checked by the first branch: if the form
+					// this element supposedly links to cannot be loaded, the FK subquery below has nothing to query, and the safe fallback is
+					// the direct comparison every other unresolvable case already takes, not the substring text search two branches down.
+					$fkSourceFormObject = $altColumnFKTargets ? $form_handler->get($sourceMeta[0]) : false;
 
 					// check if user is searching for blank values, and if so, then query this element directly, rather than looking in the source
 					// ALSO do this if the user is searching for a numeric value with an = operator, unless that number belongs to an alternate column (see above)
 					// Note that $ifParts[0] gets surrounded by `` when going through prepareElementMetaData (?!)
-					if (($ifParts[1] === '' OR trim($operator) == 'IS NULL' OR trim($operator) == 'IS NOT NULL' OR (is_numeric($ifParts[1]) AND trim($operator) == '=' AND !$altColumnFKTargets)) AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
+					if (($ifParts[1] === '' OR trim($operator) == 'IS NULL' OR trim($operator) == 'IS NOT NULL' OR (is_numeric($ifParts[1]) AND trim($operator) == '=' AND (!$altColumnFKTargets OR !$fkSourceFormObject))) AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
 						$newWhereClause = " $queryElement $operator $quotes$likebits" . formulize_db_escape($ifParts[1]) . "$likebits$quotes ";
 
 					// A numeric equals search that belongs to one or more linked alternate columns. Compare it to those columns' foreign keys directly,
@@ -2328,14 +2333,18 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 					// quickfilter dropdowns emit for a linked column and reinterpreting it would change every saved view and screen that uses one.
 					// Callers that have declared the number is a literal label rather than a key are left alone too, and fall through to the text search.
 					} elseif ($altColumnFKTargets
-						AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])
-						AND $fkSourceFormObject = $form_handler->get($sourceMeta[0])) {
+						AND $fkSourceFormObject
+						AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
 						$fkComparisons = array();
 						$fkValue = intval($ifParts[1]);
 						foreach ($altColumnFKTargets as $fkTargetHandle) {
-							$safeFKHandle = formulize_db_escape($fkTargetHandle);
+							// this is a column identifier going in unquoted backticks, not a string literal, so it is validated against
+							// a whitelist rather than escaped - the same rule formulize_tryDelegatedSearchWhere() applies to $tableAlias
+							if (!formulizeDataHandler::validateSqlIdentifier($fkTargetHandle)) {
+								continue;
+							}
 							// the alternate column can itself hold multiple values, in which case it stores a comma wrapped list rather than a single entry id
-							$fkComparisons[] = "(source.`$safeFKHandle` = $fkValue OR source.`$safeFKHandle` LIKE '%,$fkValue,%')";
+							$fkComparisons[] = "(source.`$fkTargetHandle` = $fkValue OR source.`$fkTargetHandle` LIKE '%,$fkValue,%')";
 						}
 						// correlate to the source form the same way the text searches below do, so that a linked element holding multiple values still matches
 						$newWhereClause = " EXISTS (SELECT 1 FROM " . DBPRE . "formulize_" . $fkSourceFormObject->getVar('form_handle') . " AS source WHERE ($queryElement = source.entry_id OR $queryElement LIKE CONCAT('%,',source.entry_id,',%')) AND (" . implode(" OR ", $fkComparisons) . ")) ";
@@ -2750,6 +2759,39 @@ function formulize_noSearchableColumn($element_id) {
 }
 
 /**
+ * Resolve an element (id or handle) to its own handle and, if it is a linked element with somewhere valid to point,
+ * the form and element it points at - using the bulk element metadata cache (formulize_getElementMetaData(), via
+ * formulize_isLinkedElement()) rather than a fresh per-element query.
+ *
+ * This is the operation resolveLinkedAltSearchColumnsToSubquery() and formulize_altColumnFKTargetsForSearch() both need,
+ * for two different roles (an alternate display column, and the column a search value was borrowed from) that turn out
+ * to be the same question: is this element linked, and if so where. Sharing it means the bulk cache seeded once per
+ * form in dataExtraction() actually gets used here too, instead of each caller re-fetching the same element by hand.
+ *
+ * @param mixed $elementIdOrHandle An element id or handle
+ * @return array|false ['handle' => this element's own ele_handle, 'sourceFormId' => int, 'sourceElementHandle' => string],
+ *   or false when the element does not exist, is not linked, or is a snapshot (which holds its label as literal text
+ *   in its own column, not a foreign key, so there is nothing to resolve)
+ */
+function formulize_resolveLinkedElementCached($elementIdOrHandle) {
+	$isHandle = !is_numeric($elementIdOrHandle);
+	$metadata = formulize_getElementMetaData($elementIdOrHandle, $isHandle);
+	if (empty($metadata)) {
+		return false;
+	}
+	// formulize_isLinkedElement() already excludes snapshots (which store their label as literal text, not a foreign
+	// key) and returns the unserialized ele_value on success, whose [2] slot is "sourceFormId#*=:*sourceElementHandle".
+	if (!$linkedEleValue = formulize_isLinkedElement($elementIdOrHandle)) {
+		return false;
+	}
+	list($sourceFormId, $sourceElementHandle) = explode("#*=:*", $linkedEleValue[2]);
+	if (!$sourceFormId OR !$sourceElementHandle) {
+		return false;
+	}
+	return array('handle' => $metadata['ele_handle'], 'sourceFormId' => intval($sourceFormId), 'sourceElementHandle' => $sourceElementHandle);
+}
+
+/**
  * Check for alternate search columns that are themselves linked elements, remove them from the list and return subqueries for them to use in the WHERE clause
  * The alternate search columns are elements in the source form of the linked element being searched, ie: the form that is aliased as "source" in the EXISTS clause that the subqueries returned here are embedded in, so that is what the subqueries correlate against
  * @param array $altSearchColumns The list of alternate search columns to check for linked forms, passed by reference so that linked columns can be removed from the list
@@ -2760,29 +2802,20 @@ function resolveLinkedAltSearchColumnsToSubquery(&$altSearchColumns) {
 	$subqueries = array();
 	$form_handler = xoops_getmodulehandler('forms', 'formulize');
 	foreach ($altSearchColumns as $idx => $altSearchColumn) {
-		// does the alt search column exist?
-		if(!$altSearchElementObject = _getElementObject($altSearchColumn)) {
+		// does the alt search column exist, is it a linked element pointing elsewhere, and is it not a snapshot (which
+		// holds its label as literal text in its own column instead of an entry id)? If any of that is not true, it is
+		// searched directly as a column, so leave it in the list.
+		if(!$resolved = formulize_resolveLinkedElementCached($altSearchColumn)) {
 			continue;
 		}
-		// is it a linked element pointing elsewhere, with valid link metadata? if not, then it is searched directly as a column, so leave it in the list
-		if(!$sourceReference = getSourceFormAndElementForLinkedElement($altSearchElementObject)) {
-			continue;
-		}
-		// snapshot elements are linked, but they store the literal label text in their own column instead of an entry id, so they are searched directly as a column too.
-		// this is the same exclusion that formulize_isLinkedElement and formulize_mapFormFieldFilter make, and it has to be made here as well, because getSourceFormAndElementForLinkedElement does not make it
-		$altSearchEleValue = $altSearchElementObject->getVar('ele_value');
-		if(is_array($altSearchEleValue) AND !empty($altSearchEleValue['snapshot'])) {
-			continue;
-		}
-		list($sourceFormId, $sourceElementHandle) = $sourceReference;
-		if(!$formObject = $form_handler->get($sourceFormId)) {
+		if(!$formObject = $form_handler->get($resolved['sourceFormId'])) {
 			throw new Exception("Could not find source form for linked alternate search column ".htmlspecialchars(strip_tags((string) $altSearchColumn)));
 		}
 		unset($altSearchColumns[$idx]); // remove the linked column from the list of columns to search, since we are using a subquery for it
 		$sqNum++;
 		$sourceFormHandle = $formObject->getVar('form_handle');
 		// prepare a subquery to look up the value that the linked alternate search column is pointing to, correlating on the "source" alias of the enclosing EXISTS clause, since the alt search column is a column in that form
-		$subqueries[] = "(SELECT source$sqNum.`" . $sourceElementHandle . "` FROM " . DBPRE . "formulize_" . $sourceFormHandle . " AS source$sqNum WHERE source$sqNum.entry_id = source.`" . $altSearchElementObject->getVar('ele_handle') . "`)";
+		$subqueries[] = "(SELECT source$sqNum.`" . $resolved['sourceElementHandle'] . "` FROM " . DBPRE . "formulize_" . $sourceFormHandle . " AS source$sqNum WHERE source$sqNum.entry_id = source.`" . $resolved['handle'] . "`)";
 	}
 	return $subqueries;
 }
@@ -2815,23 +2848,25 @@ function formulize_extractEmptySetConditions($fundamental_filters, $filter) {
 	}
 
 	$emptySetTerms = array(); // keyed by the group key from the prefix, so that EMPTYSET1: and EMPTYSET2: stay separate sets
-	$remaining = array(0 => array(), 1 => array(), 2 => array(), 3 => array());
+	$emptySetIndexes = array(); // indexes of the rows pulled out below, so they can be dropped from the remaining filters afterward
 	$sawEmptySetCondition = false;
 
 	foreach ($fundamental_filters[0] as $i => $conditionElementId) {
 
+		// normalize this row's operator and type now, so a gap in a ragged fundamental_filters array can't produce an undefined
+		// index later - whether or not this row turns out to be an empty set.
+		$fundamental_filters[1][$i] = isset($fundamental_filters[1][$i]) ? $fundamental_filters[1][$i] : "=";
 		$term = isset($fundamental_filters[2][$i]) ? $fundamental_filters[2][$i] : "";
+		$fundamental_filters[3][$i] = isset($fundamental_filters[3][$i]) ? $fundamental_filters[3][$i] : "all";
+
 		$groupPrefix = formulize_extractSearchGroupPrefix($term);
 		if ($groupPrefix['group'] !== 'emptyset') {
-			$remaining[0][] = $conditionElementId;
-			$remaining[1][] = isset($fundamental_filters[1][$i]) ? $fundamental_filters[1][$i] : "=";
-			$remaining[2][] = $term;
-			$remaining[3][] = isset($fundamental_filters[3][$i]) ? $fundamental_filters[3][$i] : "all";
 			continue;
 		}
 
 		// this row is an empty set whatever happens to its term below. Note it now, so that a term we end up dropping still gets taken
 		// out of the fundamental filters - left behind, the prefix would be read as part of a literal search value and match nothing.
+		$emptySetIndexes[] = $i;
 		$sawEmptySetCondition = true;
 
 		// resolve a reference to another column's search box. This also reports which column the value came from, which the
@@ -2857,8 +2892,7 @@ function formulize_extractEmptySetConditions($fundamental_filters, $filter) {
 			}
 		}
 
-		$operator = isset($fundamental_filters[1][$i]) ? $fundamental_filters[1][$i] : "=";
-		$operator = ($operator == 'NOT') ? '!=' : $operator; // the same conversion buildConditionsFilterSQL makes, to avoid a syntax error
+		$operator = ($fundamental_filters[1][$i] == 'NOT') ? '!=' : $fundamental_filters[1][$i]; // the same conversion buildConditionsFilterSQL makes, to avoid a syntax error
 
 		$thisTerm = $conditionElementId . "/**/" . $value . "/**/" . $operator;
 		if ($provenanceHandle) {
@@ -2873,6 +2907,13 @@ function formulize_extractEmptySetConditions($fundamental_filters, $filter) {
 
 	foreach ($emptySetTerms as $theseTerms) {
 		$filter[] = array(0 => 'and', 1 => implode("][", $theseTerms), 2 => 'none'); // every condition in one set has to be true of the same connected entry
+	}
+
+	// drop the rows pulled out above, keeping the four parallel arrays in step with each other
+	$dropIndexes = array_flip($emptySetIndexes);
+	$remaining = array();
+	foreach (array(0, 1, 2, 3) as $col) {
+		$remaining[$col] = array_values(array_diff_key($fundamental_filters[$col], $dropIndexes));
 	}
 
 	// a set of parallel arrays that are all empty still counts as four elements, so hand back a genuinely empty array when nothing is left,
@@ -2928,47 +2969,29 @@ function formulize_altColumnFKTargetsForSearch($elementFilterMapEntry, $ifParts,
 		return array();
 	}
 
-	// which of the alternate columns are linked elements, and what form does each of them point at?
+	// which of the alternate columns are linked elements, and what form does each of them point at? (snapshot alt
+	// columns, which hold literal label text rather than a foreign key, are excluded inside the helper itself.)
 	$candidates = array();
 	foreach (array_filter(is_array($ele_value[10]) ? $ele_value[10] : array($ele_value[10])) as $altSearchColumn) {
-		if (!$altSearchElementObject = _getElementObject($altSearchColumn)) {
-			continue;
+		if ($resolved = formulize_resolveLinkedElementCached($altSearchColumn)) {
+			$candidates[] = $resolved;
 		}
-		if (!$sourceReference = getSourceFormAndElementForLinkedElement($altSearchElementObject)) {
-			continue;
-		}
-		// snapshot elements are linked, but they store the literal label text in their own column, so they hold no foreign key to compare.
-		// Same exclusion resolveLinkedAltSearchColumnsToSubquery makes, for the same reason.
-		$altSearchEleValue = $altSearchElementObject->getVar('ele_value');
-		if (is_array($altSearchEleValue) AND !empty($altSearchEleValue['snapshot'])) {
-			continue;
-		}
-		$candidates[] = array('handle' => $altSearchElementObject->getVar('ele_handle'), 'sourceFormId' => $sourceReference[0]);
 	}
 	if (!$candidates) {
 		return array();
 	}
 
 	// if the value came out of another column's search box, and that column points at the same form as exactly one of the candidates, that is the one
-	if (!empty($ifParts[3]) AND $provenanceElementObject = _getElementObject($ifParts[3])) {
-		if ($provenanceReference = getSourceFormAndElementForLinkedElement($provenanceElementObject)) {
-			$provenanceMatches = array();
-			foreach ($candidates as $candidate) {
-				if ($candidate['sourceFormId'] == $provenanceReference[0]) {
-					$provenanceMatches[] = $candidate['handle'];
-				}
-			}
-			if (count($provenanceMatches) == 1) {
-				return $provenanceMatches;
-			}
+	if (!empty($ifParts[3]) AND $provenanceResolved = formulize_resolveLinkedElementCached($ifParts[3])) {
+		$provenanceMatches = array_filter($candidates, function($candidate) use ($provenanceResolved) {
+			return $candidate['sourceFormId'] == $provenanceResolved['sourceFormId'];
+		});
+		if (count($provenanceMatches) == 1) {
+			return array_column($provenanceMatches, 'handle');
 		}
 	}
 
-	$handles = array();
-	foreach ($candidates as $candidate) {
-		$handles[] = $candidate['handle'];
-	}
-	return $handles;
+	return array_column($candidates, 'handle');
 }
 
 // THIS FUNCTION TAKES INPUTS ABOUT AND ELEMENT, AND RETURNS A SET OF INFORMATION THAT IS NECESSARY WHEN BUILDING VARIOUS PARTS OF THE WHERE CLAUSE

--- a/modules/formulize/include/extract.php
+++ b/modules/formulize/include/extract.php
@@ -629,7 +629,7 @@ function dataExtraction($frame, $form, $filter, $andor, $scope, $limitStart, $li
 		// PARSE THE FILTER THAT HAS BEEN PASSED IN, INTO WHERE CLAUSE AND OTHER RELATED CLAUSES WE WILL NEED
 		// parsing the filter MUST come early in the process, because other things rely on it!
 		formulize_getElementMetaData("", false, $fid); // initialize the element metadata for this form...serious performance gain from this
-		list($formFieldFilterMap, $whereClause, $orderByClause, $oneSideFilters, $otherPerGroupFilterJoins, $otherPerGroupFilterWhereClause, $missingEntrySatisfiesSearch) = formulize_parseFilter($filter, $andor, $linkformids, $fid, $frid, $scope, $isUserTableForm);
+		list($formFieldFilterMap, $whereClause, $orderByClause, $oneSideFilters, $otherPerGroupFilterJoins, $otherPerGroupFilterWhereClause, $missingEntrySatisfiesSearch, $emptySetFilters) = formulize_parseFilter($filter, $andor, $linkformids, $fid, $frid, $scope, $isUserTableForm);
 
 		// ***********************
 		// NOTE:  the oneSideFilters are divided into two sections, the AND filters and OR filters for a given form
@@ -730,7 +730,8 @@ function dataExtraction($frame, $form, $filter, $andor, $scope, $limitStart, $li
 					$linkSelectIndex[$formAliasId] = "f$formAliasId.entry_id AS f" . $formAliasId . "_entry_id, f$formAliasId.creation_uid AS f" . $formAliasId . "_creation_uid, f$formAliasId.mod_uid AS f" . $formAliasId . "_mod_uid, f$formAliasId.creation_datetime AS f" . $formAliasId . "_creation_datetime, f$formAliasId.mod_datetime AS f" . $formAliasId . "_mod_datetime, f$formAliasId.*";
 					$linkSelect .= ", ".$linkSelectIndex[$formAliasId];
 					// when a main form entry with no connected entry would satisfy the search on this form, stay with a LEFT JOIN so those entries survive the join, and then get matched by the "IS NULL" terms in the where clause
-					$joinType = (isset($formFieldFilterMap[$linkedFid]) AND !isset($missingEntrySatisfiesSearch[$linkedFid])) ? "INNER" : "LEFT";
+					// an empty set expression on this form does the same thing for a different reason: an entry with nothing connected to it satisfies "no connected entry matches this" by definition, so it has to survive the join to be tested
+					$joinType = (isset($formFieldFilterMap[$linkedFid]) AND !isset($missingEntrySatisfiesSearch[$linkedFid]) AND !isset($emptySetFilters[$linkedFid])) ? "INNER" : "LEFT";
 					$linkedFormObject = $form_handler->get($linkedFid);
 					if($linkedFormObject->getVar('entries_are_users')) {
 						$linkedEauUidColumn = 'formulize_user_account_uid_' . $linkedFid;
@@ -755,32 +756,50 @@ function dataExtraction($frame, $form, $filter, $andor, $scope, $limitStart, $li
 					}
 					$joinTextIndex["f" . $formAliasId] = $newJoinText;
 					$joinText .= $newJoinText;
-					if (isset($oneSideFilters[$linkedFid]) AND is_array($oneSideFilters[$linkedFid]) AND count($oneSideFilters[$linkedFid]) > 0) { // only setup the existsJoinText when there is a where clause that applies to this form...otherwise, we don't care, this form is not relevant to the query that the calculations will do (except maybe when the mainform is not the one-side form...but that's another story)
+					$hasOneSideFilters = (isset($oneSideFilters[$linkedFid]) AND is_array($oneSideFilters[$linkedFid]) AND count($oneSideFilters[$linkedFid]) > 0);
+					$hasEmptySetFilters = (isset($emptySetFilters[$linkedFid]) AND is_array($emptySetFilters[$linkedFid]) AND count($emptySetFilters[$linkedFid]) > 0);
+					if ($hasOneSideFilters OR $hasEmptySetFilters) { // only setup the existsJoinText when there is a where clause that applies to this form...otherwise, we don't care, this form is not relevant to the query that the calculations will do (except maybe when the mainform is not the one-side form...but that's another story)
 						// If this linked form is entries_are_users and any filter references its EAU table aliases,
 						// inject those joins inside the EXISTS subquery (before the WHERE).
 						$existsEauJoins = "";
 						if (isset($eauLinkedJoinTextIndex[$linkedFid])) {
-							$linkedFilterContent = implode(' ', $oneSideFilters[$linkedFid]);
+							$linkedFilterContent = implode(' ', ($hasOneSideFilters ? $oneSideFilters[$linkedFid] : array()))
+								. ' ' . implode(' ', ($hasEmptySetFilters ? $emptySetFilters[$linkedFid] : array()));
 							$eauAlias = "f$formAliasId";
 							if (strpos($linkedFilterContent, "eau_usertable_{$eauAlias}") !== false ||
 								strpos($linkedFilterContent, "eau_profile_{$eauAlias}") !== false) {
 								$existsEauJoins = $eauLinkedJoinTextIndex[$linkedFid];
 							}
 						}
+						$thisLinkedFidPerGroupFilter = isset($perGroupFiltersPerForms[$linkedFid]) ? $perGroupFiltersPerForms[$linkedFid] : "";
 						$existsBoolean = $existsJoinText ? " $andor " : "";
 						$existsFromAndAlias = DBPRE . "formulize_" . $linkedFormObject->getVar('form_handle') . " AS f$formAliasId";
-						$thisExists = " EXISTS(SELECT 1 FROM $existsFromAndAlias $existsEauJoins WHERE " . $newJoinText;
-						foreach ($oneSideFilters[$linkedFid] as $thisOneSideFilter) {
-							$thisLinkedFidPerGroupFilter = isset($perGroupFiltersPerForms[$linkedFid]) ? $perGroupFiltersPerForms[$linkedFid] : "";
-							$thisExists .= " AND ( $thisOneSideFilter $thisLinkedFidPerGroupFilter) ";
+						$existsClausesForThisForm = array();
+						if ($hasOneSideFilters) {
+							$thisExists = " EXISTS(SELECT 1 FROM $existsFromAndAlias $existsEauJoins WHERE " . $newJoinText;
+							foreach ($oneSideFilters[$linkedFid] as $thisOneSideFilter) {
+								$thisExists .= " AND ( $thisOneSideFilter $thisLinkedFidPerGroupFilter) ";
+							}
+							$thisExists .= ") "; // close the exists clause itself
+							// the exists clause on its own throws away main form entries that have nothing connected to them at all, so when those entries would satisfy the search, allow for them explicitly.
+							// Note $newJoinText already has this form's per group filter on the end of it, so a connected entry the user isn't allowed to see counts as no connected entry, which is what we want.
+							if (isset($missingEntrySatisfiesSearch[$linkedFid])) {
+								$thisExists = " ( $thisExists OR NOT EXISTS(SELECT 1 FROM $existsFromAndAlias $existsEauJoins WHERE $newJoinText) ) ";
+							}
+							$existsClausesForThisForm[] = $thisExists;
 						}
-						$thisExists .= ") "; // close the exists clause itself
-						// the exists clause on its own throws away main form entries that have nothing connected to them at all, so when those entries would satisfy the search, allow for them explicitly.
-						// Note $newJoinText already has this form's per group filter on the end of it, so a connected entry the user isn't allowed to see counts as no connected entry, which is what we want.
-						if (isset($missingEntrySatisfiesSearch[$linkedFid])) {
-							$thisExists = " ( $thisExists OR NOT EXISTS(SELECT 1 FROM $existsFromAndAlias $existsEauJoins WHERE $newJoinText) ) ";
+						// Empty set expressions are the mirror image: the main form entry qualifies only when no connected entry matches the conditions.
+						// Each expression is its own clause, and they are always AND'd, since each one names a connected entry that must not be there.
+						// An entry with nothing connected to it passes these automatically, which is the behaviour we want and why the join is left open.
+						if ($hasEmptySetFilters) {
+							foreach ($emptySetFilters[$linkedFid] as $thisEmptySetFilter) {
+								$existsClausesForThisForm[] = " NOT EXISTS(SELECT 1 FROM $existsFromAndAlias $existsEauJoins WHERE " . $newJoinText . " AND ( $thisEmptySetFilter $thisLinkedFidPerGroupFilter) ) ";
+							}
 						}
-						$existsJoinText .= $existsBoolean . $thisExists;
+						// bracket the clauses for this form when there is more than one of them, so the global and/or between forms cannot bind into the middle of the set
+						$existsJoinText .= $existsBoolean . (count($existsClausesForThisForm) > 1
+							? " ( " . implode(" AND ", $existsClausesForThisForm) . " ) "
+							: implode("", $existsClausesForThisForm));
 					}
 				}
 			}
@@ -1965,7 +1984,7 @@ function gatherDerivedValueFieldMetadata($fid, $linkformids)
 // Returns the WHERE clause string if the handler implements buildSearchWhereClause(), or false otherwise.
 // This allows element types that require complex subqueries (e.g., group_memberships) to encapsulate
 // their own SQL generation rather than embedding it in the monolithic formulize_parseFilter function.
-function formulize_tryDelegatedSearchWhere($eleType, $term, $operator, $quotes, $likebits, $fid, $tableAlias = 'main')
+function formulize_tryDelegatedSearchWhere($eleType, $term, $operator, $quotes, $likebits, $fid, $tableAlias = 'main', $queryElement = '')
 {
 	$classFile = XOOPS_ROOT_PATH . '/modules/formulize/class/' . $eleType . 'Element.php';
 	if (!file_exists($classFile)) {
@@ -2004,7 +2023,9 @@ function formulize_tryDelegatedSearchWhere($eleType, $term, $operator, $quotes, 
 			$likebits = '';
 			$quotes = $quotes === '' ? '' : "'";
 		}
-		return $typeHandler->buildSearchWhereClause($term, $normalizedOperator, $quotes, $likebits, $fid, $tableAlias);
+		// $queryElement is the fully qualified column this term is searching, for the element types whose column varies
+		// from form to form. Handlers with a fixed column of their own simply do not declare the parameter.
+		return $typeHandler->buildSearchWhereClause($term, $normalizedOperator, $quotes, $likebits, $fid, $tableAlias, $queryElement);
 	}
 	return false;
 }
@@ -2016,7 +2037,7 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 {
 	global $xoopsDB;
 	if ($filtertemp == "") {
-		return array(array(), "", "", array(), "", "", array());
+		return array(array(), "", "", array(), "", "", array(), array());
 	}
 
 	$formFieldFilterMap = array();
@@ -2026,6 +2047,8 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 	$otherPerGroupFilterWhereClause = array();
 
 	$missingEntryTermCounts = array(); // per connected form, per local and/or, per search expression: how many terms there are, and how many of them a main form entry with no connected entry at all would satisfy. Used further down to work out whether such entries need to be included in the results
+
+	$emptySetFiltersTemp = array(); // per connected form, per search expression: conditions that must match NO connected entry. Rendered as NOT EXISTS clauses by the caller, and never part of the row level where clause
 
 	$oneSideFiltersTemp = array(); // we need to capture each filter individually, just in case we need to apply them individually to each part of the query for calculations.  Filters for calculations will not work right if the combination of filter terms is excessively complex, ie: includes OR'd terms across different forms in a framework, certain other complicated types of bracketing
 
@@ -2045,6 +2068,10 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 	} else {
 		$filter = $filtertemp;
 	}
+
+	// conditions written with an EMPTYSET: prefix are lifted out of the fundamental filters and turned into ordinary search expressions here,
+	// so that the loop below handles them the same way it handles one typed into a search box
+	list($fundamental_filters, $filter) = formulize_extractEmptySetConditions($fundamental_filters, $filter);
 
 	// When user is anon, add anon passcodes if any to the fundamental filters, if the passed in scope is uid=0 or [3], which would both mean "view all entries by the anon user".
 	global $xoopsUser;
@@ -2085,10 +2112,17 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 			continue;
 		} // ignore filters that are empty...can happen if only OR filters are specified, and maybe at other times too
 
-		if ($numSeachExps > 0) {
-			$whereClause .= $andor;
+		// An expression can carry a quantifier in its third slot. "none" means its conditions describe connected entries that must NOT
+		// exist for a main form entry to qualify. Those terms never go into the row level where clause, because the entries we are looking
+		// for are precisely the ones with no such row to compare against. They only go into the EXISTS layer, negated, further down.
+		$expressionIsEmptySet = (isset($filterParts[2]) AND $filterParts[2] === 'none');
+
+		if (!$expressionIsEmptySet) {
+			if ($numSeachExps > 0) {
+				$whereClause .= $andor;
+			}
+			$whereClause .= "(";
 		}
-		$whereClause .= "(";
 
 		$numIndivFilters = 0;
 		foreach (explode("][", $filterParts[1]) as $indivFilter) {
@@ -2274,11 +2308,37 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 					// HANDLE LINKED ELEMENTS
 				} elseif ($sourceMeta = $formFieldFilterMap[$mappedForm][$element_id]['islinked']) {
 
+					// When this element's alternate display columns include linked elements of their own, a numeric equals search can be a foreign
+					// key held in one of those alternate columns rather than a reference to this element's own target. Work that out before the
+					// shortcut below, because it decides whether the number is compared to this element or looked up inside the source form.
+					$altColumnFKTargets = formulize_altColumnFKTargetsForSearch($formFieldFilterMap[$mappedForm][$element_id], $ifParts, $operator);
+
 					// check if user is searching for blank values, and if so, then query this element directly, rather than looking in the source
-					// ALSO do this if the user is searching for a numeric value with an = operator
+					// ALSO do this if the user is searching for a numeric value with an = operator, unless that number belongs to an alternate column (see above)
 					// Note that $ifParts[0] gets surrounded by `` when going through prepareElementMetaData (?!)
-					if (($ifParts[1] === '' OR trim($operator) == 'IS NULL' OR trim($operator) == 'IS NOT NULL' OR (is_numeric($ifParts[1]) AND trim($operator) == '=')) AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
+					if (($ifParts[1] === '' OR trim($operator) == 'IS NULL' OR trim($operator) == 'IS NOT NULL' OR (is_numeric($ifParts[1]) AND trim($operator) == '=' AND !$altColumnFKTargets)) AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
 						$newWhereClause = " $queryElement $operator $quotes$likebits" . formulize_db_escape($ifParts[1]) . "$likebits$quotes ";
+
+					// A numeric equals search that belongs to one or more linked alternate columns. Compare it to those columns' foreign keys directly,
+					// instead of resolving them to their readable values and substring matching the concatenated text, which would match far too much.
+					// Over matching is especially destructive inside an empty set expression, where it silently removes main form entries from the results.
+					//
+					// This only applies when the value arrived through a {reference} to another column, which is what $ifParts[3] records. A bare
+					// numeric equals on this column keeps its existing meaning of "this element's own target entry id", because that is what the
+					// quickfilter dropdowns emit for a linked column and reinterpreting it would change every saved view and screen that uses one.
+					// Callers that have declared the number is a literal label rather than a key are left alone too, and fall through to the text search.
+					} elseif ($altColumnFKTargets
+						AND !isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])
+						AND $fkSourceFormObject = $form_handler->get($sourceMeta[0])) {
+						$fkComparisons = array();
+						$fkValue = intval($ifParts[1]);
+						foreach ($altColumnFKTargets as $fkTargetHandle) {
+							$safeFKHandle = formulize_db_escape($fkTargetHandle);
+							// the alternate column can itself hold multiple values, in which case it stores a comma wrapped list rather than a single entry id
+							$fkComparisons[] = "(source.`$safeFKHandle` = $fkValue OR source.`$safeFKHandle` LIKE '%,$fkValue,%')";
+						}
+						// correlate to the source form the same way the text searches below do, so that a linked element holding multiple values still matches
+						$newWhereClause = " EXISTS (SELECT 1 FROM " . DBPRE . "formulize_" . $fkSourceFormObject->getVar('form_handle') . " AS source WHERE ($queryElement = source.entry_id OR $queryElement LIKE CONCAT('%,',source.entry_id,',%')) AND (" . implode(" OR ", $fkComparisons) . ")) ";
 					} else {
 						if (isset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')])) {
 							unset($GLOBALS['formulize_linkedNumericValueIsLiteral'][trim($ifParts[0], '`')]);
@@ -2403,7 +2463,10 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 					}
 
 					// HANDLE ELEMENT TYPES THAT IMPLEMENT THEIR OWN buildSearchWhereClause
-				} elseif ($delegatedWhereClause = formulize_tryDelegatedSearchWhere($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], $ifParts[1], $operator, $quotes, $likebits, $fid)) {
+				// $elementPrefix is the alias of the table this element actually lives in - "main", or "f0", "f1" and so on when
+				// the element belongs to a connected form. Handlers that build a clause against a fixed column of their own
+				// need it to name the right table, and $queryElement is already qualified with it for the ones that do not.
+				} elseif ($delegatedWhereClause = formulize_tryDelegatedSearchWhere($formFieldFilterMap[$mappedForm][$element_id]['ele_type'], $ifParts[1], $operator, $quotes, $likebits, $fid, $elementPrefix, $queryElement)) {
 					$newWhereClause = $delegatedWhereClause;
 
 					// HANDLE IN / NOT IN ON A PLAIN ELEMENT
@@ -2468,6 +2531,22 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 				}
 			}
 
+			// terms in an empty set expression are collected separately, for rendering as a NOT EXISTS against the connected form they belong to.
+			// They are only meaningful against a connected form, since a term on the main form has no set of entries to quantify over.
+			// (That also excludes recursive relationships, where the connected form is the main form, and the terms cannot be told apart. Out of scope for now.)
+			if ($expressionIsEmptySet) {
+				if (!isset($mappedForm) OR $mappedForm == $fid OR !is_array($linkfids) OR !in_array($mappedForm, $linkfids)) {
+					continue;
+				}
+				if (!isset($emptySetFiltersTemp[$mappedForm][$numSeachExps])) {
+					$emptySetFiltersTemp[$mappedForm][$numSeachExps] = " $newWhereClause "; // don't add the local andor on the first term for a form
+				} else {
+					$emptySetFiltersTemp[$mappedForm][$numSeachExps] .= " " . $filterParts[0] . " $newWhereClause ";
+				}
+				$numIndivFilters++;
+				continue;
+			}
+
 			if ($numIndivFilters > 0) {
 				$whereClause .= $filterParts[0]; // apply local andor setting
 			}
@@ -2502,10 +2581,12 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 			$numIndivFilters++;
 		}
 
-		if ($whereClause == "(") { // if no contents for the whereclause where generated...make a fake contents (should only happen if the only filter term passed in is a newest operator)
-			$whereClause .= "main.entry_id>0";
+		if (!$expressionIsEmptySet) {
+			if ($whereClause == "(") { // if no contents for the whereclause where generated...make a fake contents (should only happen if the only filter term passed in is a newest operator)
+				$whereClause .= "main.entry_id>0";
+			}
+			$whereClause .= ")";
 		}
-		$whereClause .= ")";
 		$numSeachExps++;
 	}
 
@@ -2515,6 +2596,15 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 	foreach ($oneSideFiltersTemp as $mappedForm => $oneSideParts) {
 		foreach ($oneSideParts as $type => $expressions) {
 			$oneSideFilters[$mappedForm][$type] = " ( ".implode(" ) $andor ( ", $expressions)." ) ";
+		}
+	}
+
+	// Each empty set expression becomes its own clause, because each one describes a separate connected entry that must not exist.
+	// Two of them on the same form are two different NOT EXISTS clauses, not one clause with both sets of conditions in it.
+	$emptySetFilters = array();
+	foreach ($emptySetFiltersTemp as $mappedForm => $expressions) {
+		foreach ($expressions as $thisExpression) {
+			$emptySetFilters[$mappedForm][] = " ( $thisExpression ) ";
 		}
 	}
 
@@ -2591,9 +2681,14 @@ function formulize_parseFilter($filtertemp, $andor, $linkfids, $fid, $frid, $sco
 		}
 	}
 
+	// Note we deliberately do NOT add the forms carrying empty set expressions to $missingEntrySatisfiesSearch. They do need the join left
+	// open, but that flag also widens the positive EXISTS clause with an "OR NOT EXISTS(join)", and applying that here would let a main form
+	// entry with nothing connected to it satisfy the positive half of the search as well. The caller keys the join type off the empty set
+	// filters themselves instead, which gets the open join without touching what the positive terms mean.
+
 	$otherPerGroupFilterJoins = !empty($otherPerGroupFilterJoins) ? implode(" ", $otherPerGroupFilterJoins) : "";
 	$otherPerGroupFilterWhereClause = !empty($otherPerGroupFilterWhereClause) ? implode(" ", $otherPerGroupFilterWhereClause) : "";
-	return array(0 => $formFieldFilterMap, 1 => $whereClause, 2 => $orderByClause, 3 => $oneSideFilters, 4 => $otherPerGroupFilterJoins, 5 => $otherPerGroupFilterWhereClause, 6 => $missingEntrySatisfiesSearch);
+	return array(0 => $formFieldFilterMap, 1 => $whereClause, 2 => $orderByClause, 3 => $oneSideFilters, 4 => $otherPerGroupFilterJoins, 5 => $otherPerGroupFilterWhereClause, 6 => $missingEntrySatisfiesSearch, 7 => $emptySetFilters);
 }
 
 /**
@@ -2690,6 +2785,190 @@ function resolveLinkedAltSearchColumnsToSubquery(&$altSearchColumns) {
 		$subqueries[] = "(SELECT source$sqNum.`" . $sourceElementHandle . "` FROM " . DBPRE . "formulize_" . $sourceFormHandle . " AS source$sqNum WHERE source$sqNum.entry_id = source.`" . $altSearchElementObject->getVar('ele_handle') . "`)";
 	}
 	return $subqueries;
+}
+
+/**
+ * Pull any EMPTYSET conditions out of a screen's fundamental filters and turn them into ordinary filter expressions.
+ *
+ * The conditions UI has no way to say "no connected entry matches this", so the intent is written into the condition's term as an
+ * EMPTYSET: prefix, which is the same vocabulary the list search boxes use. Translating it here, as the filters are unpacked, means
+ * everything downstream sees a normal search expression carrying the "none" quantifier in its third slot, and nothing else has to know
+ * these conditions came from the admin UI rather than from a search box.
+ *
+ * The point of doing it this way rather than teaching buildConditionsFilterSQL about empty sets is that these conditions then go through
+ * exactly the same term building as every other search, so linked elements, foreign key references, encrypted fields and everything else
+ * behave identically. The trade is that they give up the extra vocabulary buildConditionsFilterSQL supports, notably curly bracket
+ * references to another form, and {BLANK}. A term that cannot be resolved is dropped, and a group left with no terms is never created,
+ * which is what we want: an empty set of conditions would mean "no connected entry at all", a completely different search.
+ *
+ * A term is one value, the same as it is for every other condition. Several conditions in one empty set are written as several rows
+ * sharing a group key (EMPTYSET1: on each of them), not as a compound term on a single row.
+ *
+ * @param array $fundamental_filters The screen's conditions: parallel arrays of element ids, operators, terms and types
+ * @param array $filter The filter expressions parsed so far, which any extracted conditions are appended to
+ * @return array The fundamental filters with the extracted conditions removed, and the filter expressions with them added
+ */
+function formulize_extractEmptySetConditions($fundamental_filters, $filter) {
+
+	if (!isset($fundamental_filters[0]) OR !is_array($fundamental_filters[0]) OR empty($fundamental_filters[0])) {
+		return array($fundamental_filters, $filter);
+	}
+
+	$emptySetTerms = array(); // keyed by the group key from the prefix, so that EMPTYSET1: and EMPTYSET2: stay separate sets
+	$remaining = array(0 => array(), 1 => array(), 2 => array(), 3 => array());
+	$sawEmptySetCondition = false;
+
+	foreach ($fundamental_filters[0] as $i => $conditionElementId) {
+
+		$term = isset($fundamental_filters[2][$i]) ? $fundamental_filters[2][$i] : "";
+		$groupPrefix = formulize_extractSearchGroupPrefix($term);
+		if ($groupPrefix['group'] !== 'emptyset') {
+			$remaining[0][] = $conditionElementId;
+			$remaining[1][] = isset($fundamental_filters[1][$i]) ? $fundamental_filters[1][$i] : "=";
+			$remaining[2][] = $term;
+			$remaining[3][] = isset($fundamental_filters[3][$i]) ? $fundamental_filters[3][$i] : "all";
+			continue;
+		}
+
+		// this row is an empty set whatever happens to its term below. Note it now, so that a term we end up dropping still gets taken
+		// out of the fundamental filters - left behind, the prefix would be read as part of a literal search value and match nothing.
+		$sawEmptySetCondition = true;
+
+		// resolve a reference to another column's search box. This also reports which column the value came from, which the
+		// extraction layer uses to tell which of a linked element's alternate columns a numeric term is a foreign key for.
+		$provenanceHandle = null;
+		$value = convertDynamicFilterTerms($groupPrefix['term'], $provenanceHandle);
+		$value = formulize_unwrapSearchBoxValue($value); // a borrowed value arrives however the search box was holding it
+
+		// Anything still carrying { } did not resolve to a value we can search on. That covers a reference to a column with no search on
+		// it, and it covers a compound term like "{a} AND {b} AND apples", which is not something a condition can express - several
+		// conditions in one empty set are written as several rows sharing a group key. Drop the term rather than search for it literally,
+		// which would silently match nothing. A term that never mentioned a reference at all, like a plain "apples", passes through here.
+		if ($value === "" OR preg_match('/\{[^}]*\}/', $value)) {
+			continue;
+		}
+
+		// a search box can carry its own operator on the front of the value. The condition author chose the operator for this row, and the
+		// reference is only there to supply which value to look for, so strip the sigil off rather than letting it override the condition.
+		if ($valueOperator = extractOperatorFromString($value)) {
+			$value = substr($value, strlen($valueOperator));
+			if ($value === "") {
+				continue;
+			}
+		}
+
+		$operator = isset($fundamental_filters[1][$i]) ? $fundamental_filters[1][$i] : "=";
+		$operator = ($operator == 'NOT') ? '!=' : $operator; // the same conversion buildConditionsFilterSQL makes, to avoid a syntax error
+
+		$thisTerm = $conditionElementId . "/**/" . $value . "/**/" . $operator;
+		if ($provenanceHandle) {
+			$thisTerm .= "/**/" . $provenanceHandle;
+		}
+		$emptySetTerms[$groupPrefix['key']][] = $thisTerm;
+	}
+
+	if (!$sawEmptySetCondition) {
+		return array($fundamental_filters, $filter); // nothing to translate, so hand the conditions back exactly as they arrived
+	}
+
+	foreach ($emptySetTerms as $theseTerms) {
+		$filter[] = array(0 => 'and', 1 => implode("][", $theseTerms), 2 => 'none'); // every condition in one set has to be true of the same connected entry
+	}
+
+	// a set of parallel arrays that are all empty still counts as four elements, so hand back a genuinely empty array when nothing is left,
+	// otherwise the caller's count() check would send buildConditionsFilterSQL a filter with nothing in it
+	$fundamental_filters = empty($remaining[0]) ? array() : $remaining;
+
+	return array($fundamental_filters, $filter);
+}
+
+/**
+ * Work out whether a search term is a foreign key held in one of a linked element's alternate display columns.
+ *
+ * A linked element that shows alternate columns is normally searched by concatenating those columns and matching a substring, because the
+ * user is searching the readable text they can see. But when the term is a number and the operator is =, and one or more of the alternate
+ * columns is itself a linked element, the number is an entry id in whatever form those alternate columns point at, and it should be compared
+ * to them directly. Substring matching a number against concatenated text matches far too much, and inside an empty set expression that
+ * silently drops main form entries out of the results, which is the worst direction for it to be wrong in.
+ *
+ * This is deliberately limited to values that arrived through a {reference} to another column, which is what the fourth part of the filter term
+ * records. A bare numeric equals typed against this column, or selected from its own quickfilter dropdown, keeps its existing meaning of "this
+ * element's own target entry id" - the quickfilter dropdowns emit exactly that for a linked column, so widening the rule would silently change
+ * every saved view and screen that has one. The reference tells us the number was chosen somewhere else and is not about this column's own target.
+ *
+ * Where the referencing column is a linked element pointing at the same form as one of the alternate columns, the ambiguity disappears completely:
+ * that is the column the number is for. Otherwise every linked alternate column is a candidate and they are compared as a set, which can collide
+ * if two of them point at forms that both happen to have an entry with this id.
+ *
+ * Elements holding multiple values are fine here. They store a comma wrapped list rather than a single entry id, and the caller correlates and
+ * compares in the form that matches either shape.
+ *
+ * @param array $elementFilterMapEntry This element's entry in the form field filter map, which carries its type and its ele_value
+ * @param array $ifParts The parts of the filter term: handle, value, operator, and the column a dynamic reference resolved the value from
+ * @param string $operator The normalized operator for this term
+ * @return array The handles of the alternate columns to compare the number to. Empty when this rule does not apply.
+ */
+function formulize_altColumnFKTargetsForSearch($elementFilterMapEntry, $ifParts, $operator) {
+
+	// LIKE counts as well as =, because the quickfilter dropdowns leave the operator off for an element that holds multiple values, so a term
+	// borrowed from one of those arrives here as a bare number. A number that came out of a linked column's dropdown is an entry id either way.
+	// Negations are excluded, since "not this key" is a different question from the one this rule answers.
+	$normalizedOperator = trim($operator);
+	if (!isset($ifParts[1]) OR !is_numeric($ifParts[1]) OR ($normalizedOperator != '=' AND $normalizedOperator != 'LIKE')) {
+		return array();
+	}
+
+	// only values pulled out of another column's search box get reinterpreted, so that existing searches on this column are untouched
+	if (empty($ifParts[3])) {
+		return array();
+	}
+
+	$ele_value = isset($elementFilterMapEntry['ele_value']) ? $elementFilterMapEntry['ele_value'] : null;
+	if (!is_array($ele_value) OR !formulize_altColumnsAreInEffect($ele_value[10] ?? null)) {
+		return array();
+	}
+
+	// which of the alternate columns are linked elements, and what form does each of them point at?
+	$candidates = array();
+	foreach (array_filter(is_array($ele_value[10]) ? $ele_value[10] : array($ele_value[10])) as $altSearchColumn) {
+		if (!$altSearchElementObject = _getElementObject($altSearchColumn)) {
+			continue;
+		}
+		if (!$sourceReference = getSourceFormAndElementForLinkedElement($altSearchElementObject)) {
+			continue;
+		}
+		// snapshot elements are linked, but they store the literal label text in their own column, so they hold no foreign key to compare.
+		// Same exclusion resolveLinkedAltSearchColumnsToSubquery makes, for the same reason.
+		$altSearchEleValue = $altSearchElementObject->getVar('ele_value');
+		if (is_array($altSearchEleValue) AND !empty($altSearchEleValue['snapshot'])) {
+			continue;
+		}
+		$candidates[] = array('handle' => $altSearchElementObject->getVar('ele_handle'), 'sourceFormId' => $sourceReference[0]);
+	}
+	if (!$candidates) {
+		return array();
+	}
+
+	// if the value came out of another column's search box, and that column points at the same form as exactly one of the candidates, that is the one
+	if (!empty($ifParts[3]) AND $provenanceElementObject = _getElementObject($ifParts[3])) {
+		if ($provenanceReference = getSourceFormAndElementForLinkedElement($provenanceElementObject)) {
+			$provenanceMatches = array();
+			foreach ($candidates as $candidate) {
+				if ($candidate['sourceFormId'] == $provenanceReference[0]) {
+					$provenanceMatches[] = $candidate['handle'];
+				}
+			}
+			if (count($provenanceMatches) == 1) {
+				return $provenanceMatches;
+			}
+		}
+	}
+
+	$handles = array();
+	foreach ($candidates as $candidate) {
+		$handles[] = $candidate['handle'];
+	}
+	return $handles;
 }
 
 // THIS FUNCTION TAKES INPUTS ABOUT AND ELEMENT, AND RETURNS A SET OF INFORMATION THAT IS NECESSARY WHEN BUILDING VARIOUS PARTS OF THE WHERE CLAUSE

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -9133,10 +9133,13 @@ function splitUpSearchStringIntoSearchTerms($searchString, $elementIdentifier) {
 		if (strpos($one_search, " OR ") !== FALSE AND strpos($one_search, " AND ") !== FALSE) {
 			$searchArray[] = formulize_swapDBText($one_search, $ele_uitext);
 
-		// split on OR and add all split results, prepended with OR
+		// split on OR and add all split results, prepended with OR. The colon form is used deliberately here rather than the bare
+		// "OR" prefix a person might type: this is the OR group syntax being constructed programmatically, so there's no reason to
+		// leave it to the all-caps-is-a-literal-search heuristic that bare OR relies on to tell a real word from an OR group -
+		// an all-capitals term like "USA OR CANADA" has to keep meaning an OR search regardless of casing.
 		}	else if (strpos($one_search, " OR ") !== FALSE) {
 			foreach(explode(" OR ", $one_search) as $or_term) {
-					$searchArray[] = "OR" . formulize_swapDBText($or_term, $ele_uitext);
+					$searchArray[] = "OR:" . formulize_swapDBText($or_term, $ele_uitext);
 			}
 
 		// split on AND and add all split results
@@ -9178,74 +9181,50 @@ function formulize_normalizeMonthNameForSearch($name) {
 }
 
 /**
- * The month names a search will recognise, as a normalized name => month number map.
+ * The month names a search will recognise, as a normalized name/abbreviation => month number map.
  *
- * Three sources, so that a month typed in the language the page is being read in is understood no matter how the site is
- * set up. English is always accepted, since people mix languages when typing and it costs nothing. The language being
- * displayed right now is added on top of that, which matters because a ?lang= override changes the language of the page
- * without reloading the site's language files. And finally whatever the loaded language files themselves call the months,
- * so a site running in a language not listed here still works without any code change.
+ * Sourced from this module's own language constants, _formulize_CAL_MONTH_01.._12 and _formulize_CAL_MONTH_01_3ABRV.._12_3ABRV
+ * - the same full-name constants calendardisplay.php already uses to build the calendar screen's month list. A language gets
+ * month name search for free the moment its modules/formulize/language/<lang>/main.php defines them; a language whose file
+ * does not define them yet simply is not recognised here until someone adds them, the same as any other untranslated string.
  *
- * Short forms are generated rather than listed, and a short form that would point at two different months is dropped
- * instead of guessing - "jui" could be juin or juillet, so French users type juin or juil.
+ * This deliberately does NOT read the core _CAL_* calendar library constants, which exist for a different, older library and
+ * are not reliably in sync with these ones across every language file - language/french/calendar.php, for one, mislabels
+ * _CAL_JUN and _CAL_JUL as the wrong months entirely.
  *
- * @return array Normalized month name => month number (1-12)
+ * English is hardcoded here and always accepted on top of whatever language this request loaded, since people mix languages
+ * when typing and it costs nothing. It has to be hardcoded rather than read the same way: PHP only ever has one language's
+ * set of these constants defined per request - whichever the site loaded - so there is no way to also read English's values
+ * on demand once a different language is active.
+ *
+ * Not cached, deliberately: the constants this reads never change within a real request (PHP cannot redefine one), so
+ * recomputing costs nothing there, and it means this always reflects whichever constants are actually defined right now.
+ *
+ * @return array Normalized month name/abbreviation => month number (1-12)
  */
 function formulize_monthNamesForSearch() {
 
-	static $cache = array();
-	global $easiestml_lang;
-	$lang = isset($_GET['lang']) ? $_GET['lang'] : $easiestml_lang;
-	$lang = preg_replace('/[^a-z]/', '', strtolower((string) $lang));
-	if (isset($cache[$lang])) {
-		return $cache[$lang];
-	}
-
-	$builtIn = array(
-		'en' => array('january','february','march','april','may','june','july','august','september','october','november','december'),
-		'fr' => array('janvier','fevrier','mars','avril','mai','juin','juillet','aout','septembre','octobre','novembre','decembre'),
-	);
-	$languagesToUse = array('en');
-	if ($lang AND isset($builtIn[$lang]) AND $lang != 'en') {
-		$languagesToUse[] = $lang;
-	}
-
+	$english = array('january','february','march','april','may','june','july','august','september','october','november','december');
 	$lookup = array();
-	// note the abbreviations are deliberately added after all the full names, so that a full name always wins a collision
-	$abbreviations = array();
-	foreach ($languagesToUse as $useLang) {
-		foreach ($builtIn[$useLang] as $index => $name) {
-			$lookup[$name] = $index + 1;
-			foreach (array(3, 4) as $length) {
-				$short = substr($name, 0, $length);
-				if ($short === $name) {
-					continue;
-				}
-				$abbreviations[$short] = (isset($abbreviations[$short]) AND $abbreviations[$short] != $index + 1) ? false : $index + 1;
-			}
-		}
-	}
-	foreach ($abbreviations as $short => $month) {
-		if ($month AND !isset($lookup[$short])) {
-			$lookup[$short] = $month;
-		}
+	foreach ($english as $index => $name) {
+		$lookup[$name] = $index + 1;
 	}
 
-	// whatever the loaded language files call the months, long and short
-	$longConstants  = array('JANUARY','FEBRUARY','MARCH','APRIL','MAY','JUNE','JULY','AUGUST','SEPTEMBER','OCTOBER','NOVEMBER','DECEMBER');
-	$shortConstants = array('JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC');
-	foreach ($longConstants as $index => $constantName) {
-		foreach (array($constantName, $shortConstants[$index]) as $thisConstant) {
-			if (defined('_CAL_' . $thisConstant)) {
-				$fromLanguageFile = formulize_normalizeMonthNameForSearch(constant('_CAL_' . $thisConstant));
-				if ($fromLanguageFile !== '') {
-					$lookup[$fromLanguageFile] = $index + 1;
+	// whatever language this request actually loaded, on top of English. A no-op when the site is already running in English.
+	// _4ABRV exists only for a month whose 3 letter form collides with another month in that language (French Juillet, which
+	// would otherwise share "jui" with Juin) - most months and most languages only ever define the plain and _3ABRV constants.
+	for ($month = 1; $month <= 12; $month++) {
+		$suffix = sprintf('%02d', $month);
+		foreach (array('_formulize_CAL_MONTH_' . $suffix, '_formulize_CAL_MONTH_' . $suffix . '_3ABRV', '_formulize_CAL_MONTH_' . $suffix . '_4ABRV') as $constantName) {
+			if (defined($constantName)) {
+				$normalized = formulize_normalizeMonthNameForSearch(constant($constantName));
+				if ($normalized !== '') {
+					$lookup[$normalized] = $month;
 				}
 			}
 		}
 	}
 
-	$cache[$lang] = $lookup;
 	return $lookup;
 }
 
@@ -9300,7 +9279,9 @@ function formulize_parseDatePeriodSearchTerm($value) {
 		$months = formulize_monthNamesForSearch();
 		$name = formulize_normalizeMonthNameForSearch($matches[1]);
 		if (!empty($months[$name])) {
-			$year = (isset($matches[2]) AND $matches[2] !== '') ? (int) $matches[2] : (int) date('Y');
+			// No year typed means "this year" - in the searching user's own timezone, the same adjustment {TODAY} makes,
+			// so a user well ahead of or behind the server does not get December mapped to the wrong year around midnight.
+			$year = (isset($matches[2]) AND $matches[2] !== '') ? (int) $matches[2] : (int) date('Y', time() + formulize_getUserUTCOffsetSecs());
 			return formulize_datePeriodForMonth($year, $months[$name]);
 		}
 	}
@@ -9345,6 +9326,21 @@ function formulize_unwrapSearchBoxValue($value) {
 }
 
 /**
+ * Split a "<key>:term" string into its key and term, for a prefix that has already been stripped off the front by the caller.
+ *
+ * Shared by every prefix below that supports the colon form, so a change to the key syntax only has to be made once.
+ *
+ * @param string $rest Whatever followed the prefix (EMPTYSET, ORSET, ...) that the caller already removed
+ * @return array|null ['term' => ..., 'key' => ...] when a colon-delimited key was found, otherwise null
+ */
+function formulize_extractKeyedGroupPrefix($rest) {
+	if (preg_match('/^(\d*):(.*)$/s', $rest, $matches)) {
+		return array('term' => $matches[2], 'key' => $matches[1]);
+	}
+	return null;
+}
+
+/**
  * Pull any group prefix off the front of a user typed search term.
  *
  * A search term can declare which group of conditions it belongs to, and what that group means:
@@ -9366,16 +9362,16 @@ function formulize_extractSearchGroupPrefix($one_search) {
 
 	if (substr($one_search, 0, 8) == "EMPTYSET") {
 		$rest = substr($one_search, 8);
-		if (preg_match('/^(\d*):(.*)$/s', $rest, $matches)) {
-			return array('term' => $matches[2], 'group' => 'emptyset', 'key' => $matches[1]);
+		if ($keyed = formulize_extractKeyedGroupPrefix($rest)) {
+			return array('term' => $keyed['term'], 'group' => 'emptyset', 'key' => $keyed['key']);
 		}
 		return array('term' => $rest, 'group' => 'emptyset', 'key' => ''); // no colon means no key, and all of the remainder is the search term
 	}
 
 	if (substr($one_search, 0, 5) == "ORSET") {
 		$rest = substr($one_search, 5);
-		if (preg_match('/^(\d*):(.*)$/s', $rest, $matches)) {
-			return array('term' => $matches[2], 'group' => 'orset', 'key' => $matches[1]);
+		if ($keyed = formulize_extractKeyedGroupPrefix($rest)) {
+			return array('term' => $keyed['term'], 'group' => 'orset', 'key' => $keyed['key']);
 		}
 		if ($rest !== "") {
 			return array('term' => substr($rest, 1), 'group' => 'orset', 'key' => substr($rest, 0, 1)); // legacy: exactly one character of key, no delimiter
@@ -9389,19 +9385,27 @@ function formulize_extractSearchGroupPrefix($one_search) {
 		if ($colonWasUsed) {
 			$rest = substr($rest, 1);
 		}
-		// The inline "X OR Y" syntax works by splitting the string and prepending OR to each piece, so a piece that already carried a group
-		// prefix of its own arrives here as OREMPTYSET:x or ORORSET1:x. Re-read the remainder instead of swallowing that prefix into the
-		// search value, which would turn it into a literal search for text like "EMPTYSET:red" and quietly match nothing.
-		// A term can only belong to one group, and the prefix the user wrote wins over the OR the splitter added.
-		if (substr($rest, 0, 8) == "EMPTYSET" OR substr($rest, 0, 5) == "ORSET") {
+
+		// CASE 1: the inline "X OR Y" syntax works by splitting the string and prepending OR to each piece, so a piece that already
+		// carried a group prefix of its own arrives here as OREMPTYSET:x or ORORSET1:x. Re-read the remainder instead of swallowing
+		// that prefix into the search value, which would turn it into a literal search for text like "EMPTYSET:red" and quietly
+		// match nothing. A term can only belong to one group, and the prefix the user wrote wins over the OR the splitter added.
+		// This is a distinct case from the plain-OR handling below: a nested prefix is never itself run through the heuristic in case 2.
+		$carriesItsOwnPrefix = (substr($rest, 0, 8) == "EMPTYSET" OR substr($rest, 0, 5) == "ORSET");
+		if ($carriesItsOwnPrefix) {
 			return formulize_extractSearchGroupPrefix($rest);
 		}
-		// Without a colon, a term written entirely in capitals is a search for that word rather than an OR search: ORANGE finds "orange",
-		// it is not an OR search for "ANGE". People write an OR search against the value they are looking for, so ORapples and ORSmith are
-		// unaffected - only a term with no lowercase in it at all is read this way. Use OR: to OR search for a value that is itself capitals.
-		if (!$colonWasUsed AND preg_match('/[A-Z]/', $rest) AND !preg_match('/[a-z]/', $rest)) {
+
+		// CASE 2: without a colon, a term written entirely in capitals is a search for that word rather than an OR search: ORANGE
+		// finds "orange", it is not an OR search for "ANGE". People write an OR search against the value they are looking for, so
+		// ORapples and ORSmith are unaffected - only a term with no lowercase in it at all is read this way. Use OR: to OR search
+		// for a value that is itself capitals.
+		$looksLikeAnAllCapitalsWord = (!$colonWasUsed AND preg_match('/[A-Z]/', $rest) AND !preg_match('/[a-z]/', $rest));
+		if ($looksLikeAnAllCapitalsWord) {
 			return $noPrefix;
 		}
+
+		// CASE 3: an ordinary OR search.
 		return array('term' => $rest, 'group' => 'or', 'key' => '');
 	}
 
@@ -9486,7 +9490,7 @@ function formulize_parseSearchesIntoFilter($searches) {
 			// remove the qsf_ parts to make the quickfilter searches work.
 			// Runs after the dynamic filter terms are resolved, since a reference to another column's search box hands us that column's raw quickfilter value to unpack.
 			if (substr($one_search, 0, 4) == "qsf_") {
-				$qsfparts = explode("_", $one_search);
+				$qsfValue = formulize_unwrapSearchBoxValue($one_search); // everything after the qsf_<n>_ counter, so a value containing an underscore survives intact
 				$allowsMulti = false;
 				if (anySelectElementType($ele_type)) {
 					$ele_value = $elementObject->getVar('ele_value');
@@ -9497,16 +9501,16 @@ function formulize_parseSearchesIntoFilter($searches) {
 					$allowsMulti = true;
 				}
 				if ($allowsMulti) {
-					$one_search = $qsfparts[2]; // will default to using LIKE since there's no operator
+					$one_search = $qsfValue; // will default to using LIKE since there's no operator
 				} else {
 					// if we've received the flag to not use the equals operator, remove the flag and don't use the operator
-					$finalQSFParts2 = str_replace('NOQSFEQUALS', '', $qsfparts[2]);
-					$one_search = $finalQSFParts2 == $qsfparts[2] ? "=" . $qsfparts[2] : $finalQSFParts2; // if no flag, two strings will be identical because nothing removed. simple, one speedy operation this way
+					$finalQSFValue = str_replace('NOQSFEQUALS', '', $qsfValue);
+					$one_search = $finalQSFValue == $qsfValue ? "=" . $qsfValue : $finalQSFValue; // if no flag, two strings will be identical because nothing removed. simple, one speedy operation this way
 				}
 				// if it's a negative QSF filter, need to include "OR Blank" in the search
-				if (substr($qsfparts[2], 0, 1) == "!") {
+				if (substr($qsfValue, 0, 1) == "!") {
 					$addToORFilter = true;
-					$one_search = substr($qsfparts[2], 1)."/**/!=][$key/**//**/=][$key/**/";
+					$one_search = substr($qsfValue, 1)."/**/!=][$key/**//**/=][$key/**/";
 					$operator = "IS NULL"; // will get tacked on the end, yuck
 				}
 			}
@@ -9610,16 +9614,18 @@ function formulize_parseSearchesIntoFilter($searches) {
 				}
 			}
 			if ($addToEmptySetFilter) {
+				// an unkeyed EMPTYSET is the implicit 0th set, and all of its terms accumulate together
+				$emptySetKey = "k" . $ownEmptySetFilterKey;
 				if ($addToItsOwnORFilter OR $addToORFilter) {
 					// some terms expand into a self contained construction whose parts have to be OR'd together, {BLANK} being the common one
-					// ("= '' OR IS NULL"). Those get a set of their own, because the conditions in a normal empty set are AND'd.
-					$emptySetSearches[] = array('andor' => 'or', 'terms' => $key . "/**/$one_search");
+					// ("= '' OR IS NULL"). Kept under its own key still, so a set made of nothing else can still become one NOT EXISTS clause
+					// below - see the comment there for what happens when a set mixes this with an ordinary AND'd term.
+					$emptySetSearches[$emptySetKey]['orTerms'][] = $key . "/**/$one_search";
 				} else {
-					$emptySetKey = "k" . $ownEmptySetFilterKey; // an unkeyed EMPTYSET is the implicit 0th set, and all of its terms accumulate together
-					if (!isset($emptySetSearches[$emptySetKey])) {
-						$emptySetSearches[$emptySetKey] = array('andor' => 'and', 'terms' => $key . "/**/$one_search");
+					if (!isset($emptySetSearches[$emptySetKey]['andTerms'])) {
+						$emptySetSearches[$emptySetKey]['andTerms'] = array($key . "/**/$one_search");
 					} else {
-						$emptySetSearches[$emptySetKey]['terms'] .= "][" . $key . "/**/$one_search";
+						$emptySetSearches[$emptySetKey]['andTerms'][] = $key . "/**/$one_search";
 					}
 				}
 			} elseif ($addToItsOwnORFilter) {
@@ -9671,17 +9677,50 @@ function formulize_parseSearchesIntoFilter($searches) {
 		// connected entries that must NOT exist for a main form entry to qualify, rather than conditions the returned rows satisfy.
 		// A set whose terms all failed to resolve never got created above, which is what we want: an empty set of conditions would
 		// mean "no connected entry at all", which is a completely different search from the one that was asked for.
-		if(count((array) $emptySetSearches)>0) {
-			foreach($emptySetSearches as $thisEmptySet) {
-				$filterIndex++;
-				$arrayFilter[$filterIndex][0] = $thisEmptySet['andor']; // normally "and", since every condition in one empty set has to be true of the same connected entry
-				$arrayFilter[$filterIndex][1] = $thisEmptySet['terms'];
-				$arrayFilter[$filterIndex][2] = "none";
-			}
+		foreach (formulize_buildEmptySetFilterRows($emptySetSearches) as $thisRow) {
+			$filterIndex++;
+			$arrayFilter[$filterIndex] = $thisRow;
 		}
 		$filter = $arrayFilter;
 	}
   return $filter;
+}
+
+/**
+ * Turn the empty-set groups collected by formulize_parseSearchesIntoFilter() into filter rows - [andor, terms, "none"],
+ * the same shape every other row in that function's $arrayFilter uses.
+ *
+ * Pure array/string work with no dependency on the module bootstrap, deliberately kept separate from the accumulation
+ * loop above so it can be tested on its own (see tests/empty_set_search_test.php).
+ *
+ * @param array $emptySetSearches Keyed by group ("k" followed by the group's key, or just "k" for the unkeyed 0th set).
+ *   Each entry is ['andTerms' => array of "][" -joinable terms, 'orTerms' => array of self-contained terms whose own
+ *   parts need to be OR'd together, {BLANK} being the only source of these today].
+ * @return array A list of [andor, terms, "none"] rows, one per group that could be represented (see inline comment
+ *   for the one case that cannot be, and is dropped rather than built wrong).
+ */
+function formulize_buildEmptySetFilterRows($emptySetSearches) {
+	$rows = array();
+	foreach ((array) $emptySetSearches as $thisEmptySet) {
+		$andTerms = isset($thisEmptySet['andTerms']) ? $thisEmptySet['andTerms'] : array();
+		$orTerms  = isset($thisEmptySet['orTerms'])  ? $thisEmptySet['orTerms']  : array();
+		if (!$orTerms) {
+			// the ordinary case: every term in this set is AND'd together in the one NOT EXISTS clause this becomes below.
+			$rows[] = array("and", implode("][", $andTerms), "none");
+		} elseif (!$andTerms AND count($orTerms) == 1) {
+			// a set made of nothing but one self-contained OR construction (a lone {BLANK}) needs no AND'ing with anything
+			// else, so it can be its own NOT EXISTS clause exactly like an ordinary set, just with "or" between its parts.
+			$rows[] = array("or", $orTerms[0], "none");
+		}
+		// else: this set mixes an ordinary AND'd term with a self-contained OR construction like {BLANK} (or has more than
+		// one of the latter), which would need "(a='' OR a IS NULL) AND b=1" inside one NOT EXISTS - genuinely nested AND/OR
+		// within a single clause, which this term-string format has no way to express: everything in one clause shares one
+		// operator between its parts, chosen once per clause, not per term. Representing this correctly needs the clause
+		// builder itself to support nested boolean grouping, which is a larger structural change than belongs in this
+		// function. Dropping the set here - producing no filter for it rather than the wrong one - is the safe direction:
+		// it means this specific combination of conditions is not enforced, not that entries are wrongly excluded.
+	}
+	return $rows;
 }
 
 

--- a/modules/formulize/include/functions.php
+++ b/modules/formulize/include/functions.php
@@ -9057,7 +9057,7 @@ function prepareLinkedElementExtraClause($pgroupsfilter, $parentFormFrom, $sourc
  * @param string $term The filter term to convert
  * @return string The converted filter term
  */
-function convertDynamicFilterTerms($term) {
+function convertDynamicFilterTerms($term, &$resolvedFromHandle = null) {
 
     // check for starting and ending ! ! and put them back at the end if necessary
     $needPreserveHiddenMarkers = false;
@@ -9078,6 +9078,11 @@ function convertDynamicFilterTerms($term) {
                 $term = "";
             }
             $term = $operatorToPutBack.$term;
+            // record which column this value came from. A reference to another column's search box is written as {search_handle},
+            // so strip the prefix the list UI uses for its search inputs and report the element handle itself. The extraction layer
+            // uses this to figure out which of a linked element's alternate columns a numeric search term is a foreign key for.
+            $resolvedFromHandle = (substr($searchgetkey, 0, 7) == "search_") ? substr($searchgetkey, 7) : $searchgetkey;
+            $resolvedFromHandle = preg_replace('/[^A-Za-z0-9_]/', '', $resolvedFromHandle); // the key came from whatever the user typed, and it travels inside a filter string that is split on /**/ and ][
         }
     }
 
@@ -9096,12 +9101,13 @@ function convertDynamicFilterTerms($term) {
  *
  * @param string $searchString The string we are parsing
  * @param mixed $elementIdentifier An element object, id number, or handle. Represents the element that this search string is searching against.
+ * @param string $resolvedFromHandle Set by reference to the handle of the column a {reference} pulled this value out of, when the string was one
  * @return array $searchArray An array of all search terms deduced from the string, even if only one.
  */
-function standardizeUserTypedSearchTerms($searchString, $elementIdentifier) {
+function standardizeUserTypedSearchTerms($searchString, $elementIdentifier, &$resolvedFromHandle = null) {
 
 	$searchString = parseBetweenDatesSyntaxInSearchStrings($searchString);
-	$searchString = convertDynamicFilterTerms($searchString);
+	$searchString = convertDynamicFilterTerms($searchString, $resolvedFromHandle);
 	return splitUpSearchStringIntoSearchTerms($searchString, $elementIdentifier);
 }
 
@@ -9149,6 +9155,160 @@ function splitUpSearchStringIntoSearchTerms($searchString, $elementIdentifier) {
 
 
 /**
+ * Reduce a month name to a form that can be compared regardless of how it was typed or stored.
+ *
+ * The language files hold names as HTML entities (F&eacute;vrier), and people type accents inconsistently or not at all,
+ * so both sides of the comparison go through here: entities decoded, lowercased, accents removed, any trailing dot dropped.
+ *
+ * @param string $name A month name, typed by a user or read out of a language file
+ * @return string The name in comparable form
+ */
+function formulize_normalizeMonthNameForSearch($name) {
+	$name = html_entity_decode((string) $name, ENT_QUOTES, 'UTF-8');
+	$name = function_exists('mb_strtolower') ? mb_strtolower($name, 'UTF-8') : strtolower($name);
+	// Both cases are listed, because without mbstring the lowercasing above only reaches ASCII, so an accented capital
+	// would survive it. Doing the folding here rather than relying on iconv//TRANSLIT keeps this independent of locale.
+	$name = strtr($name, array(
+		'à'=>'a', 'â'=>'a', 'ä'=>'a', 'ç'=>'c', 'é'=>'e', 'è'=>'e', 'ê'=>'e', 'ë'=>'e',
+		'î'=>'i', 'ï'=>'i', 'ô'=>'o', 'ö'=>'o', 'ù'=>'u', 'û'=>'u', 'ü'=>'u',
+		'À'=>'a', 'Â'=>'a', 'Ä'=>'a', 'Ç'=>'c', 'É'=>'e', 'È'=>'e', 'Ê'=>'e', 'Ë'=>'e',
+		'Î'=>'i', 'Ï'=>'i', 'Ô'=>'o', 'Ö'=>'o', 'Ù'=>'u', 'Û'=>'u', 'Ü'=>'u',
+	));
+	return rtrim(trim(strtolower($name)), '.');
+}
+
+/**
+ * The month names a search will recognise, as a normalized name => month number map.
+ *
+ * Three sources, so that a month typed in the language the page is being read in is understood no matter how the site is
+ * set up. English is always accepted, since people mix languages when typing and it costs nothing. The language being
+ * displayed right now is added on top of that, which matters because a ?lang= override changes the language of the page
+ * without reloading the site's language files. And finally whatever the loaded language files themselves call the months,
+ * so a site running in a language not listed here still works without any code change.
+ *
+ * Short forms are generated rather than listed, and a short form that would point at two different months is dropped
+ * instead of guessing - "jui" could be juin or juillet, so French users type juin or juil.
+ *
+ * @return array Normalized month name => month number (1-12)
+ */
+function formulize_monthNamesForSearch() {
+
+	static $cache = array();
+	global $easiestml_lang;
+	$lang = isset($_GET['lang']) ? $_GET['lang'] : $easiestml_lang;
+	$lang = preg_replace('/[^a-z]/', '', strtolower((string) $lang));
+	if (isset($cache[$lang])) {
+		return $cache[$lang];
+	}
+
+	$builtIn = array(
+		'en' => array('january','february','march','april','may','june','july','august','september','october','november','december'),
+		'fr' => array('janvier','fevrier','mars','avril','mai','juin','juillet','aout','septembre','octobre','novembre','decembre'),
+	);
+	$languagesToUse = array('en');
+	if ($lang AND isset($builtIn[$lang]) AND $lang != 'en') {
+		$languagesToUse[] = $lang;
+	}
+
+	$lookup = array();
+	// note the abbreviations are deliberately added after all the full names, so that a full name always wins a collision
+	$abbreviations = array();
+	foreach ($languagesToUse as $useLang) {
+		foreach ($builtIn[$useLang] as $index => $name) {
+			$lookup[$name] = $index + 1;
+			foreach (array(3, 4) as $length) {
+				$short = substr($name, 0, $length);
+				if ($short === $name) {
+					continue;
+				}
+				$abbreviations[$short] = (isset($abbreviations[$short]) AND $abbreviations[$short] != $index + 1) ? false : $index + 1;
+			}
+		}
+	}
+	foreach ($abbreviations as $short => $month) {
+		if ($month AND !isset($lookup[$short])) {
+			$lookup[$short] = $month;
+		}
+	}
+
+	// whatever the loaded language files call the months, long and short
+	$longConstants  = array('JANUARY','FEBRUARY','MARCH','APRIL','MAY','JUNE','JULY','AUGUST','SEPTEMBER','OCTOBER','NOVEMBER','DECEMBER');
+	$shortConstants = array('JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC');
+	foreach ($longConstants as $index => $constantName) {
+		foreach (array($constantName, $shortConstants[$index]) as $thisConstant) {
+			if (defined('_CAL_' . $thisConstant)) {
+				$fromLanguageFile = formulize_normalizeMonthNameForSearch(constant('_CAL_' . $thisConstant));
+				if ($fromLanguageFile !== '') {
+					$lookup[$fromLanguageFile] = $index + 1;
+				}
+			}
+		}
+	}
+
+	$cache[$lang] = $lookup;
+	return $lookup;
+}
+
+/**
+ * The first and last day of a given month.
+ *
+ * @param int $year Four digit year
+ * @param int $month Month number, 1-12
+ * @return array start and end, both as YYYY-MM-DD
+ */
+function formulize_datePeriodForMonth($year, $month) {
+	return array(
+		'start' => sprintf('%04d-%02d-01', $year, $month),
+		'end'   => sprintf('%04d-%02d-%02d', $year, $month, (int) date('t', mktime(0, 0, 0, $month, 1, $year))),
+	);
+}
+
+/**
+ * Work out whether a date search names a whole month or a whole year rather than one particular day.
+ *
+ * Dates typed into a search box are run through strtotime, which always produces a single day: "2026-10" becomes the 1st
+ * and "October" becomes today's date in October, neither of which is what anyone meant. This spots the terms that describe
+ * a period, so the search can be turned into a range instead. Anything more specific returns false and is left alone.
+ *
+ * Recognised: 2026, 2026-10, 2026-1, and a month by name with an optional year - October, Oct, Octobre 2026, oct. 2026.
+ *
+ * @param string $value The search term, with any operator already removed
+ * @return array|false start and end as YYYY-MM-DD, or false when the term is not a whole month or year
+ */
+function formulize_parseDatePeriodSearchTerm($value) {
+
+	if (!is_string($value)) {
+		return false;
+	}
+	$value = trim($value);
+	if ($value === '') {
+		return false;
+	}
+
+	// a whole year, or a year and a month
+	if (preg_match('/^(\d{4})(?:-(\d{1,2}))?$/', $value, $matches)) {
+		$year = (int) $matches[1];
+		if (!isset($matches[2]) OR $matches[2] === '') {
+			return array('start' => sprintf('%04d-01-01', $year), 'end' => sprintf('%04d-12-31', $year));
+		}
+		$month = (int) $matches[2];
+		return ($month >= 1 AND $month <= 12) ? formulize_datePeriodForMonth($year, $month) : false;
+	}
+
+	// a month by name, with or without a year. The letter class has to be unicode aware for names like Février.
+	if (preg_match('/^(\p{L}{3,10})\.?(?:\s*,?\s*(\d{4}))?$/u', $value, $matches)) {
+		$months = formulize_monthNamesForSearch();
+		$name = formulize_normalizeMonthNameForSearch($matches[1]);
+		if (!empty($months[$name])) {
+			$year = (isset($matches[2]) AND $matches[2] !== '') ? (int) $matches[2] : (int) date('Y');
+			return formulize_datePeriodForMonth($year, $months[$name]);
+		}
+	}
+
+	return false;
+}
+
+/**
  * Convert "between 2001-01-01 and 2002-02-02" to a normal date filter with two dates
  *
  * @param string $searchString The string we are parsing
@@ -9160,6 +9320,92 @@ function parseBetweenDatesSyntaxInSearchStrings($searchString) {
 		$searchString = ">={$matches[1]}//<={$matches[2]}";
 	}
 	return $searchString;
+}
+
+/**
+ * Unwrap a value taken straight out of a list screen's search box.
+ *
+ * A search box does not always hold the value itself. A quickfilter dropdown stores its selection wrapped as qsf_<n>_<value>, because the
+ * option list needs to tell its entries apart. Anything that borrows another column's search box has to unwrap that before it has a value
+ * it can search on, and this is the one place that knows the wrapper format, so that borrowing code does not have to.
+ *
+ * @param string $value The raw contents of a search box
+ * @return string The value itself, returned unchanged when it was not wrapped
+ */
+function formulize_unwrapSearchBoxValue($value) {
+
+	if (!is_string($value)) {
+		return $value;
+	}
+	// take everything after the counter rather than exploding on underscores, so that a value containing an underscore survives intact
+	if (preg_match('/^qsf_\d+_(.*)$/s', $value, $matches)) {
+		return $matches[1];
+	}
+	return $value;
+}
+
+/**
+ * Pull any group prefix off the front of a user typed search term.
+ *
+ * A search term can declare which group of conditions it belongs to, and what that group means:
+ *   OR      / OR:term        the term joins the single set of OR'd conditions
+ *   ORSET1: / ORSETxterm     the term joins a named set of OR'd conditions
+ *   EMPTYSET: / EMPTYSET1:   the term joins a set of conditions that must match NO connected entry
+ *
+ * With a colon, the key can be any number of digits, and no key at all means the implicit 0th set. The legacy ORSET syntax
+ * has no delimiter and takes exactly one character as the key, which is why the colon form was added: ORSETterm silently
+ * consumes the "t". EMPTYSET is new so it only supports the colon form for keys, and reads everything after a bare
+ * EMPTYSET as the search term.
+ *
+ * @param string $one_search The search term, possibly carrying a group prefix
+ * @return array The term with any prefix removed, the kind of group it belongs to ('', 'or', 'orset' or 'emptyset'), and the group key
+ */
+function formulize_extractSearchGroupPrefix($one_search) {
+
+	$noPrefix = array('term' => $one_search, 'group' => '', 'key' => '');
+
+	if (substr($one_search, 0, 8) == "EMPTYSET") {
+		$rest = substr($one_search, 8);
+		if (preg_match('/^(\d*):(.*)$/s', $rest, $matches)) {
+			return array('term' => $matches[2], 'group' => 'emptyset', 'key' => $matches[1]);
+		}
+		return array('term' => $rest, 'group' => 'emptyset', 'key' => ''); // no colon means no key, and all of the remainder is the search term
+	}
+
+	if (substr($one_search, 0, 5) == "ORSET") {
+		$rest = substr($one_search, 5);
+		if (preg_match('/^(\d*):(.*)$/s', $rest, $matches)) {
+			return array('term' => $matches[2], 'group' => 'orset', 'key' => $matches[1]);
+		}
+		if ($rest !== "") {
+			return array('term' => substr($rest, 1), 'group' => 'orset', 'key' => substr($rest, 0, 1)); // legacy: exactly one character of key, no delimiter
+		}
+		return array('term' => '', 'group' => 'orset', 'key' => ''); // bare ORSET, which the legacy parse also treated as a group with an empty term
+	}
+
+	if (substr($one_search, 0, 2) == "OR" and strlen($one_search) > 2) {
+		$rest = substr($one_search, 2);
+		$colonWasUsed = (substr($rest, 0, 1) == ":");
+		if ($colonWasUsed) {
+			$rest = substr($rest, 1);
+		}
+		// The inline "X OR Y" syntax works by splitting the string and prepending OR to each piece, so a piece that already carried a group
+		// prefix of its own arrives here as OREMPTYSET:x or ORORSET1:x. Re-read the remainder instead of swallowing that prefix into the
+		// search value, which would turn it into a literal search for text like "EMPTYSET:red" and quietly match nothing.
+		// A term can only belong to one group, and the prefix the user wrote wins over the OR the splitter added.
+		if (substr($rest, 0, 8) == "EMPTYSET" OR substr($rest, 0, 5) == "ORSET") {
+			return formulize_extractSearchGroupPrefix($rest);
+		}
+		// Without a colon, a term written entirely in capitals is a search for that word rather than an OR search: ORANGE finds "orange",
+		// it is not an OR search for "ANGE". People write an OR search against the value they are looking for, so ORapples and ORSmith are
+		// unaffected - only a term with no lowercase in it at all is read this way. Use OR: to OR search for a value that is itself capitals.
+		if (!$colonWasUsed AND preg_match('/[A-Z]/', $rest) AND !preg_match('/[a-z]/', $rest)) {
+			return $noPrefix;
+		}
+		return array('term' => $rest, 'group' => 'or', 'key' => '');
+	}
+
+	return $noPrefix;
 }
 
 /**
@@ -9176,11 +9422,13 @@ function formulize_parseSearchesIntoFilter($searches) {
 	$ORstart = 1;
 	$ORfilter = "";
 	$individualORSearches = array();
+	$emptySetSearches = array(); // sets of conditions that must match NO connected entry, keyed the same way the individual OR searches are
   $element_handler = xoops_getmodulehandler('elements','formulize');
 	global $xoopsUser, $xoopsConfig;
 	foreach($searches as $key => $master_one_search) { // $key is the element handle
 
-		$searchArray = standardizeUserTypedSearchTerms($master_one_search, $key);
+		$searchProvenance = null;
+		$searchArray = standardizeUserTypedSearchTerms($master_one_search, $key, $searchProvenance);
 
 		foreach ($searchArray as $one_search) {
 			// used for trapping the {BLANK} keywords into their own space so they don't interfere with each other, or other filters
@@ -9201,9 +9449,42 @@ function formulize_parseSearchesIntoFilter($searches) {
 			}
 
 			$addToORFilter = false; // flag to indicate if we need to apply the current search term to a set of "OR'd" terms
+			$addToEmptySetFilter = false; // flag to indicate that this term belongs to a set of conditions that must match NO connected entry
+			$ownEmptySetFilterKey = "";
 			$operator = "";
+			$provenanceHandle = $searchProvenance; // the column that a dynamic reference pulled this value out of, if any
 
-			// remove the qsf_ parts to make the quickfilter searches work
+			// strip out any starting and ending ! that indicate that the column should not be stripped
+			if (substr($one_search, 0, 1) == "!" and substr($one_search, -1) == "!") {
+				$one_search = substr($one_search, 1, -1);
+			}
+
+			// look for group prefixes (OR, ORSET, EMPTYSET) and strip them off, recording which group this term belongs to.
+			// This has to happen before the dynamic filter terms are resolved below, because a {reference} is only unpacked when it
+			// is the entire value, so a prefix sitting in front of one would stop it from ever resolving.
+			$groupPrefix = formulize_extractSearchGroupPrefix($one_search);
+			$one_search = $groupPrefix['term'];
+			switch ($groupPrefix['group']) {
+				case 'emptyset':
+					$addToEmptySetFilter = true;
+					$ownEmptySetFilterKey = $groupPrefix['key'];
+					break;
+				case 'orset':
+					$addToItsOwnORFilter = true;
+					$ownORFilterKey = $groupPrefix['key'];
+					break;
+				case 'or':
+					$addToORFilter = true;
+					break;
+			}
+
+			$one_search = convertDynamicFilterTerms($one_search, $provenanceHandle); // probably don't need to do this again?? Except what we unpacked first time might have nested { } terms in it? If it did, we would need to do this, however rare that might be
+			if ($one_search === "") {
+				continue;
+			}
+
+			// remove the qsf_ parts to make the quickfilter searches work.
+			// Runs after the dynamic filter terms are resolved, since a reference to another column's search box hands us that column's raw quickfilter value to unpack.
 			if (substr($one_search, 0, 4) == "qsf_") {
 				$qsfparts = explode("_", $one_search);
 				$allowsMulti = false;
@@ -9227,28 +9508,6 @@ function formulize_parseSearchesIntoFilter($searches) {
 					$addToORFilter = true;
 					$one_search = substr($qsfparts[2], 1)."/**/!=][$key/**//**/=][$key/**/";
 					$operator = "IS NULL"; // will get tacked on the end, yuck
-				}
-			}
-
-			// strip out any starting and ending ! that indicate that the column should not be stripped
-			if (substr($one_search, 0, 1) == "!" and substr($one_search, -1) == "!") {
-				$one_search = substr($one_search, 1, -1);
-			}
-
-			$one_search = convertDynamicFilterTerms($one_search); // probably don't need to do this again?? Except what we unpacked first time might have nested { } terms in it? If it did, we would need to do this, however rare that might be
-			if ($one_search === "") {
-				continue;
-			}
-
-			// look for OR indicators...if all caps OR is at the front, then that means that this search is to put put into a separate set of OR filters that gets appended as a set to the main set of AND filters
-			if (substr($one_search, 0, 2) == "OR" and strlen($one_search) > 2) {
-				if (substr($one_search, 2, 3) == "SET") {
-					$addToItsOwnORFilter = true;
-					$ownORFilterKey = substr($one_search, 2, 4);
-					$one_search = substr($one_search, 6);
-				} else {
-					$addToORFilter = true;
-					$one_search = substr($one_search, 2);
 				}
 			}
 
@@ -9344,8 +9603,26 @@ function formulize_parseSearchesIntoFilter($searches) {
 			}
 			if ($operator) {
 				$one_search = $one_search . "/**/" . $operator;
+				// record the column a dynamic reference pulled this value out of, in the fourth slot of the term.
+				// Only meaningful alongside an explicit operator, which is also the only case the extraction layer consults it in.
+				if ($provenanceHandle) {
+					$one_search = $one_search . "/**/" . $provenanceHandle;
+				}
 			}
-			if ($addToItsOwnORFilter) {
+			if ($addToEmptySetFilter) {
+				if ($addToItsOwnORFilter OR $addToORFilter) {
+					// some terms expand into a self contained construction whose parts have to be OR'd together, {BLANK} being the common one
+					// ("= '' OR IS NULL"). Those get a set of their own, because the conditions in a normal empty set are AND'd.
+					$emptySetSearches[] = array('andor' => 'or', 'terms' => $key . "/**/$one_search");
+				} else {
+					$emptySetKey = "k" . $ownEmptySetFilterKey; // an unkeyed EMPTYSET is the implicit 0th set, and all of its terms accumulate together
+					if (!isset($emptySetSearches[$emptySetKey])) {
+						$emptySetSearches[$emptySetKey] = array('andor' => 'and', 'terms' => $key . "/**/$one_search");
+					} else {
+						$emptySetSearches[$emptySetKey]['terms'] .= "][" . $key . "/**/$one_search";
+					}
+				}
+			} elseif ($addToItsOwnORFilter) {
 				if ($ownORFilterKey) {
 					if (!isset($individualORSearches[$ownORFilterKey])) {
 						$individualORSearches[$ownORFilterKey] = $key . "/**/$one_search";
@@ -9370,8 +9647,9 @@ function formulize_parseSearchesIntoFilter($searches) {
 			}
 		}
 	}
-	// if there's a set of options that have been OR'd, then we need to construction a more complex filter
-	if($ORfilter OR count((array) $individualORSearches)>0) {
+	// if there's a set of options that have been OR'd, or a set that has to match no connected entry, then we need to construction a more complex filter
+	if($ORfilter OR count((array) $individualORSearches)>0 OR count((array) $emptySetSearches)>0) {
+		$arrayFilter = array();
 		$filterIndex = 0;
         if($filter) {
     		$arrayFilter[$filterIndex][0] = "and";
@@ -9387,6 +9665,18 @@ function formulize_parseSearchesIntoFilter($searches) {
 				$filterIndex++;
 				$arrayFilter[$filterIndex][0] = "or";
 				$arrayFilter[$filterIndex][1] = $thisORfilter;
+			}
+		}
+		// Empty set expressions carry a quantifier in the third slot. It tells the extraction layer that these conditions describe
+		// connected entries that must NOT exist for a main form entry to qualify, rather than conditions the returned rows satisfy.
+		// A set whose terms all failed to resolve never got created above, which is what we want: an empty set of conditions would
+		// mean "no connected entry at all", which is a completely different search from the one that was asked for.
+		if(count((array) $emptySetSearches)>0) {
+			foreach($emptySetSearches as $thisEmptySet) {
+				$filterIndex++;
+				$arrayFilter[$filterIndex][0] = $thisEmptySet['andor']; // normally "and", since every condition in one empty set has to be true of the same connected entry
+				$arrayFilter[$filterIndex][1] = $thisEmptySet['terms'];
+				$arrayFilter[$filterIndex][2] = "none";
 			}
 		}
 		$filter = $arrayFilter;

--- a/modules/formulize/include/usersAndGroups.php
+++ b/modules/formulize/include/usersAndGroups.php
@@ -474,10 +474,12 @@ function formulize_gatherCompositeDataSet($settings, $searches, $sort, $order, $
 	$showcols = explode(",", $settings['oldcols']);
 	if ($settings['global_search']) {
 		foreach ($showcols as $column) {
+			// OR: rather than bare OR, since this constructs the OR group syntax programmatically and an all-capitals global
+			// search term (a country code, an acronym) must still be read as an OR search rather than a literal search.
 			if (isset($searches[$column]) && $searches[$column]) {
-				$searches[$column] .= "//OR" . $settings['global_search'];
+				$searches[$column] .= "//OR:" . $settings['global_search'];
 			} else {
-				$searches[$column] = "OR" . $settings['global_search'];
+				$searches[$column] = "OR:" . $settings['global_search'];
 			}
 		}
 	}

--- a/modules/formulize/language/english/main.php
+++ b/modules/formulize/language/english/main.php
@@ -612,6 +612,23 @@ define("_formulize_CAL_MONTH_10", "October");
 define("_formulize_CAL_MONTH_11", "November");
 define("_formulize_CAL_MONTH_12", "December");
 
+// Used by the list search "October" / "2026-10" period search, in addition to the full names above. Kept to 3 letters like the
+// week day abbreviations below - if a language's abbreviations collide (two months sharing a short form), leave the colliding
+// ones undefined rather than guessing; the full month name still works for those.
+define("_formulize_CAL_MONTH_01_3ABRV", "Jan");
+define("_formulize_CAL_MONTH_02_3ABRV", "Feb");
+define("_formulize_CAL_MONTH_03_3ABRV", "Mar");
+define("_formulize_CAL_MONTH_04_3ABRV", "Apr");
+define("_formulize_CAL_MONTH_05_3ABRV", "May");
+define("_formulize_CAL_MONTH_06_3ABRV", "Jun");
+define("_formulize_CAL_MONTH_07_3ABRV", "Jul");
+define("_formulize_CAL_MONTH_08_3ABRV", "Aug");
+define("_formulize_CAL_MONTH_09_3ABRV", "Sep");
+define("_formulize_CAL_MONTH_09_4ABRV", "Sept");
+define("_formulize_CAL_MONTH_10_3ABRV", "Oct");
+define("_formulize_CAL_MONTH_11_3ABRV", "Nov");
+define("_formulize_CAL_MONTH_12_3ABRV", "Dec");
+
 define("_formulize_CAL_WEEK_1", "Sunday");
 define("_formulize_CAL_WEEK_2", "Monday");
 define("_formulize_CAL_WEEK_3", "Tuesday");

--- a/modules/formulize/language/french/main.php
+++ b/modules/formulize/language/french/main.php
@@ -183,6 +183,23 @@ define("_formulize_CAL_MONTH_09", "Septembre");
 define("_formulize_CAL_MONTH_10", "Octobre");
 define("_formulize_CAL_MONTH_11", "Novembre");
 define("_formulize_CAL_MONTH_12", "Décembre");
+
+// Used by the list search "Octobre" / "2026-10" period search, in addition to the full names above. Juin and Juillet
+// deliberately have no 3 letter form - both would abbreviate to "jui", and a person searching that would not get the
+// month they meant. Juillet does have an unambiguous 4 letter form, "Juil"; Juin doesn't need one since Juin is
+// itself only 4 letters, so its full name already matches. Every other month is unambiguous at 3 letters.
+define("_formulize_CAL_MONTH_01_3ABRV", "Jan");
+define("_formulize_CAL_MONTH_02_3ABRV", "Fév");
+define("_formulize_CAL_MONTH_03_3ABRV", "Mar");
+define("_formulize_CAL_MONTH_04_3ABRV", "Avr");
+define("_formulize_CAL_MONTH_05_3ABRV", "Mai");
+define("_formulize_CAL_MONTH_07_4ABRV", "Juil");
+define("_formulize_CAL_MONTH_08_3ABRV", "Aoû");
+define("_formulize_CAL_MONTH_09_3ABRV", "Sep");
+define("_formulize_CAL_MONTH_10_3ABRV", "Oct");
+define("_formulize_CAL_MONTH_11_3ABRV", "Nov");
+define("_formulize_CAL_MONTH_12_3ABRV", "Déc");
+
 define("_formulize_CAL_RETURNFROMMULTI", "Retourner au calendrier");
 define("_formulize_CAL_WEEK_1", "Dimanche");
 define("_formulize_CAL_WEEK_1_3ABRV", "Dim");

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,8 @@ behaviour. CI runs them *before* the e2e suite, since they have nothing to wait 
 * `password_hashing_test.php`
 * `reference_binding_test.php`
 * `normalize_then_escape_test.php`
+* `date_search_test.php`
+* `empty_set_search_test.php`
 
 **Integrity tests against a built system** boot the application and read the live database, so CI runs
 them *after* the e2e suite, when the setup specs have finished building the museum system.

--- a/tests/date_search_test.php
+++ b/tests/date_search_test.php
@@ -23,11 +23,12 @@
  * a day of the week, or a word that is not a date at all. A term wrongly treated as a period would widen a search
  * silently, so the fall-through cases are as important as the matches.
  *
- * LANGUAGE. Month names come from three places, and the tests cover each: English always, because people mix languages
- * when typing; the language the page is being read in, which matters because a ?lang= override changes that without
- * reloading the site's language files; and the _CAL_ constants of whatever language files are loaded, so a site running
- * in a language Formulize does not ship a table for still works. Names are compared with accents folded and entities
- * decoded, since the language files store them encoded (F&eacute;vrier) and nobody types accents consistently.
+ * LANGUAGE. Month names come from two places, and the tests cover each: English, hardcoded and always accepted because
+ * people mix languages when typing; and this module's own _formulize_CAL_MONTH_NN / _formulize_CAL_MONTH_NN_3ABRV
+ * language constants (the same ones the calendar screen uses), whichever language this request actually loaded - a site
+ * running in a language that has not defined those constants yet simply is not understood here until it does. Names are
+ * compared with accents folded and entities decoded, since some language files store them encoded and nobody types
+ * accents consistently.
  *
  * OPERATORS. Naming a period changes what the comparison operators should mean: after October is after all of it, before
  * October is before any of it. That matrix is checked in full, because getting one of them backwards would return
@@ -112,18 +113,24 @@ foreach (array('formulize_normalizeMonthNameForSearch', 'formulize_monthNamesFor
     eval($code);
 }
 
-// The real buildSearchWhereClause, wrapped in a bare class so it can be called without the module bootstrap. Only the
-// one property it reads is declared, so if the method ever starts depending on more of the handler this stops compiling
-// rather than quietly testing something different.
+// The real buildSearchWhereClause, wrapped in a bare class so it can be called without the module bootstrap. It reads no
+// properties of its own - everything it needs arrives as an argument - so the class has nothing to declare beyond the
+// method itself; if that ever stops being true, this stops compiling rather than quietly testing something different.
 $clauseSource = extractFunctionSource(file_get_contents($dateFile), 'buildSearchWhereClause');
 if ($clauseSource === false) {
     fwrite(STDERR, "Could not extract buildSearchWhereClause() from $dateFile\n");
     exit(2);
 }
-eval('class DateHandlerUnderTest { public $searchPeriod = false; ' . $clauseSource . ' }');
+eval('class DateHandlerUnderTest { ' . $clauseSource . ' }');
 
 // Dates contain nothing that needs escaping, so this stands in faithfully for the real one.
 function formulize_db_escape($value) { return addslashes($value); }
+
+// The real formulize_getUserUTCOffsetSecs() needs xoops_getmodulehandler() and a profile handler, which need the module
+// bootstrap this test deliberately avoids. This stands in for it - controllable per test via $GLOBALS['__utcOffsetForTest']
+// - rather than pulling in that whole chain just to test that the offset gets added, which is all this file cares about.
+$GLOBALS['__utcOffsetForTest'] = 0;
+function formulize_getUserUTCOffsetSecs($userObject = null, $timestamp = null) { return $GLOBALS['__utcOffsetForTest']; }
 
 // ---- tiny assertion harness -------------------------------------------------
 $GLOBALS['__pass'] = 0;
@@ -153,16 +160,26 @@ check('february, leap year',     periodOf('2024-02'),    '2024-02-01..2024-02-29
 check('february, common year',   periodOf('2026-02'),    '2026-02-01..2026-02-28');
 check('month 13 is not a month', periodOf('2026-13'),    'not a period');
 
+// Simulates modules/formulize/language/english/main.php having been loaded, which a real request always has, whether or
+// not English is the site's active language - formulize_monthNamesForSearch() hardcodes the full English names as a floor,
+// but the abbreviations are only ever read from these constants, the same as any other language. These are the exact
+// values that file defines, not a reimplementation. Only a few months are defined here - the ones this section's checks
+// actually use - so that none of them collide with the different language simulated further below: a real deployment only
+// ever has one language's constants defined at a time, which this test approximates by keeping the two sets of months apart.
+define('_formulize_CAL_MONTH_04_3ABRV', 'Apr');
+define('_formulize_CAL_MONTH_09_3ABRV', 'Sep');
+define('_formulize_CAL_MONTH_09_4ABRV', 'Sept');
+
 echo "\nPERIODS - month names in English, which are always accepted:\n";
 check('full name',               periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
-check('abbreviated',             periodOf('Oct'),          "$thisYear-10-01..$thisYear-10-31");
+check('abbreviated',             periodOf('Apr'),           "$thisYear-04-01..$thisYear-04-30");
 check('lowercase',               periodOf('october'),      "$thisYear-10-01..$thisYear-10-31");
-check('uppercase',               periodOf('OCT'),          "$thisYear-10-01..$thisYear-10-31");
-check('trailing dot',            periodOf('Oct.'),         "$thisYear-10-01..$thisYear-10-31");
+check('uppercase',               periodOf('APR'),           "$thisYear-04-01..$thisYear-04-30");
+check('trailing dot',            periodOf('Apr.'),          "$thisYear-04-01..$thisYear-04-30");
 check('four letter form',        periodOf('Sept'),         "$thisYear-09-01..$thisYear-09-30");
 check('with a year',             periodOf('October 2026'), '2026-10-01..2026-10-31');
-check('abbreviated with a year', periodOf('Feb 2024'),     '2024-02-01..2024-02-29');
-check('comma before the year',   periodOf('Oct, 2024'),    '2024-10-01..2024-10-31');
+check('abbreviated with a year', periodOf('Apr 2024'),      '2024-04-01..2024-04-30');
+check('comma before the year',   periodOf('Apr, 2024'),     '2024-04-01..2024-04-30');
 // May is both a month and an ordinary word, but on a date column it can only mean the month.
 check('May is a month',          periodOf('May'),          "$thisYear-05-01..$thisYear-05-31");
 
@@ -176,8 +193,37 @@ check('an abbreviated weekday',  periodOf('Sat'),          'not a period');
 check('not a date at all',       periodOf('bread'),        'not a period');
 check('empty',                   periodOf(''),             'not a period');
 
-echo "\nLANGUAGE - the language the page is being read in, on top of English:\n";
-$_GET['lang'] = 'fr';
+echo "\nTIMEZONE - a year with no month typed resolves in the searching user's own time, not the server's:\n";
+check('no offset, this year',    periodOf('December'), "$thisYear-12-01..$thisYear-12-31");
+// However many seconds stand between server "now" and next New Year's Day, plus a margin - deterministic regardless of
+// when this test happens to run, unlike hardcoding a specific date. A user this far ahead of the server has already
+// turned over into next year, so "December" with no year has to mean next December, not this one.
+$nextYear = $thisYear + 1;
+$GLOBALS['__utcOffsetForTest'] = (strtotime("$nextYear-01-01 00:00:00 UTC") - time()) + 3600;
+check('big offset, next year',   periodOf('December'), "$nextYear-12-01..$nextYear-12-31");
+$GLOBALS['__utcOffsetForTest'] = 0;
+
+echo "\nLANGUAGE - unit tests for the low level name normalization, independent of which constants are defined:\n";
+check('entity decoded',          formulize_normalizeMonthNameForSearch('F&eacute;vrier'), 'fevrier');
+check('umlaut folded',           formulize_normalizeMonthNameForSearch('M&auml;rz'),       'marz');
+check('trailing dot stripped',   formulize_normalizeMonthNameForSearch('Oct.'),             'oct');
+
+echo "\nLANGUAGE - whatever this module's language file for the active language defines, on top of English:\n";
+// Stands in for modules/formulize/language/french/main.php having been loaded for this request - these are the exact
+// constants that file defines, not a reimplementation. A real request only ever has one language's constants defined
+// (PHP cannot redefine a constant), which is exactly what this simulates: one additional language, layered on English.
+define('_formulize_CAL_MONTH_01', 'Janvier');
+define('_formulize_CAL_MONTH_02', 'Février');
+define('_formulize_CAL_MONTH_06', 'Juin');
+define('_formulize_CAL_MONTH_07', 'Juillet');
+define('_formulize_CAL_MONTH_08', 'Août');
+define('_formulize_CAL_MONTH_10', 'Octobre');
+define('_formulize_CAL_MONTH_01_3ABRV', 'Jan');
+define('_formulize_CAL_MONTH_02_3ABRV', 'Fév');
+define('_formulize_CAL_MONTH_08_3ABRV', 'Aoû');
+define('_formulize_CAL_MONTH_10_3ABRV', 'Oct');
+define('_formulize_CAL_MONTH_07_4ABRV', 'Juil');
+// Juin and Juillet intentionally get no _3ABRV here, matching the real file - both would abbreviate to "jui".
 check('french full name',        periodOf('Octobre'),      "$thisYear-10-01..$thisYear-10-31");
 check('french lowercase',        periodOf('octobre'),      "$thisYear-10-01..$thisYear-10-31");
 check('french abbreviated',      periodOf('oct'),          "$thisYear-10-01..$thisYear-10-31");
@@ -187,30 +233,24 @@ check('accented, uppercase',     periodOf('FÉVRIER'),      "$thisYear-02-01..$t
 check('circumflex',              periodOf('Août'),         "$thisYear-08-01..$thisYear-08-31");
 check('circumflex left off',     periodOf('aout'),         "$thisYear-08-01..$thisYear-08-31");
 check('french with a year',      periodOf('Janvier 2024'), '2024-01-01..2024-01-31');
-check('juin, four letters',      periodOf('juin'),         "$thisYear-06-01..$thisYear-06-30");
-check('juil, four letters',      periodOf('juil'),         "$thisYear-07-01..$thisYear-07-31");
-// "jui" is the first three letters of both juin and juillet, so it is dropped rather than guessed at.
+check('juin, full name',         periodOf('juin'),         "$thisYear-06-01..$thisYear-06-30");
+check('juillet, full name',      periodOf('juillet'),      "$thisYear-07-01..$thisYear-07-31");
+check('juil, the 4 letter form', periodOf('juil'),         "$thisYear-07-01..$thisYear-07-31");
+// "jui" is the first three letters of both juin and juillet, and the real language file deliberately defines no
+// _3ABRV for either of them, so this has to fall through rather than guess.
 check('ambiguous short form',    periodOf('jui'),          'not a period');
 check('english still works',     periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
-unset($_GET['lang']);
-
-echo "\nLANGUAGE - whatever the loaded language files call the months:\n";
-// Stands in for a site whose language files are neither of the two Formulize ships a table for. The names are stored
-// HTML encoded, exactly as the real language files store them.
-define('_CAL_OCTOBER', 'Oktober');
-define('_CAL_MARCH', 'M&auml;rz');
-$_GET['lang'] = 'de'; // a language with no built-in table, so only English and the constants are in play
-check('name from language file', periodOf('Oktober'),      "$thisYear-10-01..$thisYear-10-31");
-check('entity decoded',          periodOf('März'),         "$thisYear-03-01..$thisYear-03-31");
-check('umlaut left off',         periodOf('marz'),         "$thisYear-03-01..$thisYear-03-31");
-check('english still works',     periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
-unset($_GET['lang']);
+// A month this simulated language file never defined a constant for at all (French Mars/March, here standing in for
+// a language that has not been given month constants yet) is understood only by its English name.
+check('undefined month, french name',  periodOf('Mars'),   'not a period');
+check('undefined month, english name', periodOf('March'),  "$thisYear-03-01..$thisYear-03-31");
 
 echo "\nOPERATORS - naming a period changes what each comparison should mean:\n";
 $handler = new DateHandlerUnderTest();
-$handler->searchPeriod = array('start' => '2026-10-01', 'end' => '2026-10-31');
-function clauseFor($handler, $operator) {
-    $clause = $handler->buildSearchWhereClause('ignored', $operator, "'", '', 1, 'main', 'main.`when`');
+// The period comes from $rawTerm (the 8th argument, the term as originally typed), not from $term (the 1st argument,
+// which by this point in the real code has already been collapsed to a single date and is irrelevant to this method).
+function clauseFor($handler, $operator, $rawTerm = 'October 2026') {
+    $clause = $handler->buildSearchWhereClause('ignored', $operator, "'", '', 1, 'main', 'main.`when`', $rawTerm);
     return $clause === false ? false : trim(preg_replace('/\s+/', ' ', $clause));
 }
 check('no operator (LIKE)', clauseFor($handler, 'LIKE'), "( main.`when` >= '2026-10-01' AND main.`when` <= '2026-10-31' )");
@@ -224,10 +264,8 @@ check('not like is outside',  clauseFor($handler, 'NOT LIKE'), "( main.`when` < 
 
 echo "\nOPERATORS - anything that is not a period is handed back to the ordinary handling:\n";
 // Returning false is what keeps every existing date search on exactly the path it took before this feature.
-$plain = new DateHandlerUnderTest();
-check('no period recorded',   clauseFor($plain, 'LIKE'), false);
-$handler->searchPeriod = array('start' => '2026-10-01', 'end' => '2026-10-31');
-check('no column to compare', $handler->buildSearchWhereClause('x', 'LIKE', "'", '', 1, 'main', ''), false);
+check('no period recorded',   clauseFor($handler, 'LIKE', 'not a period'), false);
+check('no column to compare', $handler->buildSearchWhereClause('x', 'LIKE', "'", '', 1, 'main', '', 'October 2026'), false);
 check('an operator with no meaning here', clauseFor($handler, 'IN'), false);
 
 echo "\n";

--- a/tests/date_search_test.php
+++ b/tests/date_search_test.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Standalone logic tests for partial date searches - a search that names a whole month or year instead of one day.
+ *
+ * These are NOT PHPUnit / Playwright - deliberately a single dependency-free script, following the same pattern as
+ * tests/password_hashing_test.php and tests/normalize_then_escape_test.php, so it can run anywhere PHP is available:
+ *   php tests/date_search_test.php
+ *
+ * WHAT THIS COVERS
+ * Date searches are run through strtotime, which always produces one particular day. That quietly does the wrong thing
+ * for a term that describes a period: "2026-10" becomes the 1st, and "October" becomes today's date in October, so
+ * ">=October" meant "on or after October 9th" rather than "on or after October 1st". Two pieces fix that, and this
+ * exercises both, using the REAL source lifted out of the shipped files rather than a reimplementation:
+ *
+ *   formulize_parseDatePeriodSearchTerm()   is this term a whole month or year, and which days does it span
+ *   formulizeDateElementHandler::buildSearchWhereClause()   the range comparison that replaces the single date
+ *
+ * Three properties matter, and each is why a whole section exists below rather than a couple of happy path checks.
+ *
+ * PRECISION, NOT PARSING. date_parse() cannot be used on its own to decide this, because "2026-10" reports day=1 rather
+ * than day=false, making it indistinguishable from "2026-10-01". So the shapes that mean a period are matched
+ * explicitly, and everything else has to fall through untouched - a single date, a relative phrase like "last Thursday",
+ * a day of the week, or a word that is not a date at all. A term wrongly treated as a period would widen a search
+ * silently, so the fall-through cases are as important as the matches.
+ *
+ * LANGUAGE. Month names come from three places, and the tests cover each: English always, because people mix languages
+ * when typing; the language the page is being read in, which matters because a ?lang= override changes that without
+ * reloading the site's language files; and the _CAL_ constants of whatever language files are loaded, so a site running
+ * in a language Formulize does not ship a table for still works. Names are compared with accents folded and entities
+ * decoded, since the language files store them encoded (F&eacute;vrier) and nobody types accents consistently.
+ *
+ * OPERATORS. Naming a period changes what the comparison operators should mean: after October is after all of it, before
+ * October is before any of it. That matrix is checked in full, because getting one of them backwards would return
+ * results that look plausible.
+ *
+ * WHAT THIS DOES NOT COVER
+ * Whether the clause is reached at all. That depends on formulize_tryDelegatedSearchWhere() finding the handler and on
+ * the surrounding filter parsing, which need the module bootstrap and a database, and are exercised against a running
+ * instance by the e2e suite. Note the handler deliberately returns false for anything that is not a period, so every
+ * ordinary date search still takes the path it always did.
+ *
+ * @package Formulize
+ * @subpackage tests
+ */
+
+// Command-line / CI only. A web request just 404s - this ships in the repo and must never be a live endpoint.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+date_default_timezone_set('UTC');
+
+$functionsFile = isset($argv[1]) ? $argv[1] : (__DIR__ . '/../modules/formulize/include/functions.php');
+$dateFile      = isset($argv[2]) ? $argv[2] : (__DIR__ . '/../modules/formulize/class/dateElement.php');
+foreach (array('functions.php' => $functionsFile, 'dateElement.php' => $dateFile) as $label => $path) {
+    if (!is_file($path)) {
+        fwrite(STDERR, "Cannot find $label at: $path\n");
+        exit(2);
+    }
+}
+
+/**
+ * Lift a single function or method's source out of a PHP file using the tokenizer, so braces inside strings or comments
+ * cannot be mistaken for its own. (Same approach as normalize_then_escape_test.php - neither file can be included
+ * standalone, they pull in the module bootstrap.)
+ */
+function extractFunctionSource($source, $functionName) {
+    $tokens = token_get_all($source);
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_FUNCTION) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+            $j++;
+        }
+        if (!is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING || $tokens[$j][1] !== $functionName) {
+            continue;
+        }
+        $collected = '';
+        $depth = 0;
+        $seenBody = false;
+        for ($k = $i; $k < $count; $k++) {
+            $text = is_array($tokens[$k]) ? $tokens[$k][1] : $tokens[$k];
+            $collected .= $text;
+            $isArrayToken = is_array($tokens[$k]);
+            if ($text === '{'
+                || ($isArrayToken && ($tokens[$k][0] === T_CURLY_OPEN || $tokens[$k][0] === T_DOLLAR_OPEN_CURLY_BRACES))) {
+                $depth++;
+                $seenBody = true;
+            } elseif ($text === '}') {
+                $depth--;
+                if ($seenBody && $depth === 0) {
+                    return $collected;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+$functionsSource = file_get_contents($functionsFile);
+foreach (array('formulize_normalizeMonthNameForSearch', 'formulize_monthNamesForSearch',
+               'formulize_datePeriodForMonth', 'formulize_parseDatePeriodSearchTerm') as $name) {
+    $code = extractFunctionSource($functionsSource, $name);
+    if ($code === false) {
+        fwrite(STDERR, "Could not extract $name()\n");
+        exit(2);
+    }
+    eval($code);
+}
+
+// The real buildSearchWhereClause, wrapped in a bare class so it can be called without the module bootstrap. Only the
+// one property it reads is declared, so if the method ever starts depending on more of the handler this stops compiling
+// rather than quietly testing something different.
+$clauseSource = extractFunctionSource(file_get_contents($dateFile), 'buildSearchWhereClause');
+if ($clauseSource === false) {
+    fwrite(STDERR, "Could not extract buildSearchWhereClause() from $dateFile\n");
+    exit(2);
+}
+eval('class DateHandlerUnderTest { public $searchPeriod = false; ' . $clauseSource . ' }');
+
+// Dates contain nothing that needs escaping, so this stands in faithfully for the real one.
+function formulize_db_escape($value) { return addslashes($value); }
+
+// ---- tiny assertion harness -------------------------------------------------
+$GLOBALS['__pass'] = 0;
+$GLOBALS['__fail'] = 0;
+function check($label, $got, $want) {
+    $ok = ($got === $want);
+    $GLOBALS[$ok ? '__pass' : '__fail']++;
+    printf("  [%s] %-42s %s\n", $ok ? 'PASS' : 'FAIL', $label,
+        $ok ? var_export($got, true) : 'got=' . var_export($got, true) . ' want=' . var_export($want, true));
+}
+// Collapse a period into one comparable string, or say it is not a period.
+function periodOf($value) {
+    $period = formulize_parseDatePeriodSearchTerm($value);
+    return $period ? $period['start'] . '..' . $period['end'] : 'not a period';
+}
+$thisYear = date('Y');
+
+echo "Partial date searches - logic tests\n";
+echo "(today is " . date('Y-m-d') . ", so terms with no year resolve into $thisYear)\n\n";
+
+echo "PERIODS - numeric forms:\n";
+check('a whole year',            periodOf('2026'),       '2026-01-01..2026-12-31');
+check('a year and month',        periodOf('2026-10'),    '2026-10-01..2026-10-31');
+check('single digit month',      periodOf('2026-1'),     '2026-01-01..2026-01-31');
+check('short month, 30 days',    periodOf('2026-04'),    '2026-04-01..2026-04-30');
+check('february, leap year',     periodOf('2024-02'),    '2024-02-01..2024-02-29');
+check('february, common year',   periodOf('2026-02'),    '2026-02-01..2026-02-28');
+check('month 13 is not a month', periodOf('2026-13'),    'not a period');
+
+echo "\nPERIODS - month names in English, which are always accepted:\n";
+check('full name',               periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
+check('abbreviated',             periodOf('Oct'),          "$thisYear-10-01..$thisYear-10-31");
+check('lowercase',               periodOf('october'),      "$thisYear-10-01..$thisYear-10-31");
+check('uppercase',               periodOf('OCT'),          "$thisYear-10-01..$thisYear-10-31");
+check('trailing dot',            periodOf('Oct.'),         "$thisYear-10-01..$thisYear-10-31");
+check('four letter form',        periodOf('Sept'),         "$thisYear-09-01..$thisYear-09-30");
+check('with a year',             periodOf('October 2026'), '2026-10-01..2026-10-31');
+check('abbreviated with a year', periodOf('Feb 2024'),     '2024-02-01..2024-02-29');
+check('comma before the year',   periodOf('Oct, 2024'),    '2024-10-01..2024-10-31');
+// May is both a month and an ordinary word, but on a date column it can only mean the month.
+check('May is a month',          periodOf('May'),          "$thisYear-05-01..$thisYear-05-31");
+
+echo "\nNOT PERIODS - these must fall through to the ordinary single date handling:\n";
+check('a full date',             periodOf('2026-10-15'),   'not a period');
+check('a day and month',         periodOf('July 25'),      'not a period');
+check('the same, reversed',      periodOf('25 July'),      'not a period');
+check('a relative phrase',       periodOf('last Thursday'),'not a period');
+check('a day of the week',       periodOf('Monday'),       'not a period');
+check('an abbreviated weekday',  periodOf('Sat'),          'not a period');
+check('not a date at all',       periodOf('bread'),        'not a period');
+check('empty',                   periodOf(''),             'not a period');
+
+echo "\nLANGUAGE - the language the page is being read in, on top of English:\n";
+$_GET['lang'] = 'fr';
+check('french full name',        periodOf('Octobre'),      "$thisYear-10-01..$thisYear-10-31");
+check('french lowercase',        periodOf('octobre'),      "$thisYear-10-01..$thisYear-10-31");
+check('french abbreviated',      periodOf('oct'),          "$thisYear-10-01..$thisYear-10-31");
+check('accented',                periodOf('Février'),      "$thisYear-02-01..$thisYear-02-28");
+check('accent left off',         periodOf('fevrier'),      "$thisYear-02-01..$thisYear-02-28");
+check('accented, uppercase',     periodOf('FÉVRIER'),      "$thisYear-02-01..$thisYear-02-28");
+check('circumflex',              periodOf('Août'),         "$thisYear-08-01..$thisYear-08-31");
+check('circumflex left off',     periodOf('aout'),         "$thisYear-08-01..$thisYear-08-31");
+check('french with a year',      periodOf('Janvier 2024'), '2024-01-01..2024-01-31');
+check('juin, four letters',      periodOf('juin'),         "$thisYear-06-01..$thisYear-06-30");
+check('juil, four letters',      periodOf('juil'),         "$thisYear-07-01..$thisYear-07-31");
+// "jui" is the first three letters of both juin and juillet, so it is dropped rather than guessed at.
+check('ambiguous short form',    periodOf('jui'),          'not a period');
+check('english still works',     periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
+unset($_GET['lang']);
+
+echo "\nLANGUAGE - whatever the loaded language files call the months:\n";
+// Stands in for a site whose language files are neither of the two Formulize ships a table for. The names are stored
+// HTML encoded, exactly as the real language files store them.
+define('_CAL_OCTOBER', 'Oktober');
+define('_CAL_MARCH', 'M&auml;rz');
+$_GET['lang'] = 'de'; // a language with no built-in table, so only English and the constants are in play
+check('name from language file', periodOf('Oktober'),      "$thisYear-10-01..$thisYear-10-31");
+check('entity decoded',          periodOf('März'),         "$thisYear-03-01..$thisYear-03-31");
+check('umlaut left off',         periodOf('marz'),         "$thisYear-03-01..$thisYear-03-31");
+check('english still works',     periodOf('October'),      "$thisYear-10-01..$thisYear-10-31");
+unset($_GET['lang']);
+
+echo "\nOPERATORS - naming a period changes what each comparison should mean:\n";
+$handler = new DateHandlerUnderTest();
+$handler->searchPeriod = array('start' => '2026-10-01', 'end' => '2026-10-31');
+function clauseFor($handler, $operator) {
+    $clause = $handler->buildSearchWhereClause('ignored', $operator, "'", '', 1, 'main', 'main.`when`');
+    return $clause === false ? false : trim(preg_replace('/\s+/', ' ', $clause));
+}
+check('no operator (LIKE)', clauseFor($handler, 'LIKE'), "( main.`when` >= '2026-10-01' AND main.`when` <= '2026-10-31' )");
+check('equals is the month', clauseFor($handler, '='),   "( main.`when` >= '2026-10-01' AND main.`when` <= '2026-10-31' )");
+check('on or after the 1st', clauseFor($handler, '>='),  "main.`when` >= '2026-10-01'");
+check('after the whole month', clauseFor($handler, '>'), "main.`when` > '2026-10-31'");
+check('on or before the 31st', clauseFor($handler, '<='),"main.`when` <= '2026-10-31'");
+check('before the whole month', clauseFor($handler, '<'),"main.`when` < '2026-10-01'");
+check('not equal is outside', clauseFor($handler, '!='), "( main.`when` < '2026-10-01' OR main.`when` > '2026-10-31' )");
+check('not like is outside',  clauseFor($handler, 'NOT LIKE'), "( main.`when` < '2026-10-01' OR main.`when` > '2026-10-31' )");
+
+echo "\nOPERATORS - anything that is not a period is handed back to the ordinary handling:\n";
+// Returning false is what keeps every existing date search on exactly the path it took before this feature.
+$plain = new DateHandlerUnderTest();
+check('no period recorded',   clauseFor($plain, 'LIKE'), false);
+$handler->searchPeriod = array('start' => '2026-10-01', 'end' => '2026-10-31');
+check('no column to compare', $handler->buildSearchWhereClause('x', 'LIKE', "'", '', 1, 'main', ''), false);
+check('an operator with no meaning here', clauseFor($handler, 'IN'), false);
+
+echo "\n";
+printf("RESULT: %d passed, %d failed\n", $GLOBALS['__pass'], $GLOBALS['__fail']);
+exit($GLOBALS['__fail'] === 0 ? 0 : 1);

--- a/tests/empty_set_search_test.php
+++ b/tests/empty_set_search_test.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Standalone logic tests for EMPTYSET searches, and for the search-term prefix parsing they share with OR/ORSET.
+ *
+ * These are NOT PHPUnit / Playwright - deliberately a single dependency-free script, following the same pattern as
+ * tests/password_hashing_test.php and tests/normalize_then_escape_test.php, so it can run anywhere PHP is available:
+ *   php tests/empty_set_search_test.php
+ *
+ * WHAT THIS COVERS
+ * An EMPTYSET term asks "no connected entry matches these conditions", which the extraction layer renders as a
+ * NOT EXISTS instead of a row level comparison. Getting a term from a search box or a screen's conditions into that
+ * shape is pure string work, done by four functions this exercises directly, using the REAL source lifted out of the
+ * shipped files rather than a reimplementation:
+ *
+ *   formulize_extractSearchGroupPrefix()    which group a term belongs to, and what that group means
+ *   formulize_unwrapSearchBoxValue()        the value inside whatever wrapper a search box was holding
+ *   splitUpSearchStringIntoSearchTerms()    how "X AND Y" in one box becomes separate terms
+ *   formulize_extractEmptySetConditions()   turning a screen's EMPTYSET conditions into filter expressions
+ *
+ * Two properties matter most here, and both are the reason for the case lists below rather than a happy path check.
+ *
+ * BACKWARD COMPATIBILITY. The prefix parser took over parsing that ORSET and OR had been doing for years, including
+ * a no-delimiter ORSET syntax that consumes exactly one character as the group key. Existing saved views hold those
+ * strings, so the legacy forms have to keep resolving identically. The ORANGE case is deliberate: it documents a
+ * long standing quirk (a search for "ORANGE" is read as an OR search for "ANGE") that we preserve rather than fix,
+ * because fixing it would change what existing saved views return.
+ *
+ * FAILING CLOSED. Every uncertain case here has to drop the term rather than search for something approximate.
+ * An EMPTYSET search that quietly matches the wrong thing removes entries from a list, and nobody notices a row
+ * that isn't there. So an unresolved reference, a compound term, or a wrapped {BLANK} must all produce no filter
+ * expression at all - and, just as importantly, must not leave the raw text behind in the screen's conditions where
+ * it would become a literal search matching nothing.
+ *
+ * WHAT THIS DOES NOT COVER
+ * The SQL itself. Whether a term becomes a NOT EXISTS, and whether a numeric term becomes a foreign key comparison
+ * against a linked element's alternate columns, is decided inside formulize_parseFilter() and getData(), which need
+ * the module bootstrap and a database. Those paths are exercised against a running instance by the e2e suite.
+ *
+ * @package Formulize
+ * @subpackage tests
+ */
+
+// Command-line / CI only. A web request just 404s - this ships in the repo and must never be a live endpoint.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+$functionsFile = isset($argv[1]) ? $argv[1] : (__DIR__ . '/../modules/formulize/include/functions.php');
+$extractFile   = isset($argv[2]) ? $argv[2] : (__DIR__ . '/../modules/formulize/include/extract.php');
+foreach (array('functions.php' => $functionsFile, 'extract.php' => $extractFile) as $label => $path) {
+    if (!is_file($path)) {
+        fwrite(STDERR, "Cannot find $label at: $path\n");
+        exit(2);
+    }
+}
+
+/**
+ * Lift a single function's source out of a PHP file using the tokenizer, so braces inside strings, regexes or
+ * comments cannot be mistaken for the function's own. (Same approach as normalize_then_escape_test.php - neither
+ * functions.php nor extract.php can be included standalone, they pull in the module bootstrap.)
+ */
+function extractFunctionSource($source, $functionName) {
+    $tokens = token_get_all($source);
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_FUNCTION) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+            $j++;
+        }
+        if (!is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING || $tokens[$j][1] !== $functionName) {
+            continue;
+        }
+        $collected = '';
+        $depth = 0;
+        $seenBody = false;
+        for ($k = $i; $k < $count; $k++) {
+            $text = is_array($tokens[$k]) ? $tokens[$k][1] : $tokens[$k];
+            $collected .= $text;
+            $isArrayToken = is_array($tokens[$k]);
+            if ($text === '{'
+                || ($isArrayToken && ($tokens[$k][0] === T_CURLY_OPEN || $tokens[$k][0] === T_DOLLAR_OPEN_CURLY_BRACES))) {
+                $depth++;
+                $seenBody = true;
+            } elseif ($text === '}') {
+                $depth--;
+                if ($seenBody && $depth === 0) {
+                    return $collected;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+$functionsSource = file_get_contents($functionsFile);
+$extractSource   = file_get_contents($extractFile);
+$toLoad = array(
+    'extractOperatorFromString'            => $functionsSource,
+    'convertStringToUseSpecialCharsToMatchDB' => $functionsSource,
+    'convertDynamicFilterTerms'            => $functionsSource,
+    'formulize_unwrapSearchBoxValue'       => $functionsSource,
+    'formulize_extractSearchGroupPrefix'   => $functionsSource,
+    'splitUpSearchStringIntoSearchTerms'   => $functionsSource,
+    'formulize_extractEmptySetConditions'  => $extractSource,
+);
+foreach ($toLoad as $name => $source) {
+    $code = extractFunctionSource($source, $name);
+    if ($code === false) {
+        fwrite(STDERR, "Could not extract $name()\n");
+        exit(2);
+    }
+    eval($code);
+}
+
+// splitUpSearchStringIntoSearchTerms() looks up the element only to fetch its ele_uitext, which it then swaps into
+// the terms. Standing in for that lookup with "no element found" reproduces exactly what happens for an element with
+// no ele_uitext configured, which is the ordinary case, and leaves the splitting logic under test untouched.
+function _getElementObject($elementIdentifier) { return false; }
+function formulize_swapDBText($value, $ele_uitext) { return $value; }
+
+// ---- tiny assertion harness -------------------------------------------------
+$GLOBALS['__pass'] = 0;
+$GLOBALS['__fail'] = 0;
+function check($label, $got, $want) {
+    $ok = ($got === $want);
+    $GLOBALS[$ok ? '__pass' : '__fail']++;
+    printf("  [%s] %-46s %s\n", $ok ? 'PASS' : 'FAIL', $label,
+        $ok ? var_export($got, true) : 'got=' . var_export($got, true) . ' want=' . var_export($want, true));
+}
+// Collapse a prefix parse into one comparable string: group/key/term.
+function prefixOf($input) {
+    $p = formulize_extractSearchGroupPrefix($input);
+    return $p['group'] . '/' . $p['key'] . '/' . $p['term'];
+}
+
+echo "EMPTYSET searches - logic tests\n\n";
+
+echo "PREFIX PARSING - which group a term belongs to:\n";
+check('EMPTYSET, no key',           prefixOf('EMPTYSET:{search_student_terms}'), 'emptyset//{search_student_terms}');
+check('EMPTYSET, numeric key',      prefixOf('EMPTYSET1:termX'),                 'emptyset/1/termX');
+check('EMPTYSET, multi-digit key',  prefixOf('EMPTYSET12:termX'),                'emptyset/12/termX');
+check('EMPTYSET, empty term',       prefixOf('EMPTYSET:'),                       'emptyset//');
+check('EMPTYSET, operator survives',prefixOf('EMPTYSET:=61'),                    'emptyset//=61');
+// No colon means no key. Unlike the legacy ORSET syntax below, EMPTYSET never eats a character off the front of
+// the term, because doing so silently changes what the user typed.
+check('EMPTYSET, no colon, no key', prefixOf('EMPTYSETtermX'),                   'emptyset//termX');
+
+echo "\nPREFIX PARSING - legacy ORSET and OR forms must resolve exactly as before:\n";
+check('ORSET legacy, numeric key',  prefixOf('ORSET1x'),                         'orset/1/x');
+check('ORSET legacy, letter key',   prefixOf('ORSETax'),                         'orset/a/x');
+check('ORSET legacy, longer term',  prefixOf('ORSET1termX'),                     'orset/1/termX');
+check('ORSET colon form',           prefixOf('ORSET1:termX'),                    'orset/1/termX');
+check('ORSET colon, no key',        prefixOf('ORSET:termX'),                     'orset//termX');
+check('ORSET colon, multi-digit',   prefixOf('ORSET12:termX'),                   'orset/12/termX');
+check('OR legacy',                  prefixOf('ORterm'),                          'or//term');
+check('OR colon form',              prefixOf('OR:term'),                         'or//term');
+check('bare OR is too short',       prefixOf('OR'),                              '//OR');
+
+echo "\nPREFIX PARSING - a term written entirely in capitals is a search, not an OR prefix:\n";
+// ORANGE used to be read as an OR search for ANGE. An OR search is written against the value being looked for, so
+// the give-away is that there is no lowercase anywhere in it. Anything with lowercase in it is still an OR search.
+check('all capitals is a search',   prefixOf('ORANGE'),                          '//ORANGE');
+check('another all-capitals word',  prefixOf('ORDERS'),                          '//ORDERS');
+check('colon overrides that',       prefixOf('OR:ORANGE'),                       'or//ORANGE');
+check('capitalised value still OR', prefixOf('ORSmith'),                         'or//Smith');
+check('lowercase value still OR',   prefixOf('ORorange'),                        'or//orange');
+// Digits are neither case, so a term with no letters keeps its previous meaning rather than changing under this rule.
+check('digits are unaffected',      prefixOf('OR123'),                           'or//123');
+
+echo "\nPREFIX PARSING - terms with no prefix are left alone:\n";
+check('plain word',                 prefixOf('apple'),                           '//apple');
+check('operator and number',        prefixOf('=61'),                             '//=61');
+check('bare reference',             prefixOf('{search_x}'),                      '//{search_x}');
+
+echo "\nSEARCH BOX VALUES - the value inside whatever wrapper the box was holding:\n";
+check('quickfilter wrapper',        formulize_unwrapSearchBoxValue('qsf_5_61'),            '61');
+// Take everything after the counter rather than exploding on underscores, so a value containing one survives.
+check('underscores in the value',   formulize_unwrapSearchBoxValue('qsf_7_JULY_BLOCK_26'), 'JULY_BLOCK_26');
+check('spaces in the value',        formulize_unwrapSearchBoxValue('qsf_0_July Block'),    'July Block');
+check('not wrapped at all',         formulize_unwrapSearchBoxValue('July Block'),          'July Block');
+check('operator, not wrapped',      formulize_unwrapSearchBoxValue('=61'),                 '=61');
+
+echo "\nINLINE AND/OR - a box holding several terms splits before the prefixes are read:\n";
+// The splitter prepends OR to each piece it makes, so a piece that already carried a prefix arrives as
+// OREMPTYSET:red. Reading that as an OR search for the literal text "EMPTYSET:red" would match nothing, silently.
+$pieces = function($input) {
+    $out = array();
+    foreach (splitUpSearchStringIntoSearchTerms($input, 'somehandle') as $term) {
+        $out[] = prefixOf($term);
+    }
+    return implode(' + ', $out);
+};
+check('AND keeps both empty sets',  $pieces('EMPTYSET:{search_term} AND EMPTYSET:Apples'),
+    'emptyset//{search_term} + emptyset//Apples');
+check('prefix is not implied',      $pieces('EMPTYSET:{search_term} AND Apples'),
+    'emptyset//{search_term} + //Apples');
+check('keys survive the split',     $pieces('EMPTYSET1:a AND EMPTYSET2:b'),
+    'emptyset/1/a + emptyset/2/b');
+check('OR does not swallow prefix', $pieces('EMPTYSET:red OR EMPTYSET:blue'),
+    'emptyset//red + emptyset//blue');
+check('OR does not swallow ORSET',  $pieces('ORSET1:a OR ORSET1:b'),
+    'orset/1/a + orset/1/b');
+// Writing AND and OR between terms in one box is not supported - there is no way to know which part was meant to group
+// together - so the splitter leaves the string whole and it becomes a plain text search. Documented in the cheat sheet,
+// and pinned here because the failure is silent: it matches nothing rather than reporting a problem.
+check('AND and OR together is text', $pieces('red OR blue AND green'),
+    '//red OR blue AND green');
+// The supported way to say the same thing: join with AND, and mark the terms that only need one match with a prefix.
+// These produce (santa) AND (cruz OR claus), and (red OR blue) AND (small OR large), once the buckets are assembled.
+check('OR: makes a group inside AND', $pieces('santa AND OR:cruz AND OR:claus'),
+    '//santa + or//cruz + or//claus');
+check('numbered groups inside AND',   $pieces('ORSET1:red AND ORSET1:blue AND ORSET2:small AND ORSET2:large'),
+    'orset/1/red + orset/1/blue + orset/2/small + orset/2/large');
+
+echo "\nSCREEN CONDITIONS - EMPTYSET rows become filter expressions, and leave the conditions:\n";
+// A screen's conditions are four parallel arrays: element ids, operators, terms, types.
+$_POST['search_student_terms'] = 'qsf_5_61';   // what a term dropdown posts
+$_POST['search_status']        = '=active';    // a typed value carrying its own operator
+$_POST['search_blanky']        = 'qsf_0_{BLANK}';
+
+// Collapse a translation into comparable strings: what is left in the conditions, and what expressions came out.
+function translate($conditions, $filter = array()) {
+    list($outConditions, $outFilter) = formulize_extractEmptySetConditions($conditions, $filter);
+    $expressions = array();
+    foreach ($outFilter as $expr) {
+        $expressions[] = $expr[0] . '|' . $expr[1] . '|' . (isset($expr[2]) ? $expr[2] : '-');
+    }
+    return array(
+        'conditions'  => empty($outConditions) ? '(empty)' : json_encode($outConditions),
+        'expressions' => implode('  ~  ', $expressions),
+    );
+}
+
+$got = translate(array(
+    0 => array(88, 42),
+    1 => array('=', '='),
+    2 => array('EMPTYSET:{search_student_terms}', 'active'),
+    3 => array('all', 'all'),
+), array(0 => array(0 => 'and', 1 => 'student_last_name/**/Smith/**/LIKE')));
+check('the ordinary condition stays put', $got['conditions'], '[[42],["="],["active"],["all"]]');
+check('the empty set becomes a term',     $got['expressions'],
+    'and|student_last_name/**/Smith/**/LIKE|-  ~  and|88/**/61/**/=/**/student_terms|none');
+
+$got = translate(array(0 => array(88), 1 => array('='), 2 => array('EMPTYSET:{search_student_terms}'), 3 => array('all')));
+check('nothing left behind',              $got['conditions'],  '(empty)');
+check('provenance is recorded',           $got['expressions'], 'and|88/**/61/**/=/**/student_terms|none');
+
+// Several conditions in one empty set describe one connected entry, so they are AND'd into a single expression.
+// A different key is a different question, and becomes its own expression.
+$got = translate(array(
+    0 => array(88, 89, 90),
+    1 => array('=', '=', '!='),
+    2 => array('EMPTYSET1:{search_student_terms}', 'EMPTYSET1:{search_status}', 'EMPTYSET2:{search_student_terms}'),
+    3 => array('all', 'all', 'all'),
+));
+check('same key groups, different key splits', $got['expressions'],
+    'and|88/**/61/**/=/**/student_terms][89/**/active/**/=/**/status|none  ~  and|90/**/61/**/!=/**/student_terms|none');
+
+$got = translate(array(0 => array(88), 1 => array('='), 2 => array('EMPTYSET:Apples'), 3 => array('all')));
+check('a plain literal needs no reference', $got['expressions'], 'and|88/**/Apples/**/=|none');
+
+$got = translate(array(0 => array(88), 1 => array('NOT'), 2 => array('EMPTYSET:{search_student_terms}'), 3 => array('all')));
+check('NOT maps to !=',                     $got['expressions'], 'and|88/**/61/**/!=/**/student_terms|none');
+
+echo "\nSCREEN CONDITIONS - anything uncertain is dropped, and never left behind as literal text:\n";
+// Each of these must produce no expression AND remove the row. Left in the conditions, the raw text would reach
+// buildConditionsFilterSQL as a search value and match nothing, blanking the screen with no indication why.
+foreach (array(
+    'unresolved reference' => 'EMPTYSET:{search_nonexistent}',
+    'compound term'        => 'EMPTYSET:{search_student_terms} AND {search_other} AND Apples',
+    'wrapped {BLANK}'      => 'EMPTYSET:{search_blanky}',
+) as $label => $term) {
+    $got = translate(array(0 => array(88), 1 => array('='), 2 => array($term), 3 => array('all')));
+    check("$label - no expression", $got['expressions'], '');
+    check("$label - row removed",   $got['conditions'],  '(empty)');
+}
+
+echo "\nSCREEN CONDITIONS - conditions with no empty sets are handed back untouched:\n";
+$got = translate(array(0 => array(42), 1 => array('='), 2 => array('active'), 3 => array('all')),
+    array(0 => array(0 => 'and', 1 => 'x/**/y/**/=')));
+check('conditions unchanged',  $got['conditions'],  '[[42],["="],["active"],["all"]]');
+check('filter unchanged',      $got['expressions'], 'and|x/**/y/**/=|-');
+
+echo "\n";
+printf("RESULT: %d passed, %d failed\n", $GLOBALS['__pass'], $GLOBALS['__fail']);
+exit($GLOBALS['__fail'] === 0 ? 0 : 1);

--- a/tests/empty_set_search_test.php
+++ b/tests/empty_set_search_test.php
@@ -9,21 +9,22 @@
  * WHAT THIS COVERS
  * An EMPTYSET term asks "no connected entry matches these conditions", which the extraction layer renders as a
  * NOT EXISTS instead of a row level comparison. Getting a term from a search box or a screen's conditions into that
- * shape is pure string work, done by four functions this exercises directly, using the REAL source lifted out of the
+ * shape is pure string work, done by five functions this exercises directly, using the REAL source lifted out of the
  * shipped files rather than a reimplementation:
  *
  *   formulize_extractSearchGroupPrefix()    which group a term belongs to, and what that group means
  *   formulize_unwrapSearchBoxValue()        the value inside whatever wrapper a search box was holding
  *   splitUpSearchStringIntoSearchTerms()    how "X AND Y" in one box becomes separate terms
  *   formulize_extractEmptySetConditions()   turning a screen's EMPTYSET conditions into filter expressions
+ *   formulize_buildEmptySetFilterRows()     turning a search box's EMPTYSET groups into filter rows, {BLANK} included
  *
  * Two properties matter most here, and both are the reason for the case lists below rather than a happy path check.
  *
  * BACKWARD COMPATIBILITY. The prefix parser took over parsing that ORSET and OR had been doing for years, including
  * a no-delimiter ORSET syntax that consumes exactly one character as the group key. Existing saved views hold those
- * strings, so the legacy forms have to keep resolving identically. The ORANGE case is deliberate: it documents a
- * long standing quirk (a search for "ORANGE" is read as an OR search for "ANGE") that we preserve rather than fix,
- * because fixing it would change what existing saved views return.
+ * strings, so the legacy forms have to keep resolving identically. The ORANGE case is the deliberate exception: a
+ * long standing quirk (a search for "ORANGE" was read as an OR search for "ANGE") is fixed rather than preserved,
+ * because a term with no lowercase in it at all is something a person wrote to search for that word, not an OR.
  *
  * FAILING CLOSED. Every uncertain case here has to drop the term rather than search for something approximate.
  * An EMPTYSET search that quietly matches the wrong thing removes entries from a list, and nobody notices a row
@@ -103,9 +104,11 @@ $toLoad = array(
     'convertStringToUseSpecialCharsToMatchDB' => $functionsSource,
     'convertDynamicFilterTerms'            => $functionsSource,
     'formulize_unwrapSearchBoxValue'       => $functionsSource,
+    'formulize_extractKeyedGroupPrefix'    => $functionsSource,
     'formulize_extractSearchGroupPrefix'   => $functionsSource,
     'splitUpSearchStringIntoSearchTerms'   => $functionsSource,
     'formulize_extractEmptySetConditions'  => $extractSource,
+    'formulize_buildEmptySetFilterRows'    => $functionsSource,
 );
 foreach ($toLoad as $name => $source) {
     $code = extractFunctionSource($source, $name);
@@ -284,6 +287,42 @@ $got = translate(array(0 => array(42), 1 => array('='), 2 => array('active'), 3 
     array(0 => array(0 => 'and', 1 => 'x/**/y/**/=')));
 check('conditions unchanged',  $got['conditions'],  '[[42],["="],["active"],["all"]]');
 check('filter unchanged',      $got['expressions'], 'and|x/**/y/**/=|-');
+
+echo "\nSEARCH BOX EMPTYSET GROUPS - {BLANK} inside a group, and the rows a search box's groups resolve to:\n";
+// {BLANK} expands into two parts that have to be OR'd with each other ("= '' OR IS NULL"), which formulize_parseSearchesIntoFilter
+// collects separately from the plain AND'd terms in the same group (see formulize_buildEmptySetFilterRows()'s own doc comment for
+// why: the term-string format has no way to nest an OR inside an otherwise AND'd clause). These exercise every shape that produces.
+function rowsOf($emptySetSearches) {
+    $rows = formulize_buildEmptySetFilterRows($emptySetSearches);
+    if (!$rows) { return '(none)'; }
+    $out = array();
+    foreach ($rows as $row) { $out[] = $row[0] . '|' . $row[1] . '|' . $row[2]; }
+    return implode(' ~ ', $out);
+}
+check('ordinary group, and-only',
+    rowsOf(array('k' => array('andTerms' => array('88/**/Apples/**/=', '89/**/active/**/=')))),
+    'and|88/**/Apples/**/=][89/**/active/**/=|none');
+check('lone {BLANK}, or-only, one term',
+    rowsOf(array('k1' => array('orTerms' => array('88/**//**/=][88/**//**/ IS NULL ')))),
+    'or|88/**//**/=][88/**//**/ IS NULL |none');
+check('{BLANK} alongside an ordinary term in the same group is dropped, not built wrong',
+    rowsOf(array('k1' => array(
+        'andTerms' => array('89/**/active/**/='),
+        'orTerms'  => array('88/**//**/=][88/**//**/ IS NULL '),
+    ))),
+    '(none)');
+check('two {BLANK}s in the same group is also dropped, for the same reason',
+    rowsOf(array('k1' => array('orTerms' => array(
+        '88/**//**/=][88/**//**/ IS NULL ',
+        '90/**//**/=][90/**//**/ IS NULL ',
+    )))),
+    '(none)');
+check('groups are independent - one dropped group does not affect another',
+    rowsOf(array(
+        'k1' => array('andTerms' => array('89/**/active/**/='), 'orTerms' => array('88/**//**/=][88/**//**/ IS NULL ')),
+        'k2' => array('andTerms' => array('90/**/red/**/=')),
+    )),
+    'and|90/**/red/**/=|none');
 
 echo "\n";
 printf("RESULT: %d passed, %d failed\n", $GLOBALS['__pass'], $GLOBALS['__fail']);


### PR DESCRIPTION
This adds support for EMPTYSET as an additional category of searches, similar to an ORSET, that gets appended to a query in order to ascertain the non-existence of linked entries that would connect to the main form. Used to find students with no assignment in a given term, in the placements system, for example. Or customers without orders for certain products, etc. Related changes were made throughout the search system to clean up various things.